### PR TITLE
galaxy reports: handle missing reports.ini.sample config file

### DIFF
--- a/roles/galaxy/handlers/main.yml
+++ b/roles/galaxy/handlers/main.yml
@@ -5,5 +5,5 @@
 - name: Restart Supervisord
   service: name=supervisord state=reloaded
 
-- name: Reload Galaxy reports
-  service: name=galaxy_reports state=reloaded
+- name: Restart Galaxy reports
+  service: name=galaxy_reports state=restarted

--- a/roles/galaxy/tasks/galaxy.yml
+++ b/roles/galaxy/tasks/galaxy.yml
@@ -1,7 +1,7 @@
 # Install and configure Galaxy
 ---
 
-- name: Create Galaxy directories
+- name: Create top-level Galaxy directories
   file:
     path='{{ item }}'
     state=directory
@@ -21,6 +21,13 @@
     version='{{ galaxy_version }}'
     dest={{ galaxy_root }}
     force=yes
+
+- name: Create additional Galaxy directories
+  file:
+    path='{{ item }}'
+    state=directory
+  with_items:
+  - '{{ galaxy_file_path }}'
 
 - name: Create welcome page
   template:

--- a/roles/galaxy/tasks/reports.yml
+++ b/roles/galaxy/tasks/reports.yml
@@ -1,24 +1,62 @@
 # Enable Galaxy's reporting interface
 ---
-- name: Create Galaxy reports configuration file
+- name: Check if reports.ini.sample exists
+  stat:
+    path: '{{ galaxy_root }}/config/reports.ini.sample'
+  register: reports_ini
+
+- name: Copy sample Galaxy reports.ini configuration file
   command:
     chdir='{{ galaxy_root }}/config'
     cp reports.ini.sample reports.ini
     creates='{{ galaxy_root }}/config/reports.ini'
   become: yes
   become_user: '{{ galaxy_user }}'
+  when: reports_ini.stat.exists == True
 
-- name: Configure Galaxy reports settings
+- name: Remove existing Galaxy reports.ini configuration file
+  file:
+    path='{{ galaxy_root }}/config/reports.ini'
+    state=absent
+  become: yes
+  become_user: '{{ galaxy_user }}'
+  when: reports_ini.stat.exists == False
+
+- name: Touch empty Galaxy reports.ini configuration file
+  file:
+    path='{{ galaxy_root }}/config/reports.ini'
+    state=touch
+  become: yes
+  become_user: '{{ galaxy_user }}'
+  when: reports_ini.stat.exists == False
+
+- name: Configure Galaxy reports server settings
+  ini_file:
+    dest='{{ galaxy_root }}/config/reports.ini'
+    section='server:main' option={{ item.option }} value={{ item.value }}
+  with_items:
+  - { option: 'use', value: 'egg:Paste#http' }
+  - { option: 'port', value: '9001' }
+  - { option: 'host', value: '127.0.0.1' }
+  - { option: 'use_threadpool', value: 'true' }
+  - { option: 'threadpool_workers', value: '10' }
+  become: yes
+  become_user: '{{ galaxy_user }}'
+  notify: Restart Galaxy reports
+
+- name: Configure Galaxy reports app settings
   ini_file:
     dest='{{ galaxy_root }}/config/reports.ini'
     section='app:main' option={{ item.option }} value={{ item.value }}
   with_items:
+  - { option: 'paste.app_factory', value: 'galaxy.webapps.reports.buildapp:app_factory' }
   - { option: 'database_connection', value: 'postgres://{{ galaxy_db_user }}:{{ galaxy_db_password }}@localhost:5432/{{ galaxy_db }}' }
+  - { option: 'file_path', value: '{{ galaxy_file_path }}' }
   - { option: 'filter-with', value: 'proxy-prefix' }
   - { option: 'cookie_path', value: '/reports' }
   become: yes
   become_user: '{{ galaxy_user }}'
-  notify: Reload Galaxy reports
+  notify: Restart Galaxy reports
 
 - name: Configure Galaxy reports proxy settings
   ini_file:
@@ -30,7 +68,7 @@
   - { option: 'prefix', value: '/reports' }
   become: yes
   become_user: '{{ galaxy_user }}'
-  notify: Reload Galaxy reports
+  notify: Restart Galaxy reports
 
 # Set up as a service
 - name: Create init.d script for Galaxy reports
@@ -38,7 +76,7 @@
     dest=/etc/init.d/galaxy_reports
     src=galaxy_reports.init.sh.j2
     mode=0755
-  notify: Reload Galaxy reports
+  notify: Restart Galaxy reports
 
 - name: Start Galaxy reports service
   service:


### PR DESCRIPTION
Workaround to deal with issue #26, for Galaxy 17.09 and above (where `reports.ini.sample` has been replaced with `reports.yml.sample`.

The workaround exploits the fact that 17.09 will use a `reports.ini` file if one is found, and creates such a file from scratch.