### PR TITLE
epel-repo: need to update 'nss' so yum can communicate with EPEL repo

### DIFF
--- a/roles/epel-repo/tasks/main.yml
+++ b/roles/epel-repo/tasks/main.yml
@@ -7,3 +7,14 @@
 - name: Install EPEL repo 
   yum: name=https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm state=present
   when: epel_status.stat.exists == false
+
+# Update 'nss' to make sure that EPEL repo can be accessed
+#
+# See:
+# - https://github.com/GovReady/govready/issues/64
+# - https://unix.stackexchange.com/a/163368/14641
+- name: Update nss
+  yum:
+    name: nss
+    state: latest
+    disablerepo: "epel"


### PR DESCRIPTION
PR which fixes a problem with the `epel-repo` role for most recent attempts to build a `vagrant`-based Palfinder VM, where the task fails with:

    Error: Cannot retrieve repository metadata (repomd.xml) for repository: epel. Please verify its path and try again

The suggested fix at https://unix.stackexchange.com/a/163368 to update the `nss` package ("... older version cannot talk with the Fedora site via curl which uses an older version of the nss library").