### PR TITLE
Give Palfinder-vagrant different "secrets" to production

### DIFF
--- a/instances/palfinder/palfinder_vagrant.yml
+++ b/instances/palfinder/palfinder_vagrant.yml
@@ -1,0 +1,7 @@
+---
+galaxy_db_password: "galaxy"
+galaxy_ftp_password: "galaxy"
+galaxy_admin_passwd: "admin"
+master_api_key: "ZaJohlori9saht4w"
+galaxy_reports_password: "reports"
+galaxy_id_secret: "faePhoh0eo6no9reiy4oos1ee0Eah0Oh"

--- a/inventories/palfinder-production.yml
+++ b/inventories/palfinder-production.yml
@@ -5,6 +5,8 @@ palfinder:
     # Server configuration
     galaxy_server_name: "palfinder.ls.manchester.ac.uk"
     enable_user_activation: yes
+    # Secrets
+    palfinder_secrets: palfinder_passwds.yml
     # Job configuration
     enable_jse_drop: yes
     galaxy_jse_drop_dir: "{{ galaxy_install_dir }}/palfinder/jse-drop-dpsf"

--- a/inventories/palfinder-vagrant.yml
+++ b/inventories/palfinder-vagrant.yml
@@ -5,6 +5,8 @@ palfinder:
     # Ansible-specific settings
     ansible_ssh_user: vagrant
     ansible_ssh_private_key_file: ~/.vagrant.d/insecure_private_key
+    # Secrets
+    palfinder_secrets: palfinder_vagrant.yml
     # Server configuration
     galaxy_server_name: 192.168.60.4
     enable_user_activation: no

--- a/palfinder.yml
+++ b/palfinder.yml
@@ -67,7 +67,7 @@
   - palfinder_motd:
 
   vars_files:
-  - instances/palfinder/palfinder_passwds.yml
+  - instances/palfinder/{{ palfinder_secrets }}
 
   roles:
   # Dependencies


### PR DESCRIPTION
PR which enables the Vagrant/test version of the Palfinder Galaxy instance to use a different "secrets" file to the production instance.

Because the test version isn't intended for production use, the secrets can be stored in plain text and the passwords can be easy to remember.