### PR TITLE
Move JSE-drop setup into its own file in 'galaxy' role

### DIFF
--- a/roles/galaxy/tasks/galaxy.yml
+++ b/roles/galaxy/tasks/galaxy.yml
@@ -193,23 +193,6 @@
     dest='{{ galaxy_root}}/config/tool_conf.xml'
   when: galaxy_tool_conf_file|default(None) != None
 
-# Import the code for the JSE-drop job runner plugin
-- name: Import the JSE-drop job runner plugin files
-  copy:
-    dest='{{ galaxy_root }}/lib/galaxy/jobs/runners/{{ item }}'
-    src='{{ item }}'
-  with_items:
-  - jse_drop.py
-  - jse_drop_runner.py
-  when: enable_jse_drop
-
-# Create the JSE-drop directory
-- name: Create JSE-drop directory
-  file:
-    path='{{ galaxy_jse_drop_dir }}'
-    state=directory
-  when: enable_jse_drop
-
 # Create/update the job_conf.xml file
 # See https://wiki.galaxyproject.org/Admin/Config/Jobs
 - name: Update Galaxy job_conf XML file

--- a/roles/galaxy/tasks/jsedrop.yml
+++ b/roles/galaxy/tasks/jsedrop.yml
@@ -1,0 +1,34 @@
+---
+# Import the code for the JSE-drop job runner plugin
+- name: Import the JSE-drop job runner plugin files
+  copy:
+    dest='{{ galaxy_root }}/lib/galaxy/jobs/runners/{{ item }}'
+    src='{{ item }}'
+  with_items:
+  - jse_drop.py
+  - jse_drop_runner.py
+
+# Create the JSE-drop directory
+- name: Create JSE-drop directory
+  file:
+    path='{{ galaxy_jse_drop_dir }}'
+    state=directory
+
+# Setup cron jobs to clean up JSE-drop directory
+- name: Clean up qsub files from JSE-drop directory
+  cron:
+    user='{{ galaxy_user }}'
+    name='Remove old JSE-drop .qsub files'
+    hour=05
+    minute=00
+    job='find {{ galaxy_jse_drop_dir }} -name "*.qsub" -type f -mtime +28 -exec rm -f {} \;'
+    state=present
+
+- name: Clean up other files from JSE-drop directory
+  cron:
+    user='{{ galaxy_user }}'
+    name='Remove all other old JSE-drop files'
+    hour=05
+    minute=00
+    job='find {{ galaxy_jse_drop_dir }} -name "*" -type f -mtime +28 -exec rm -f {} \;'
+    state=present

--- a/roles/galaxy/tasks/main.yml
+++ b/roles/galaxy/tasks/main.yml
@@ -16,6 +16,9 @@
 - include: reports.yml
   when: enable_reports
 
+- include: jsedrop.yml
+  when: enable_jse_drop
+
 - include: purgehistories.yml
 
 - include: logrotate.yml


### PR DESCRIPTION
PR which moves the JSE-Drop setup into its own file in the `galaxy` roles, and adds cron jobs to clean up old files in the JSE-Drop area.