### PR TITLE
Galaxy 19.05: update dependencies for EPEL and netstat

### DIFF
--- a/roles/epel-repo/tasks/main.yml
+++ b/roles/epel-repo/tasks/main.yml
@@ -8,13 +8,19 @@
   yum: name=https://dl.fedoraproject.org/pub/epel/epel-release-latest-{{ ansible_distribution_major_version }}.noarch.rpm state=present
   when: epel_status.stat.exists == false
 
-# Update 'nss' to make sure that EPEL repo can be accessed
+# Update 'curl' and 'nss' to make sure that EPEL repo can
+# be accessed
 #
 # See:
 # - https://github.com/GovReady/govready/issues/64
 # - https://unix.stackexchange.com/a/163368/14641
-- name: Update nss
+# - https://stackoverflow.com/a/55851121
+- name: "Update curl and nss to work with EPEL"
   yum:
-    name: nss
-    state: latest
+    name: "{{ item }}"
+    state: "latest"
     disablerepo: "epel"
+  with_items:
+  - nss
+  - curl
+  - libcurl

--- a/roles/galaxy/tasks/dependencies.yml
+++ b/roles/galaxy/tasks/dependencies.yml
@@ -10,7 +10,5 @@
   - java-1.8.0-openjdk
   - samtools
   - python2-pyyaml
-  - nss
-  - curl
-  - libcurl
+  - net-tools
   register: installed_dependencies


### PR DESCRIPTION
PR which updates installation of `yum` packages that are required for deployment:

* `epel-repo` role: also update the `curl` and `libcurl` packages (otherwise `yum` is unable to access EPEL repo on subsequent package installations, when testing with Vagrant)
* `galaxy` role: remove the updates for `curl` and `libcurl` and add `net-tools` (so the `netstat` utility is available on the target VM).