### PR TITLE
JSE-Drop: update permissions and restart local service

### DIFF
--- a/roles/galaxy/tasks/jsedrop.yml
+++ b/roles/galaxy/tasks/jsedrop.yml
@@ -13,6 +13,7 @@
   file:
     path='{{ galaxy_jse_drop_dir }}'
     state=directory
+    mode=0775
 
 # Setup cron jobs to clean up JSE-drop directory
 - name: Clean up qsub files from JSE-drop directory

--- a/roles/jsedrop/tasks/main.yml
+++ b/roles/jsedrop/tasks/main.yml
@@ -1,45 +1,59 @@
 ---
 # Install jsedrop.py as a service on the remote host
 
-- name: "Install jsedrop.py dependencies (SL6)"
-  yum:
-    state=present
-    name="{{item}}"
-  with_items:
-  - python34
+- name: "Install and start local JSE-Drop service (SL6)"
+  block:
+    - name: "Install jsedrop.py dependencies"
+      yum:
+        state=present
+        name="{{item}}"
+      with_items:
+        - python34
+
+    - name: "Install jsedrop.py"
+      copy:
+        src="jsedrop.py"
+        dest="{{ jsedrop_install_dir }}/jsedrop.py"
+        mode="ugo+x"
+
+    - name: "Create init.d script for jsedrop"
+      template:
+        src="jsedrop.init.j2"
+        dest="/etc/init.d/jsedrop"
+        mode='ugo+x'
+
+    - name: "(Re)start jsedrop.service"
+      service:
+        name="jsedrop"
+        enabled=yes
+        state=restarted
   when: ansible_distribution_major_version == "6"
 
-- name: "Install jsedrop.py dependencies (SL7)"
-  yum:
-    state=present
-    name="{{item}}"
-  with_items:
-  - python3
+- name: "Install and start local JSE-Drop service (SL7)"
+  block:
+    - name: "Install jsedrop.py dependencies"
+      yum:
+        state=present
+        name="{{item}}"
+      with_items:
+        - python3
+
+    - name: "Install jsedrop.py"
+      copy:
+        src="jsedrop.py"
+        dest="{{ jsedrop_install_dir }}/jsedrop.py"
+        mode="ugo+x"
+
+    - name: "Create service file for jsedrop.service"
+      template:
+        src="jsedrop.service.j2"
+        dest="/lib/systemd/system/jsedrop.service"
+      notify:
+        - "Restart jsedrop.service"
+
+    - name: "(Re)start jsedrop.service"
+      systemd:
+        name="jsedrop"
+        enabled=yes
+        state=restarted
   when: ansible_distribution_major_version == "7"
-
-- name: "Install jsedrop.py"
-  copy:
-    src="jsedrop.py"
-    dest="{{ jsedrop_install_dir }}/jsedrop.py"
-    mode="ugo+x"
-
-- name: "Create init.d script for jsedrop (SL6)"
-  template:
-    src="jsedrop.init.j2"
-    dest="/etc/init.d/jsedrop"
-    mode='ugo+x'
-  when: ansible_distribution_major_version == "6"
-
-- name: "Create service file for jsedrop.service (SL7)"
-  template:
-    src="jsedrop.service.j2"
-    dest="/lib/systemd/system/jsedrop.service"
-  notify:
-  - "Restart jsedrop.service"
-  when: ansible_distribution_major_version == "7"
-
-- name: "Start jsedrop.service"
-  service:
-    name="jsedrop"
-    enabled=yes
-    state=started


### PR DESCRIPTION
PR which updates some of the JSE-Drop-related tasks:

* `galaxy` role: update the permissions for the drop-off directory used by JSE-Drop
* `jsedrop` role: distinguish between setting up the local JSE-Drop service on Scientific Linux 6 and 7, and use the appropriate service management for the OS; also ensure that the service is explicitly restarted each time.