### PR TITLE
galaxy: fix the bad 'uwsgi_write_timeout' directive in nginx template

### DIFF
--- a/roles/galaxy/templates/nginx-galaxy.conf.j2
+++ b/roles/galaxy/templates/nginx-galaxy.conf.j2
@@ -39,7 +39,7 @@ server {
     uwsgi_temp_path /tmp/uwsgi;
     uwsgi_max_temp_file_size 1024k;
     uwsgi_read_timeout 600s;
-    uwsgi_write_timeout 600s;
+    uwsgi_send_timeout 600s;
     # Additional locations (may be none)
 {% if galaxy_nginx_extra_locations is not none %}
     {% for loc in galaxy_nginx_extra_locations %}


### PR DESCRIPTION
PR to fix the bad `uwsgi_write_timeout` directive in the `nginx-galaxy.conf.j2` template in the `galaxy` role (should be `uwsgi_send_timeout`).