### PR TITLE
Fixes to the JSEDrop reference implementation in role 'jsedrop'

### DIFF
--- a/roles/jsedrop/files/jsedrop.py
+++ b/roles/jsedrop/files/jsedrop.py
@@ -389,7 +389,7 @@ STDERR:
                 status,output = self._backend.get_status(job_id)
             except Exception as ex:
                 self.log("-- WARNING error getting status for "
-                         "job '%s'" % job)
+                         "job '%s': %s" % (job,ex))
                 return
             if status is None:
                 # Job still running, write qstat file

--- a/roles/jsedrop/files/jsedrop.py
+++ b/roles/jsedrop/files/jsedrop.py
@@ -326,7 +326,7 @@ class JSEDrop(object):
             qsubmit_file = os.path.join(self._drop_dir,
                                         "%s.drop.qsubmit" % job)
             with open(qsubmit_file,'wt') as fp:
-                fp.write("//%s  %s//" % (job,job_id))
+                fp.write(" //%s//\n" % job_id)
         except Exception as ex:
             # Submission failed, write qfail file
             status = 1


### PR DESCRIPTION
PR which fixes the handling of job IDs in the `jsedrop.py` reference implementation of JSEDrop in the `jsedrop` role, to improve internal consistency and ensure that the behaviour matches that of the Perl implementation used on the local cluster system. Specifically the fixes are to the format of the job IDs and to the contents of the output `.drop.qsubmit` file.