### PR TITLE
galaxy-utils: pin psycopg2 version

### DIFF
--- a/roles/galaxy-utils/tasks/main.yml
+++ b/roles/galaxy-utils/tasks/main.yml
@@ -6,7 +6,7 @@
     executable='{{ python_install_dir }}/bin/pip'
     state=present
   with_items:
-    - "psycopg2"
+    - "psycopg2==2.6.2"
     - "pyyaml"
 
 - name: Install Nebulizer


### PR DESCRIPTION
PR which pins the version of the `psycopg2` to 2.6.2 when installing with `pip` in the `galaxy-utils` role; newer versions are incompatible with dependencies installed with `yum` elsewhere.