### PR TITLE
jse_drop_runner.py: fix external job name acquisition in 'stop_job'.

### DIFF
--- a/roles/galaxy/files/jse_drop_runner.py
+++ b/roles/galaxy/files/jse_drop_runner.py
@@ -254,7 +254,7 @@ class JSEDropJobRunner(AsynchronousJobRunner):
     def stop_job(self,job):
         # Attempts to remove a job from the JSE-Drop queue
         # Fetch the job id used by JSE-Drop
-        job_name = job.get_job_runner_external_id()
+        job_name = job.get_job().get_job_runner_external_id()
         # Fetch the drop dir
         try:
             drop_off_dir = self._get_drop_dir()


### PR DESCRIPTION
PR which fixes the acquisition of the external job name in the `stop_job` method of the `JSEDropJobRunner` class, which was broken (see issue #52).

Although the documentation for building job runners indicates that `stop_job` should receive a `galaxy.model.Job` instance (see https://docs.galaxyproject.org/en/release_19.05/dev/build_a_job_runner.html#stop-job-method-stage-4), the error trace in the bug report suggests that it is actually receiving an instance of `galaxy.jobs.runners.JobWrapper`.

To get the `Job` instance it is first necessary to use the `get_job` method of the `JobWrapper`, and from that then acquire the external job name to use for JSE-Drop.