### PR TITLE
galaxy-utils: update nebulizer version to 0.4.2 (was 0.2.0).

### DIFF
--- a/roles/galaxy-utils/tasks/main.yml
+++ b/roles/galaxy-utils/tasks/main.yml
@@ -8,7 +8,7 @@
 
 - name: Install Nebulizer
   pip:
-    name='https://github.com/pjbriggs/nebulizer/archive/v0.2.0.tar.gz'
+    name='https://github.com/pjbriggs/nebulizer/archive/v0.4.2.tar.gz'
     executable='{{ python_install_dir }}/bin/pip'
     extra_args='--prefix {{ galaxy_utils_dir }} --no-binary :all:'
     state=present


### PR DESCRIPTION
PR updates the version of `nebulizer` that is installed in the `galaxy-utils` role to 0.4.2 from 0.2.0 (should correctly handle conda-based tool dependencies).