### PR TITLE
Set explicitly set the nginx 'client_body_temp_path' directive for file uploads

### DIFF
--- a/roles/galaxy/defaults/main.yml
+++ b/roles/galaxy/defaults/main.yml
@@ -165,6 +165,10 @@ galaxy_sanitize_whitelist_file: "config/sanitize_whitelist.txt"
 # - ...
 galaxy_sanitize_whitelist_tools:
 
+# nginx configuration
+nginx_client_body_temp_path: "/tmp/nginx"
+nginx_client_max_body_size: "10G"
+
 # uWSGI configuration
 galaxy_uwsgi_processes: 8
 

--- a/roles/galaxy/templates/nginx-galaxy.conf.j2
+++ b/roles/galaxy/templates/nginx-galaxy.conf.j2
@@ -34,6 +34,7 @@ server {
 {% else %}
     listen 80 default;
 {% endif %}
+    client_body_temp_path /tmp/nginx;
     client_max_body_size 10G;
     # UWSGI settings
     uwsgi_temp_path /tmp/uwsgi;

--- a/roles/galaxy/templates/nginx-galaxy.conf.j2
+++ b/roles/galaxy/templates/nginx-galaxy.conf.j2
@@ -34,8 +34,8 @@ server {
 {% else %}
     listen 80 default;
 {% endif %}
-    client_body_temp_path /tmp/nginx;
-    client_max_body_size 10G;
+    client_body_temp_path {{ nginx_client_body_temp_path }};
+    client_max_body_size {{ nginx_client_max_body_size }};
     # UWSGI settings
     uwsgi_temp_path /tmp/uwsgi;
     uwsgi_max_temp_file_size 1024k;


### PR DESCRIPTION
PR to address issue #59 by adding the `client_body_temp_path` directive to the `nginxproxy` task in the `galaxy` role.