### PR TITLE
Explicitly add Python to PATH for certificate renewal cronjob

### DIFF
--- a/roles/lets-encrypt-client/tasks/main.yml
+++ b/roles/lets-encrypt-client/tasks/main.yml
@@ -48,3 +48,9 @@
     job="service nginx restart >> /var/log/le-renew"
     hour=2 minute=35 weekday=1
     state=absent
+
+# Add logrotation rule for le-renew
+- name: Rotate certificate renewal logs
+  template:
+    dest=/etc/logrotate.d/lets-encrypt
+    src=logrotate-lets-encrypt.j2

--- a/roles/lets-encrypt-client/tasks/main.yml
+++ b/roles/lets-encrypt-client/tasks/main.yml
@@ -28,7 +28,7 @@
   cron:
     user="root"
     name="Renew SSL certificate from Lets Encrypt"
-    job='/usr/local/bin/certbot-auto renew --deploy-hook "service nginx reload" >> /var/log/le-renew'
+    job='export PATH={{ galaxy_python_dir }}/bin:$PATH && /usr/local/bin/certbot-auto renew --deploy-hook "service nginx reload" >> /var/log/le-renew'
     hour=2 minute=30 weekday=1
     state=present
 

--- a/roles/lets-encrypt-client/templates/logrotate-lets-encrypt.j2
+++ b/roles/lets-encrypt-client/templates/logrotate-lets-encrypt.j2
@@ -1,0 +1,8 @@
+/var/log/le-renew {
+  monthly
+  rotate 8
+  compress
+  missingok
+  notifempty
+}
+


### PR DESCRIPTION
Adds the location of installed Python 2.7 to the `PATH` when performing certificate renewal using `certbot-auto`.