### PR TITLE
Increase pal_finder default quota

### DIFF
--- a/palfinder.yml
+++ b/palfinder.yml
@@ -44,7 +44,7 @@
         owner: "pjbriggs"
         section: ""
   # Default quota
-  - default_quota_gb: 30
+  - default_quota_gb: 50
   # Automatic dataset deletion
   - delete_datasets_after: "30 days"
   # Audit report

--- a/palfinder.yml
+++ b/palfinder.yml
@@ -44,7 +44,7 @@
         owner: "pjbriggs"
         section: ""
   # Default quota
-  - default_quota_gb: 20
+  - default_quota_gb: 30
   # Automatic dataset deletion
   - delete_datasets_after: "30 days"
   # Audit report


### PR DESCRIPTION
Increase the default quota for users of the `pal_finder` Galaxy service.