### PR TITLE
Implement automatic clean up of deleted JSEDrop jobs

### DIFF
--- a/roles/galaxy/defaults/main.yml
+++ b/roles/galaxy/defaults/main.yml
@@ -139,6 +139,9 @@ galaxy_default_runner: "local"
 galaxy_jse_drop_galaxy_id: "{{ galaxy_name }}"
 galaxy_jse_drop_dir: "{{ galaxy_dir }}/jse-drop"
 galaxy_jse_drop_virtual_env: "{{ galaxy_root }}/.venv"
+# Grace period after which files from deleted jobs
+# can be removed (seconds)
+galaxy_jse_drop_cleanup_grace_period: "600"
 
 # Job destinations
 # Define entries as a dictionary with:

--- a/roles/galaxy/files/jse_drop.py
+++ b/roles/galaxy/files/jse_drop.py
@@ -13,7 +13,6 @@ from datetime import timedelta
 class JSEDropStatus(object):
     MISSING = 0
     WAITING = 1
-    SUBMITTED = 2
     FAILED = 3
     RUNNING = 4
     FINISHED = 5

--- a/roles/galaxy/files/jse_drop.py
+++ b/roles/galaxy/files/jse_drop.py
@@ -470,6 +470,29 @@ class JSEDrop(object):
             except OSError:
                 pass
 
+def jse_drop_cleanup_deleted(drop_dir,interval):
+    """
+    Clean up deleted jobs in the specified drop directory
+
+    Arguments:
+      drop_dir (str): path to JSE 'drop-off' directory
+      interval (int): interval (in seconds) from now which
+        deleted jobs must be older than in order to be
+        cleaned up
+
+    """
+    jsedrop = JSEDrop(drop_dir)
+    now = datetime.now()
+    interval = timedelta(seconds=interval)
+    jobs = [j for j in jsedrop.jobs()
+            if (jsedrop.status(j) == JSEDropStatus.DELETED
+                and
+                (now - datetime.fromtimestamp(jsedrop.timestamp(j)))
+                > interval)]
+    for job in jobs:
+        print("Cleaning up deleted job '%s'" % job)
+        jsedrop.cleanup(job)
+
 if __name__ == '__main__':
     # Test program
     import sys

--- a/roles/galaxy/files/jse_drop.py
+++ b/roles/galaxy/files/jse_drop.py
@@ -1,5 +1,42 @@
 """
 Python API for the JSE-drop job submission mechnanism.
+
+Provides the following classes:
+
+- ``JSEDropStatus``: status codes for JSE-drop jobs returned by
+  the ``JSEDrop.status`` method
+- ``JSEDrop``: class providing API methods for submitting,
+  monitoring and controlling JSE-drop jobs
+
+There is also a utility function:
+
+- ``jse_drop_cleanup_deleted``: removes the files associated
+  with deleted JSE-drop jobs which are older than a specified
+  time interval
+
+In normal operation the status codes indicate the following:
+
+- ``WAITING``: job has ``qsub`` file but not yet been
+  submitted by JSE-Drop (i.e. there is no ``qsubmit`` file)
+- ``RUNNING``: job is running (i.e. there is a ``qsubmit``
+  file indicating job started, but no ``qacct`` file to
+  indicate that it has finished)
+- ``FINISHED``: job has completed (i.e. there is a ``qacct``
+  file indicating the job has finished)
+- ``DELETING``: job is scheduled for deletion but may still
+  be active (i.e. there is a ``qdel`` file but no ``qdeleted``
+  file)
+- ``DELETED``: job has been deleted (i.e. there is a
+  ``qdeleted`` file)
+
+The following status codes indicate a problem:
+
+- ``FAILED``: job failed on submission (i.e. there is a
+  ``qfail`` file)
+- ``ERROR``: job was submitted but is in an error state
+  (e.g. ``Eqw`` state for Grid Engine backend)
+- ``MISSING``: job with that name is not found
+
 """
 import os
 import shutil

--- a/roles/galaxy/files/jse_drop.py
+++ b/roles/galaxy/files/jse_drop.py
@@ -414,6 +414,8 @@ class JSEDrop(object):
                       '.drop.qacct',)
         # Remove stdout/stderr first
         for f in (self.stdout_file(name),self.stderr_file(name)):
+            if f is None:
+                continue
             try:
                 os.remove(f)
             except OSError:

--- a/roles/galaxy/files/jse_drop.py
+++ b/roles/galaxy/files/jse_drop.py
@@ -43,6 +43,7 @@ import shutil
 import tempfile
 import re
 import glob
+import time
 from datetime import datetime
 from datetime import timedelta
 
@@ -526,7 +527,8 @@ def jse_drop_cleanup_deleted(drop_dir,interval):
                 (now - datetime.fromtimestamp(jsedrop.timestamp(j)))
                 > interval)]
     for job in jobs:
-        print("Cleaning up deleted job '%s'" % job)
+        print("%s: cleaning up deleted job '%s'" %
+              (time.strftime("%Y-%m-%d %H:%M:%S"),job))
         jsedrop.cleanup(job)
 
 if __name__ == '__main__':

--- a/roles/galaxy/files/jse_drop.py
+++ b/roles/galaxy/files/jse_drop.py
@@ -6,6 +6,8 @@ import shutil
 import tempfile
 import re
 import glob
+from datetime import datetime
+from datetime import timedelta
 
 # JSE-drop job status codes
 class JSEDropStatus(object):
