### PR TITLE
VagrantFile: workaround for error under Vagrant >= 2.0.3

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,10 +3,10 @@
 
 VAGRANT_API_VERSION = "2"
 
-# If using Vagrant < 2 then need to update the default
-# location for downloading boxes
-# See https://stackoverflow.com/a/48844332/579925
-Vagrant::DEFAULT_SERVER_URL.replace('https://vagrantcloud.com')
+# When using Vagrant >= 2.0.3 remove the line below to prevent
+# errors like "Message: RuntimeError: can't modify frozen String"
+# See e.g. https://github.com/p4lang/tutorials/issues/131
+#Vagrant::DEFAULT_SERVER_URL.replace('https://vagrantcloud.com')
 
 Vagrant.configure(VAGRANT_API_VERSION) do |config|
   # General Vagrant VM configuration


### PR DESCRIPTION
PR to implement a workaround for issue #60, by commenting out the line that is a problem when using Vagrant >= 2.0.3.