### PR TITLE
Enable number of concurrent jobs to be specified in 'job conf.xml'

### DIFF
--- a/palfinder.yml
+++ b/palfinder.yml
@@ -47,6 +47,10 @@
         owner: "pjbriggs"
         section: ""
   - enable_tool_shed_check: yes
+  # Concurrent jobs
+  - galaxy_registered_user_concurrent_jobs: 2
+  - galaxy_unregistered_user_concurrent_jobs: 0
+  - galaxy_concurrent_jobs: 2
   # Add tools to whitelist for rendering HTML correctly
   - galaxy_sanitize_whitelist_tools:
       - "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.71"

--- a/palfinder.yml
+++ b/palfinder.yml
@@ -48,9 +48,9 @@
         section: ""
   - enable_tool_shed_check: yes
   # Concurrent jobs
-  - galaxy_registered_user_concurrent_jobs: 2
+  - galaxy_registered_user_concurrent_jobs: 8
   - galaxy_unregistered_user_concurrent_jobs: 0
-  - galaxy_concurrent_jobs: 2
+  - galaxy_concurrent_jobs: 8
   # Add tools to whitelist for rendering HTML correctly
   - galaxy_sanitize_whitelist_tools:
       - "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.71"

--- a/roles/galaxy/defaults/main.yml
+++ b/roles/galaxy/defaults/main.yml
@@ -144,6 +144,11 @@ galaxy_job_destinations:
 # - destination (target destination)
 galaxy_tool_destinations:
 
+# Limits for running jobs
+galaxy_registered_user_concurrent_jobs: 2
+galaxy_unregistered_user_concurrent_jobs: 0
+galaxy_concurrent_jobs: 2
+
 # HTML sanitization whitelist
 galaxy_sanitize_whitelist_file: "config/sanitize_whitelist.txt"
 # List of paths for whitelisted tools e.g.

--- a/roles/galaxy/templates/job_conf.xml.j2
+++ b/roles/galaxy/templates/job_conf.xml.j2
@@ -48,9 +48,9 @@
     </tools>
 {% endif %}
     <limits>
-        <limit type="registered_user_concurrent_jobs">2</limit>
-        <limit type="unregistered_user_concurrent_jobs">0</limit>
+        <limit type="registered_user_concurrent_jobs">{{ galaxy_registered_user_concurrent_jobs }}</limit>
+        <limit type="unregistered_user_concurrent_jobs">{{ galaxy_unregistered_user_concurrent_jobs }}</limit>
         <limit type="job_walltime">24:00:00</limit>
-        <limit type="concurrent_jobs" id="local">2</limit>
+        <limit type="concurrent_jobs" id="local">{{ galaxy_concurrent_jobs }}</limit>
     </limits>
 </job_conf>


### PR DESCRIPTION
PR which updates the `galaxy` role to allow the number of concurrent jobs for registered, unregistered and local jobs to be explicitly specified in `job_conf.xml` (previously they were hardcoded).

(Also update `palfinder.yml` to set the appropriate values.)