### PR TITLE
Vagrantfile: turn off iptables and create /mnt/rvmi on VM creation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -186,16 +186,13 @@ the ``ansible-playbook`` command line, for example::
 Testing using Vagrant
 ---------------------
 
-The repo includes a ``Vagrantfile`` which can be used to create a
-virtual machine for testing the deployment.
+The repo includes a ``Vagrantfile`` which can be used to create
+virtual machines for testing the deployment.
 
 Example set up::
 
-    vagrant up
-    vagrant ssh
-    [vagrant@palfinder ~]$ sudo service iptables stop
-    [vagrant@palfinder ~]$ sudo mkdir -p /mnt/rvmi
-    [vagrant@palfinder ~]$ sudo chmod ugo+rwX /mnt/rvmi/
+    vagrant up palfinder
+    vagrant ssh palfinder
 
 Use the Vagrant-specific Palfinder inventory file to test locally
 (note that this is not as fully-featured as the production version).

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -17,5 +17,10 @@ Vagrant.configure(VAGRANT_API_VERSION) do |config|
   config.vm.define "palfinder" do |palfinder|
     palfinder.vm.hostname = "palfinder"
     palfinder.vm.network :private_network, ip: "192.168.60.4"
+    palfinder.vm.provision "shell", inline: <<-SHELL
+    service iptables stop
+    mkdir -p /mnt/rvmi
+    chmod ugo+rwX /mnt/rvmi/
+  SHELL
   end
 end


### PR DESCRIPTION
PR which adds some basic configuration to the palfinder testing VM set up via the `Vagrantfile`:

- turn off `iptables`
- create and set permissions on `/mnt/rvmi/`