### PR TITLE
Fix JSE-Drop multiple deletion attempts for job in 'Eqw' state

### DIFF
--- a/roles/galaxy/files/jse_drop.py
+++ b/roles/galaxy/files/jse_drop.py
@@ -346,8 +346,8 @@ class JSEDrop(object):
         """
         kill_file = os.path.join(self._drop_dir,"%s.drop.qdel" % name)
         if os.path.exists(kill_file):
-            raise OSError("Kill file for job with name '%s' already exists" %
-                          name)
+            # Kill file already exists, ignore
+            return
         with open(kill_file,'w') as fp:
             pass
 


### PR DESCRIPTION
PR which addresses an issue with the handling of jobs in `Eqw` (error) states when using JSE-Drop for job submission.

If Galaxy checks the JSE-Drop directory more frequently than the JSE-Drop monitoring process does, then it may attempt to kill jobs in an error state multiple times (by creating a `.drop.qdel` file) before the monitoring process acts on this and removes the job. In this case, the `JSEDrop.kill` method (in `roles/galaxy/files/jse_drop.py`) raises an `OSError` exception if the `.drop.qdel` file already exists.

This PR fixes this behaviour by ignoring a pre-existing `.drop.qdel` file (as the kill operation is already pending in this case).