### PR TITLE
Jse drop add prefix option WIP

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -256,6 +256,9 @@ Notes on the deployment
    * Additional options can be set for ``qsub`` via the
      ``galaxy_jse_drop_qsub_options`` parameter.
 
+   * An optional identifier can be inserted into job names by
+     setting the ``galaxy_jse_drop_galaxy_id`` parameter.
+
 Known Issues
 ------------
 

--- a/README.rst
+++ b/README.rst
@@ -249,15 +249,17 @@ Notes on the deployment
      the Galaxy installation; this can be changed by specifying the
      ``galaxy_jse_drop_virtual_env`` parameter.
 
-   * By default the number of slots (i.e. cores) used for running
-     jobs is 1; this can be changed by specifying the
-     ``galaxy_jse_drop_slots`` parameter.
-
-   * Additional options can be set for ``qsub`` via the
-     ``galaxy_jse_drop_qsub_options`` parameter.
-
    * An optional identifier can be inserted into job names by
      setting the ``galaxy_jse_drop_galaxy_id`` parameter.
+
+   For each JSE-drop job destination there are additional parameters:
+
+   * Set the number of slots (i.e. cores) used for running by
+     specifying the ``jse_drop_slots`` parameter (defaults
+     to 1 slot if not specified).
+
+   * Options to use with ``qsub`` when submitting jobs can be
+     specified via the ``jse_drop_qsub_options`` parameter.
 
 Known Issues
 ------------

--- a/palfinder.yml
+++ b/palfinder.yml
@@ -35,14 +35,8 @@
   - galaxy_job_destinations:
       - id: "jse_drop_default"
         runner: "jse_drop"
-        jse_drop_galaxy_id: "{{ galaxy_name }}"
-        jse_drop_dir: "{{ galaxy_jse_drop_dir }}"
-        jse_drop_virtual_env: "{{ galaxy_root }}/.venv"
       - id: "jse_drop_8_cores"
         runner: "jse_drop"
-        jse_drop_galaxy_id: "{{ galaxy_name }}"
-        jse_drop_dir: "{{ galaxy_jse_drop_dir }}"
-        jse_drop_virtual_env: "{{ galaxy_root }}/.venv"
         jse_drop_qsub_options: "-pe smp.pe 8"
         jse_drop_slots: "8"
   - galaxy_tool_destinations:

--- a/palfinder.yml
+++ b/palfinder.yml
@@ -35,10 +35,12 @@
   - galaxy_job_destinations:
       - id: "jse_drop_default"
         runner: "jse_drop"
+        jse_drop_galaxy_id: "{{ galaxy_name }}"
         jse_drop_dir: "{{ galaxy_jse_drop_dir }}"
         jse_drop_virtual_env: "{{ galaxy_root }}/.venv"
       - id: "jse_drop_8_cores"
         runner: "jse_drop"
+        jse_drop_galaxy_id: "{{ galaxy_name }}"
         jse_drop_dir: "{{ galaxy_jse_drop_dir }}"
         jse_drop_virtual_env: "{{ galaxy_root }}/.venv"
         jse_drop_qsub_options: "-pe smp.pe 8"

--- a/roles/galaxy/defaults/main.yml
+++ b/roles/galaxy/defaults/main.yml
@@ -73,7 +73,9 @@ enable_jse_drop: no
 galaxy_default_runner: "local"
 
 # JSE-drop defaults
+galaxy_jse_drop_galaxy_id: "{{ galaxy_name }}"
 galaxy_jse_drop_dir: "{{ galaxy_dir }}/jse-drop"
+galaxy_jse_drop_virtual_env: "{{ galaxy_root }}/.venv"
 
 # Job destinations
 galaxy_job_destinations:

--- a/roles/galaxy/files/jse_drop_runner.py
+++ b/roles/galaxy/files/jse_drop_runner.py
@@ -25,7 +25,7 @@ To configure Galaxy to use JSE-drop:
    <destinations>
       <destination id="jse_drop_8core" runner="jse_drop">
          <param id="drop_dir">/mnt/galaxy/database/jse-drop</param>
