### PR TITLE
galaxy role: use uWSGI installed by Galaxy

### DIFF
--- a/roles/galaxy/tasks/main.yml
+++ b/roles/galaxy/tasks/main.yml
@@ -10,8 +10,9 @@
   become: yes
   become_user: "{{ galaxy_user }}"
 
-- include: static.yml
-  when: galaxy_extra_static_content|default(None) != None
+- include: uwsgi.yml
+  become: yes
+  become_user: "{{ galaxy_user }}"
 
 - include: reports.yml
   when: enable_reports
@@ -26,10 +27,9 @@
 - include: ftpupload.yml
   when: enable_ftp_upload
 
-- include: uwsgi.yml
-  become: yes
-  become_user: "{{ galaxy_user }}"
-
 - include: supervisor.yml
 
 - include: nginxproxy.yml
+
+- include: static.yml
+  when: galaxy_extra_static_content|default(None) != None

--- a/roles/galaxy/tasks/uwsgi.yml
+++ b/roles/galaxy/tasks/uwsgi.yml
@@ -1,16 +1,6 @@
 # Install and configure uWSGI and set up handlers
 # See https://wiki.galaxyproject.org/Admin/Config/Performance/Scaling#uWSGI
 ---
-- name: Install uWSGI and PasteDeploy
-  pip:
-    name='{{ item }}'
-    executable='{{ galaxy_root }}/.venv/bin/pip'
-    extra_args='--no-binary :all:'
-    state=present
-  with_items:
-  - uwsgi
-  - uwsgitop
-  - PasteDeploy
 
 - name: Configure Galaxy uWSGI settings
   ini_file:


### PR DESCRIPTION
PR which removes the explicit installation of the `uWSGI` package into the Galaxy `virtualenv` (as Galaxy now installs and controls this anyway).