### PR TITLE
'galaxy' role: add clean-up of job working directory

### DIFF
--- a/roles/galaxy/tasks/cleanup.yml
+++ b/roles/galaxy/tasks/cleanup.yml
@@ -36,10 +36,10 @@
     state=present
   with_items:
   - { name: "Clean up files from job working directory",
-      job: "find {{ galaxy_job_working_dir }} -mindepth 2 -type f -mtime +28 -exec rm -rf {} \;",
+      job: "find {{ galaxy_job_working_dir }} -mindepth 2 -type f -mtime +28 -exec rm -rf {} \\;",
       hour: 00,
       minute: 10 }
   - { name: "Clean up empty directories from job working directory",
-      job: "find {{ galaxy_job_working_dir }} -mindepth 2 -type d -mtime +28 -empty -exec rmdir {} \;",
+      job: "find {{ galaxy_job_working_dir }} -mindepth 2 -type d -mtime +28 -empty -exec rmdir {} \\;",
       hour: 00,
       minute: 15 }

--- a/roles/galaxy/tasks/cleanup.yml
+++ b/roles/galaxy/tasks/cleanup.yml
@@ -1,6 +1,6 @@
 # See https://galaxyproject.org/admin/config/performance/purge-histories-and-datasets/
 ---
-- name: Set up daily cron jobs to purge deleted data
+- name: "Set up daily cron jobs to purge deleted data in Galaxy"
   cron:
     user='{{ galaxy_user }}'
     name='{{ item.name }}'
@@ -26,3 +26,20 @@
   - { name: 'Purge datasets',
       script: 'purge_datasets.sh',
       hour: 04, minute: 00 }
+
+- name: "Clean up Galaxy job working directory"
+  cron:
+    user='{{ galaxy_user }}'
+    name='{{ item.name }}'
+    job='{{ item.job }}'
+    hour={{ item.hour }} minute={{ item.minute }}
+    state=present
+  with_items:
+  - { name: "Clean up files from job working directory",
+      job: "find {{ galaxy_job_working_dir }} -mindepth 2 -type f -mtime +28 -exec rm -rf {} \;",
+      hour: 00,
+      minute: 10 }
+  - { name: "Clean up empty directories from job working directory",
+      job: "find {{ galaxy_job_working_dir }} -mindepth 2 -type d -mtime +28 -empty -exec rmdir {} \;",
+      hour: 00,
+      minute: 15 }

--- a/roles/galaxy/tasks/main.yml
+++ b/roles/galaxy/tasks/main.yml
@@ -18,7 +18,7 @@
   become: yes
   become_user: "{{ galaxy_user }}"
 
-- include: purgehistories.yml
+- include: cleanup.yml
 
 - include: logrotate.yml
 


### PR DESCRIPTION
PR which updates the `galaxy` role to add periodic clean up of the job working directory via `cron` jobs.

As part of the PR the dataset purging tasks in `galaxy/tasks/purgehistories.yml` have been moved to a new more `galaxy/tasks/cleanup.yml` file, where the new clean-up `cron` jobs also reside.