### PR TITLE
Update to Galaxy version 'release_17.09'

### DIFF
--- a/palfinder.yml
+++ b/palfinder.yml
@@ -4,7 +4,7 @@
   vars:
   # Galaxy configuration
   - galaxy_name: "palfinder"
-  - galaxy_version: "v16.01"
+  - galaxy_version: "release_17.09"
   - galaxy_install_dir: "/mnt/rvmi/palfinder/galaxy"
   - galaxy_python_dir: "/mnt/rvmi/palfinder/galaxy/python"
   - enable_require_login: yes


### PR DESCRIPTION
PR to update the Galaxy version for Palfinder to `release_17.09` (part of issue #11).