### PR TITLE
Update JSE-Drop runner to handle jobs in error state

### DIFF
--- a/roles/galaxy/files/jse_drop.py
+++ b/roles/galaxy/files/jse_drop.py
@@ -15,6 +15,7 @@ class JSEDropStatus(object):
     FAILED = 3
     RUNNING = 4
     FINISHED = 5
+    ERROR = 6
 
 class JSEDrop(object):
     """
@@ -152,6 +153,12 @@ class JSEDrop(object):
             # Waiting for submission
             return JSEDropStatus.WAITING
         if not os.path.exists("%s.drop.qacct" % base_name):
+            # Check for job in error state
+            try:
+                if self.qstat(base_name)['state'] == "Eqw":
+                    return JSEDropStatus.ERROR
+            except KeyError:
+                pass
             # Running
             return JSEDropStatus.RUNNING
         # Finished

--- a/roles/galaxy/files/jse_drop_runner.py
+++ b/roles/galaxy/files/jse_drop_runner.py
@@ -323,7 +323,7 @@ class JSEDropJobRunner(AsynchronousJobRunner):
             elif jse_drop_status == JSEDropStatus.ERROR:
                 # Job is in error state
                 log.warn("%s: job is in error state" % job_name)
-                message = "Job in error state"
+                message = "Job in error state: try resubmitting?"
             else:
                 # Can't find the job
                 log.warn("%s: no such job in JSE-drop?" % job_name)

--- a/roles/galaxy/files/jse_drop_runner.py
+++ b/roles/galaxy/files/jse_drop_runner.py
@@ -313,16 +313,22 @@ class JSEDropJobRunner(AsynchronousJobRunner):
                 jse_drop.cleanup(job_name)
             return None
         if jse_drop_status in (JSEDropStatus.FAILED,
-                               JSEDropStatus.MISSING):
+                               JSEDropStatus.MISSING,
+                               JSEDropStatus.ERROR,):
             if jse_drop_status == JSEDropStatus.FAILED:
                 # Get message from qfail file
                 log.warn("%s: failed" % job_name)
                 message = "Submission to JSE-drop failed: %s" % \
                           jse_drop.qfail(job_name)['stderr']
+            elif jse_drop_status == JSEDropStatus.ERROR:
+                # Job is in error state
+                log.warn("%s: job is in error state" % job_name)
+                message = "Job in error state"
             else:
                 # Can't find the job
                 log.warn("%s: no such job in JSE-drop?" % job_name)
                 message = "%s: no such job in JSE-drop?" % job_name
+            job_state.fail_message = message
             self.fail_job(job_state)
             # Remove the JSE-drop files
             cleanup_job = self.app.config.cleanup_job


### PR DESCRIPTION
PR to address issue #4, by updating the JSE-Drop job runner to detect jobs that are in an error state on the cluster (i.e. `qstat` status is `Eqw`).

For this first pass Galaxy (via the runner) now deletes jobs in the error and marks them as failed, with an error message suggesting that the job should be resubmitted.