### PR TITLE
galaxy role: enable more Galaxy configuration options to be set.

### DIFF
--- a/roles/galaxy/defaults/main.yml
+++ b/roles/galaxy/defaults/main.yml
@@ -64,6 +64,15 @@ galaxy_install_dir: "/home/galaxy/galaxies"
 galaxy_dir: "{{ galaxy_install_dir }}/{{ galaxy_name }}"
 galaxy_root: "{{ galaxy_dir }}/galaxy"
 galaxy_tool_dependency_dir: '{{ galaxy_dir }}/tool_dependencies'
+galaxy_database_dir: '{{ galaxy_root }}/database'
+
+# Files and working directories
+galaxy_job_working_dir: "{{ galaxy_database_dir }}/jobs_directory"
+galaxy_file_path: "{{ galaxy_database_dir }}/files"
+galaxy_new_file_path: "{{ galaxy_database_dir }}/tmp"
+
+# Conda options
+galaxy_conda_auto_install: yes
 
 # User account creation
 enable_user_activation: no
@@ -81,6 +90,9 @@ galaxy_tool_conf_file:
 # filesystem after job completion
 # Should be 'always', 'onsuccess', or 'never'
 galaxy_cleanup_job: "always"
+
+# Allow admins to paste filesystem paths during upload
+galaxy_allow_path_paste: no
 
 # Job runners
 enable_drmaa: no

--- a/roles/galaxy/tasks/galaxy.yml
+++ b/roles/galaxy/tasks/galaxy.yml
@@ -64,12 +64,24 @@
   - { option: 'allow_user_impersonation', value: 'True' }
   - { option: 'allow_user_deletion', value: 'True' }
   - { option: 'allow_library_path_paste', value: 'True' }
+  - { option: 'file_path', value: '{{ galaxy_file_path }}' }
+  - { option: 'new_file_path', value: '{{ galaxy_new_file_path }}' }
+  - { option: 'job_working_dir', value: '{{ galaxy_job_working_dir }}' }
   - { option: 'tool_dependency_dir', value: '{{ galaxy_tool_dependency_dir }}' }
   - { option: 'id_secret', value: '{{ galaxy_id_secret }}' }
   - { option: 'admin_users', value: '{{ galaxy_admin_user }}' }
   - { option: 'welcome_url', value: '/static/welcome.html' }
   - { option: 'show_welcome_with_login', value: 'True' }
+  - { option: 'allow_path_paste', value: '{{ galaxy_allow_path_paste }}' }
   - { option: 'cleanup_job', value: '{{ galaxy_cleanup_job }}' }
+
+# Set conda options
+- name: Set conda options
+  ini_file:
+    dest='{{ galaxy_root }}/config/galaxy.ini'
+    section='app:main' option='{{ item.option }}' value='{{ item.value }}'
+  with_items:
+  - { option: 'conda_auto_install', value: '{{ galaxy_conda_auto_install }}' }
 
 # Set proxy prefix options
 - name: Set proxy prefix options


### PR DESCRIPTION
PR enabling the following configuration options to be set in `galaxy.ini`:

- `allow_path_paste`
- `conda_auto_install`
- `file_path`
- `new_file_path`
- `job_working_dir`