### PR TITLE
'galaxy' role: fix the checks on database existence

### DIFF
--- a/roles/galaxy/tasks/galaxy.yml
+++ b/roles/galaxy/tasks/galaxy.yml
@@ -164,23 +164,23 @@
 # Create or update Galaxy database
 - name: "Check if Galaxy database exists"
   shell:
-    psql -c '\dt' '{{ galaxy_db }}'
+    "PGPASSWORD={{ galaxy_db_password }} psql -c '\\dt' '{{ galaxy_db }}'"
   register: dbstatus
 
 - name: "Run create_db.py to initialise the Galaxy database"
   command:
     chdir='{{ galaxy_root }}'
     .venv/bin/python scripts/create_db.py
-  when: dbstatus.rc != 0
+  when: dbstatus.stdout == "No relations found."
 
 - name: "Update existing Galaxy database"
   block:
     - name: "Dump Galaxy database SQL as a backup"
       shell:
-        "pg_dump {{ galaxy_db}} > {{ galaxy_dir}}/backups/{{ galaxy_db }}.$(date +%Y-%m-%d-%H%M%S).sql"
+        "PGPASSWORD={{ galaxy_db_password }} pg_dump {{ galaxy_db}} > {{ galaxy_dir}}/backups/{{ galaxy_db }}.$(date +%Y-%m-%d-%H%M%S).sql"
 
     - name: "Update the Galaxy database"
       command:
         chdir='{{ galaxy_root }}'
         ./manage_db.sh upgrade
-  when: dbstatus.rc == 0
+  when: dbstatus.stdout != "No relations found."


### PR DESCRIPTION
PR which fixes the broken check on whether the Galaxy database already exists: the original check was based on MySQL, and also only checked if the database exists (not whether it has any contents). The fix is compatible with Postgres and checks for database content.