### PR TITLE
galaxy-utils: ensure that 'setuptools' is most recent version

### DIFF
--- a/roles/galaxy-utils/tasks/main.yml
+++ b/roles/galaxy-utils/tasks/main.yml
@@ -1,5 +1,14 @@
 # Install utilities
 ---
+# Need latest setuptools to install nebulizer
+# Error looks like the one reported here:
+# - https://github.com/rm-hull/luma.examples/issues/45
+- name: Install latest setuptools
+  pip:
+    name="setuptools"
+    executable='{{ python_install_dir }}/bin/pip'
+    state=latest
+
 - name: Install dependencies for utilities
   pip:
     name="{{ item }}"


### PR DESCRIPTION
PR which ensures that `setuptools` is the most recent version when installing in the `galaxy-utils` role. Without this the installation fails on `nebulizer` complaining about attributes in the `setup` function needing to be dictionary items.