### PR TITLE
Galaxy 19.05: enable direct customisation of colour scheme by setting SCSS values

### DIFF
--- a/roles/galaxy/defaults/main.yml
+++ b/roles/galaxy/defaults/main.yml
@@ -32,7 +32,15 @@ galaxy_welcome_template: "welcome.html.j2"
 galaxy_terms:
 galaxy_citations:
 
-# CSS styles
+# (S)CSS styles/custom colours
+# Define entries as a dictionary with:
+# - var   (SCSS variable e.g. 'brand-primary')
+# - value (Value e.g. 'red', '#660099')
+galaxy_custom_scss: null
+
+# Pre-built base CSS file to import for this
+# instance (overwrites existing CSS file)
+# !!!DEPRECATED: use 'galaxy_custom_scss' instead!!!
 galaxy_base_css: null
 
 # Message of the day

--- a/roles/galaxy/tasks/galaxy.yml
+++ b/roles/galaxy/tasks/galaxy.yml
@@ -47,7 +47,15 @@
     dest='{{ galaxy_root }}/static/citations.html'
   when: galaxy_citations|default(None) != None
 
-- name: Import base CSS styles file
+- name: "Set up custom colours in SCSS file"
+  replace:
+    path: '{{ galaxy_root }}/client/galaxy/style/scss/theme/blue.scss'
+    regexp: "^\\$({{ item.var }}): (.*);"
+    replace: "${{ item.var }}: {{ item.value }};"
+  with_items: "{{ galaxy_custom_scss }}"
+  when: galaxy_custom_scss|default(None) != None
+
+- name: "DEPRECATED: import base CSS styles file"
   copy:
     src='{{ galaxy_base_css }}'
     dest='{{ galaxy_root }}/static/style/blue/base.css'


### PR DESCRIPTION
PR which enables the colour scheme of the Galaxy instances to be customised directly by specifying values for the SCSS variables in `client/galaxy/style/scss/theme/blue.scss`.

The most useful values to modify are:

* `brand-primary`: sets the colour for the main controls (e.g. tool execute button) and links
* `brand-secondary`: sets the colour for tool controls
* `brand-dark`: sets the colour for the navbar/masthead

They can be specified via the `galaxy_custom_scss` variable in the playbooks, for example:

    
    - galaxy_custom_scss:
          - var: "brand-dark"
            value: "#660099"

This feature sits next to the original method of explicitly specifying a .css file to use, but the new method of customisation should be used preferentially.