### PR TITLE
Update to Galaxy release 18.09

### DIFF
--- a/cetus.yml
+++ b/cetus.yml
@@ -9,7 +9,7 @@
   - galaxy_gid: 400
   # Galaxy configuration
   - galaxy_name: "cetus"
-  - galaxy_version: "release_18.05"
+  - galaxy_version: "release_18.09"
   - galaxy_install_dir: "/mnt/rvmi/cetus/galaxy"
   - galaxy_dir: "/mnt/rvmi/cetus/galaxy/teaching"
   # Database and reference data

--- a/cetus.yml
+++ b/cetus.yml
@@ -50,6 +50,7 @@
   - galaxy-user
   - epel-repo
   - nfslock
+  - git
   - python27
   - nginx
   - postgresql

--- a/palfinder.yml
+++ b/palfinder.yml
@@ -4,7 +4,7 @@
   vars:
   # Galaxy configuration
   - galaxy_name: "palfinder"
-  - galaxy_version: "release_18.05"
+  - galaxy_version: "release_18.09"
   - galaxy_install_dir: "/mnt/rvmi/palfinder/galaxy"
   - galaxy_python_dir: "/mnt/rvmi/palfinder/galaxy/python"
   - enable_require_login: yes

--- a/palfinder.yml
+++ b/palfinder.yml
@@ -81,6 +81,7 @@
   - galaxy-user
   - epel-repo
   - nfslock
+  - git
   - selinux
   - python27
   - nginx

--- a/roles/galaxy/defaults/main.yml
+++ b/roles/galaxy/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # Name for Galaxy instance
 galaxy_name: "palfinder"
-galaxy_version: 'release_18.05'
+galaxy_version: 'release_18.09'
 
 # User running Galaxy service
 galaxy_user: "galaxy"

--- a/roles/galaxy/tasks/dependencies.yml
+++ b/roles/galaxy/tasks/dependencies.yml
@@ -3,7 +3,6 @@
 - name: Install Galaxy dependencies
   yum: name={{ item }} state=latest
   with_items:
-  - git
   - python-psycopg2
   - libtool
   - libtool-ltdl

--- a/roles/galaxy/tasks/galaxy.yml
+++ b/roles/galaxy/tasks/galaxy.yml
@@ -17,6 +17,7 @@
 
 - name: Clone Galaxy source
   git:
+    executable='/usr/local/bin/git'
     repo='{{ galaxy_repo }}'
     version='{{ galaxy_version }}'
     dest={{ galaxy_root }}
@@ -80,6 +81,8 @@
   command:
     chdir='{{ galaxy_root }}'
     ./scripts/common_startup.sh
+  environment:
+    PATH: '/usr/local/bin:{{ ansible_env.PATH }}'
 
 - name: Run create_db.py to initialise the database
   command:

--- a/roles/git/defaults/main.yml
+++ b/roles/git/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+# git defaults
+git_version: '2.20.0'
+git_checksum: 'sha256:7cc724cd9ea54b73f41ed53edbc75703df8a3108b9e30367bcf5c3a1daa3cee2'
+git_install_dir: '/usr/local'

--- a/roles/git/tasks/main.yml
+++ b/roles/git/tasks/main.yml
@@ -1,0 +1,69 @@
+---
+# Install git on remote server
+#
+# NOTE: we need a newer version of git than is available
+# via yum on Scientific Linux 6, hence installing it this way
+# rather than pulling in from yum
+- name: Uninstall yum version of git
+  yum:
+    name=git
+    state=absent
+
+- name: Determine the user home directory
+  shell:
+    "echo $HOME"
+  register: user_home
+  changed_when: False
+
+- name: Determine the build directory
+  set_fact:
+    build_dir: "{{ user_home.stdout }}/build"
+
+- name: Print the location of the build directory
+  debug: msg="Build directory {{ build_dir }}"
+
+- name: Create build directory
+  file:
+    path='{{ build_dir }}'
+    state=directory
+
+- name: Install build dependencies
+  yum:
+    name={{ item }}
+    state=present
+  with_items:
+    - libcurl-devel
+    - expat-devel
+    - asciidoc
+    - xmlto
+    - docbook2X
+
+# Need to make link to docbook2x-text to build
+# git documentation, see
+# https://groups.google.com/d/msg/git-users/DMaDpy8Bpww/jqXULjp8ry8J
+- name: Make symlink to db2x_docbook2texi
+  file:
+    state=link
+    src='/usr/bin/db2x_docbook2texi'
+    dest='/usr/bin/docbook2x-texi'
+
+- name: Download git source
+  get_url:
+    url='https://github.com/git/git/archive/v{{ git_version }}.tar.gz'
+    checksum='{{ git_checksum }}'
+    dest='{{ build_dir }}'
+
+- name: Unpack git source
+  unarchive:
+    src='{{ build_dir }}/git-{{ git_version }}.tar.gz'
+    dest='{{ build_dir }}'
+    copy=no
+    owner=root
+    group=root
+    creates='{{ build_dir }}/git-{{ git_version }}'
+
+- name: Install git
+  command:
+    chdir='{{ build_dir }}/git-{{ git_version }}'
+    make prefix={{ git_install_dir }} install install-doc install-html install-info
+    creates={{ git_install_dir }}/bin/git

--- a/roles/git/tasks/main.yml
+++ b/roles/git/tasks/main.yml
@@ -32,8 +32,12 @@
     name={{ item }}
     state=present
   with_items:
+    - gcc
+    - openssl-devel
     - libcurl-devel
     - expat-devel
+    - tcl
+    - gettext
     - asciidoc
     - xmlto
     - docbook2X


### PR DESCRIPTION
PR which updates the playbooks and the Palfinder and Cetus configurations to use Galaxy release 18.09.

* Update the default Galaxy version in the `galaxy` role to `release_18.09`
* Update the Galaxy versions in `palfinder.yml` and `cetus.yml` to `release_`18.09`
* Add new role `git` to install git 2.20.0 (up-to-date version of git needed to build the Galaxy client for this release)