### PR TITLE
Update nginx proxy SSL configuration to strengthen security

### DIFF
--- a/roles/galaxy/tasks/nginxproxy.yml
+++ b/roles/galaxy/tasks/nginxproxy.yml
@@ -43,7 +43,7 @@
 
 - name: Create strong Diffie-Hellman parameter group
   command: openssl dhparam -out /etc/ssl/certs/dhparam.pem 2048
-  when: dhparam_file.exists == False
+  when: dhparam_file.stat.exists == False
 
 # Make sure that the .well-know directory exists for certbot
 # Let's Encrypt client

--- a/roles/galaxy/tasks/nginxproxy.yml
+++ b/roles/galaxy/tasks/nginxproxy.yml
@@ -36,6 +36,15 @@
   notify:
   - Restart Nginx
 
+# Set up strong Diffie-Hellman group for TLS/SSL
+- name: Check for Diffie-Hellman parameter file
+  stat: path=/etc/ssl/certs/dhparam.pem
+  register: dhparam_file
+
+- name: Create strong Diffie-Hellman parameter group
+  command: openssl dhparam -out /etc/ssl/certs/dhparam.pem 2048
+  when: dhparam_file.exists == False
+
 # Make sure that the .well-know directory exists for certbot
 # Let's Encrypt client
 - name: Add certbot .well-known web directory

--- a/roles/galaxy/templates/nginx-galaxy.conf.j2
+++ b/roles/galaxy/templates/nginx-galaxy.conf.j2
@@ -27,6 +27,10 @@ server {
     ssl on;
     ssl_certificate     {{ ssl_certificate }};
     ssl_certificate_key {{ ssl_certificate_key }};
+    # Disable SSLv3
+    ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+    # Use strong Diffie-Hellman group
+    ssl_dhparam /etc/ssl/certs/dhparam.pem;
     # Validation directory for Let's Encrypt/certbot
     location ~ /.well-known {
         allow all;


### PR DESCRIPTION
PR implements two updates to the SSL configuration of the nginx proxy in order to strength security:

 - Explicitly specify supported SSL protocols to remove SSLv3 (to secure against the POODLE attack, see e.g. https://en.wikipedia.org/wiki/POODLE)
 - Set up strong Diffie-Hellman group for SSL