@@ -396,6 +398,39 @@ class JSEDrop(object):
             return
         with open(kill_file,'w') as fp:
             pass
+
+    def timestamp(self,name):
+        """
+        Return timestamp associated with a job
+
+        This will be the most recent timestamp across
+        all '.drop.*' files associated with the job
+
+        Arguments:
+          name (str): name of the job
+
+        """
+        extensions = ('.drop.qsub',
+                      '.drop.qsubmit',
+                      '.drop.qfail',
+                      '.drop.qstat',
+                      '.drop.qdel',
+                      '.drop.qdeleted',
+                      '.drop.qacct',)
+        timestamp = None
+        for ext in extensions:
+            try:
+                ts = os.path.getmtime(os.path.join(self._drop_dir,
+                                                   "%s%s" % (name,ext)))
+                if timestamp:
+                    timestamp = max(timestamp,ts)
+                else:
+                    timestamp = ts
+            except OSError:
+                pass
+            except Exception as ex:
+                print("%s: failed to get job timestamp: %s" % (name,ex))
+        return timestamp
 
     def cleanup(self,name):
         """

--- a/roles/galaxy/files/jse_drop.py
+++ b/roles/galaxy/files/jse_drop.py
@@ -16,6 +16,8 @@ class JSEDropStatus(object):
     RUNNING = 4
     FINISHED = 5
     ERROR = 6
+    DELETING = 7
+    DELETED = 8
 
 class JSEDrop(object):
     """
@@ -149,6 +151,12 @@ class JSEDrop(object):
         if os.path.exists("%s.drop.qfail" % base_name):
             # Submission failed
             return JSEDropStatus.FAILED
+        if os.path.exists("%s.drop.qdeleted" % base_name):
+            # Job has been deleted
+            return JSEDropStatus.DELETED
+        if os.path.exists("%s.drop.qdel" % base_name):
+            # Job is pending deletion
+            return JSEDropStatus.DELETING
         if not os.path.exists("%s.drop.qsubmit" % base_name):
             # Waiting for submission
             return JSEDropStatus.WAITING

--- a/roles/galaxy/files/jse_drop_runner.py
+++ b/roles/galaxy/files/jse_drop_runner.py
@@ -312,6 +312,11 @@ class JSEDropJobRunner(AsynchronousJobRunner):
             if cleanup_job == "always" or cleanup_job == "onsuccess":
                 jse_drop.cleanup(job_name)
             return None
+        if jse_drop_status in (JSEDropStatus.DELETED,
+                               JSEDropStatus.DELETING,):
+            # Job either deleted, or waiting to be deleted
+            # Nothing to do here either way
+            return None
         if jse_drop_status in (JSEDropStatus.FAILED,
                                JSEDropStatus.MISSING,
                                JSEDropStatus.ERROR,):

--- a/roles/galaxy/tasks/jsedrop.yml
+++ b/roles/galaxy/tasks/jsedrop.yml
@@ -32,3 +32,11 @@
     minute=00
     job='find {{ galaxy_jse_drop_dir }} -name "*" -type f -mtime +28 -exec rm -f {} \;'
     state=present
+
+- name: "Clean up deleted files from JSE-drop directory"
+  cron:
+    user='{{ galaxy_user }}'
+    name='Clean up deleted JSE-drop jobs'
+    special_time='hourly'
+    job='source {{ galaxy_root }}/.venv/bin/activate && PYTHONPATH={{ galaxy_root }}/lib:$PYTHONPATH python -c "from galaxy.jobs.runners.jse_drop import jse_drop_cleanup_deleted ; jse_drop_cleanup_deleted(\"{{ galaxy_jse_drop_dir }}\",{{ galaxy_jse_drop_cleanup_grace_period }})"'
+    state=present

--- a/roles/galaxy/tasks/jsedrop.yml
+++ b/roles/galaxy/tasks/jsedrop.yml
@@ -38,5 +38,5 @@
     user='{{ galaxy_user }}'
     name='Clean up deleted JSE-drop jobs'
     special_time='hourly'
-    job='source {{ galaxy_root }}/.venv/bin/activate && PYTHONPATH={{ galaxy_root }}/lib:$PYTHONPATH python -c "from galaxy.jobs.runners.jse_drop import jse_drop_cleanup_deleted ; jse_drop_cleanup_deleted(\"{{ galaxy_jse_drop_dir }}\",{{ galaxy_jse_drop_cleanup_grace_period }})"'
+    job='source {{ galaxy_root }}/.venv/bin/activate && PYTHONPATH={{ galaxy_root }}/lib:$PYTHONPATH python -c "from galaxy.jobs.runners.jse_drop import jse_drop_cleanup_deleted ; jse_drop_cleanup_deleted(\'{{ galaxy_jse_drop_dir }}\',{{ galaxy_jse_drop_cleanup_grace_period }})" 2>&1 1>>{{ galaxy_log_dir}}/jse_drop_cleanup.log'
     state=present


### PR DESCRIPTION
PR which implements automatic clean up of files left over from JSEDrop jobs which have been deleted by Galaxy, as an attempt to address possible problems highlighted in issue #71.

This cleanup mechanism is required because Galaxy delegates the clean up of deleted jobs to the job submission system, however clean up is not implemented in the current JSEDrop backend.

The attempted fix is to add a cronjob to the `galaxy` role which runs hourly and removes files from jobs that were deleted 10 or more minutes earlier; this default grace period can be changed by setting the `galaxy_jse_drop_cleanup_grace_period` parameter in the ansible playbooks.