### PR TITLE
Update Palfinder to Galaxy 19.05

### DIFF
--- a/inventories/palfinder/production.yml
+++ b/inventories/palfinder/production.yml
@@ -9,6 +9,7 @@ palfinder:
     palfinder_secrets: palfinder_passwds.yml
     # Job configuration
     enable_jse_drop: yes
+    enable_local_jse_drop: no
     galaxy_jse_drop_dir: "{{ galaxy_install_dir }}/palfinder/jse-drop-csf3"
     galaxy_default_runner: "jse_drop_default"
     galaxy_job_destinations:

--- a/inventories/palfinder/vagrant.yml
+++ b/inventories/palfinder/vagrant.yml
@@ -11,9 +11,10 @@ palfinder:
     galaxy_server_name: 192.168.60.4
     enable_user_activation: no
     # Job configuration
-    # Job configuration
     enable_jse_drop: yes
     enable_local_jse_drop: yes
+    jsedrop_python3_yum_package: "python34"
+    jsedrop_python3: "/usr/bin/python3.4"
     galaxy_jse_drop_dir: "{{ galaxy_install_dir }}/palfinder/jse-drop-csf3"
     galaxy_default_runner: "jse_drop_default"
     galaxy_job_destinations:

--- a/inventories/palfinder/vagrant.yml
+++ b/inventories/palfinder/vagrant.yml
@@ -11,7 +11,14 @@ palfinder:
     galaxy_server_name: 192.168.60.4
     enable_user_activation: no
     # Job configuration
-    enable_jse_drop: no
+    # Job configuration
+    enable_jse_drop: yes
+    enable_local_jse_drop: yes
+    galaxy_jse_drop_dir: "{{ galaxy_install_dir }}/palfinder/jse-drop-csf3"
+    galaxy_default_runner: "jse_drop_default"
+    galaxy_job_destinations:
+      - id: "jse_drop_default"
+        runner: "jse_drop"
     # Postfix/email configuration
     enable_smtp: no
     # SSL configuration

--- a/palfinder.yml
+++ b/palfinder.yml
@@ -74,8 +74,13 @@
   - ssl_certificate: "/etc/letsencrypt/live/{{ galaxy_server_name }}/fullchain.pem"
   - ssl_certificate_key: "/etc/letsencrypt/live/{{ galaxy_server_name }}/privkey.pem"
   # Palfinder-specific settings
-  # Message of the day to display on the front page
-  - palfinder_motd:
+  # Message of the day to display on the front page and message
+  # to display under masthead
+  # -- for ansible <2.6 "errors=..." option is not supported so
+  #    an empty placeholder file is required to stop the playbook
+  #    failing
+  - palfinder_motd: "{{ lookup('file', 'instances/palfinder/files/motd', errors='warn') }}"
+  - galaxy_message: "{{ lookup('file', 'instances/palfinder/files/message', errors='warn') }}"
 
   vars_files:
   - instances/palfinder/{{ palfinder_secrets }}

--- a/palfinder.yml
+++ b/palfinder.yml
@@ -4,7 +4,7 @@
   vars:
   # Galaxy configuration
   - galaxy_name: "palfinder"
-  - galaxy_version: "release_18.09"
+  - galaxy_version: "release_19.05"
   - galaxy_install_dir: "/mnt/rvmi/palfinder/galaxy"
   - galaxy_python_dir: "/mnt/rvmi/palfinder/galaxy/python"
   - enable_require_login: yes

--- a/palfinder.yml
+++ b/palfinder.yml
@@ -55,6 +55,7 @@
   - galaxy_sanitize_whitelist_tools:
       - "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.71"
       - "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.72"
+      - "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.72+galaxy1"
   # Default quota
   - default_quota_gb: 50
   # Automatic dataset deletion

--- a/palfinder.yml
+++ b/palfinder.yml
@@ -95,6 +95,10 @@
   - role: postfix-null-client
     when: enable_smtp
   - lets-encrypt-client
+  # Local JSEDrop service
+  - role: jsedrop
+    jsedrop_drop_dir: "{{ galaxy_jse_drop_dir }}"
+    when: enable_local_jse_drop
   # Install Galaxy-specific Python 2.7
   - role: python27
     install_dir: "{{ galaxy_python_dir }}"


### PR DESCRIPTION
PR which updates the Palfinder Galaxy instance to `release_19.05`.

In addition the PR also updates the Vagrant test instance to use a local JSEDrop service, to better mimic the deployment on the production VM.