-         <param id="galaxy_name">devel</param>
+         <param id="galaxy_id">devel</param>
          <param id="virtual_env">/mnt/galaxy/.venv</param>
          <param id="qsub_options">-pe smp.pe 8</param>
          <param id="galaxy_slots">8</param>
@@ -37,7 +37,7 @@ The parameters available for the runner are:
  * drop_dir: the path to the directory that JSE-drop is
    monitoring; Galaxy will drop files for jobs here, and
    JSE-drop will write its outputs here (required)
- * galaxy_name: a string that will be inserted into job
+ * galaxy_id: a string that will be inserted into job
    names as an identifier (optional, but can be used to
    ensure that multiple Galaxy instances using the same
    'drop_dir' won't have a job name collision)

--- a/roles/galaxy/templates/job_conf.xml.j2
+++ b/roles/galaxy/templates/job_conf.xml.j2
@@ -6,7 +6,13 @@
         <plugin id="drmaa" type="runner" load="galaxy.jobs.runners.drmaa:DRMAAJobRunner"/>
 {% endif %}
 {% if enable_jse_drop %}
-	<plugin id="jse_drop" type="runner" load="galaxy.jobs.runners.jse_drop_runner:JSEDropJobRunner" />
+	<plugin id="jse_drop" type="runner" load="galaxy.jobs.runners.jse_drop_runner:JSEDropJobRunner">
+	  <param id="drop_dir">{{ galaxy_jse_drop_dir }}</param>
+	  <param id="virtual_env">{{ galaxy_jse_drop_virtual_env }}</param>
+{% if galaxy_jse_drop_name is defined %}
+	  <param id="galaxy_id">{{ galaxy_jse_drop_galaxy_id }}</param>
+{% endif %}
+        </plugin>
 {% endif %}
     </plugins>
     <handlers default="handlers">
@@ -27,12 +33,6 @@
 {% if galaxy_job_destinations %}
 {% for dest in galaxy_job_destinations %}
         <destination id="{{ dest.id }}" runner="{{ dest.runner }}">
-{% if dest.runner == "jse_drop" and enable_jse_drop %}
-	  <param id="drop_dir">{{ dest.jse_drop_dir }}</param>
-	  <param id="virtual_env">{{ dest.jse_drop_virtual_env }}</param>
-{% if dest.jse_drop_galaxy_id is defined %}
-	  <param id="galaxy_id">{{ dest.jse_drop_galaxy_id }}</param>
-{% endif %}
 {% if dest.jse_drop_qsub_options is defined %}
           <param id="qsub_options">{{ dest.jse_drop_qsub_options }}</param>
 {% endif %}

--- a/roles/galaxy/templates/job_conf.xml.j2
+++ b/roles/galaxy/templates/job_conf.xml.j2
@@ -39,7 +39,6 @@
 {% if dest.jse_drop_slots is defined %}
 	  <param id="galaxy_slots">{{ dest.jse_drop_slots }}</param>
 {% endif %}
-{% endif %}
 	</destination>
 {% endfor %}
 {% endif %}

--- a/roles/galaxy/templates/job_conf.xml.j2
+++ b/roles/galaxy/templates/job_conf.xml.j2
@@ -30,6 +30,9 @@
 {% if dest.runner == "jse_drop" and enable_jse_drop %}
 	  <param id="drop_dir">{{ dest.jse_drop_dir }}</param>
 	  <param id="virtual_env">{{ dest.jse_drop_virtual_env }}</param>
+{% if dest.jse_drop_galaxy_id is defined %}
+	  <param id="galaxy_id">{{ dest.jse_drop_galaxy_id }}</param>
+{% endif %}
 {% if dest.jse_drop_qsub_options is defined %}
           <param id="qsub_options">{{ dest.jse_drop_qsub_options }}</param>
 {% endif %}


### PR DESCRIPTION
This is a work-in-progess PR to add a new option to the JSE-drop job handler configuration, to insert an identifier string into job names.

The purpose of this new option is to enable differentiation of jobs submitted by different Galaxy instances to the same JSE-drop directory. Primarily this is intended to circumvent accidental job name collisions (although highly unlikely) however it could potentially be used for auditing purposes.
