### PR TITLE
galaxy-install-tools: include tool panel section when specifying tools for installation

### DIFF
--- a/palfinder.yml
+++ b/palfinder.yml
@@ -36,10 +36,13 @@
   - galaxy_tools:
       - tool: "fastqc"
         owner: "devteam"
+        section: ""
       - tool: "trimmomatic"
         owner: "pjbriggs"
+        section: ""
       - tool: "pal_finder"
         owner: "pjbriggs"
+        section: ""
   # Default quota
   - default_quota_gb: 20
   # Automatic dataset deletion

--- a/roles/galaxy-install-tools/tasks/main.yml
+++ b/roles/galaxy-install-tools/tasks/main.yml
@@ -7,6 +7,6 @@
 
 - name: Install Galaxy tools
   command:
-    "{{ galaxy_utils_dir }}/bin/install_tool.sh toolshed.g2.bx.psu.edu {{ item.tool }} {{ item.owner }} {{ master_api_key }} {{ galaxy_url }}"
+    "{{ galaxy_utils_dir }}/bin/install_tool.sh toolshed.g2.bx.psu.edu {{ item.tool }} {{ item.owner }} {{ master_api_key }} {{ galaxy_url }} --section '{{ item.section }}'"
   with_items: "{{ galaxy_tools }}"
   when: galaxy_tools|default(None) != None

--- a/roles/galaxy-utils/files/install_tool.sh
+++ b/roles/galaxy-utils/files/install_tool.sh
@@ -3,7 +3,7 @@
 # Install tool using nebulizer & Galaxy API
 
 if [ $# -eq 0 ] ; then
-    echo Usage: $0 SHED TOOL OWNER APIKEY \[URL\]
+    echo Usage: $0 SHED TOOL OWNER APIKEY \[URL\] \[--section SECTION\]
     exit
 fi
 
@@ -11,11 +11,20 @@ SHED=$1
 TOOL=$2
 OWNER=$3
 APIKEY=$4
-if [ ! -z "$5" ] ; then
-    URL=$5
-else
-    URL=http://localhost:80
-fi
+SECTION=
+URL=http://localhost:80
+while [ ! -z "$5" ] ; do
+    case "$5" in
+	--section)
+	    shift
+	    SECTION=$5
+	    ;;
+	*)
+	    URL=$5
+	    ;;
+    esac
+    shift
+done
 
 NEBULIZER=$(dirname $0)/nebulizer
 
@@ -38,7 +47,11 @@ if [ -n "$(tool_installed)" ] ; then
 fi
 
 # Install the tool
-$NEBULIZER -k $APIKEY install_tool $URL $SHED $OWNER $TOOL
+if [ -z "$SECTION" ] ; then
+    $NEBULIZER -k $APIKEY install_tool $URL $SHED $OWNER $TOOL
+else
+    $NEBULIZER -k $APIKEY install_tool --tool-panel-section "$SECTION" $URL $SHED $OWNER $TOOL
+fi
 retcode=$?
 echo Tool installation returned $retcode
 if [ $retcode -ne 0 ] ; then


### PR DESCRIPTION
PR which modifies the `galaxy-install-tools` role to also require the tool panel section when tools are specified for installation.

Using an empty string (i.e. `""`) targets the top-level tool panel rather than a section (as used in the updated `palfinder.yml` playbook).