### PR TITLE
JSEDrop service: fix installation and '--run-as-user' functionality

### DIFF
--- a/inventories/mintaka/production.yml
+++ b/inventories/mintaka/production.yml
@@ -22,6 +22,3 @@ mintaka:
     enable_https: yes
     ssl_certificate: "/etc/letsencrypt/live/{{ galaxy_server_name }}/fullchain.pem"
     ssl_certificate_key: "/etc/letsencrypt/live/{{ galaxy_server_name }}/privkey.pem"
-    # Local JSE-drop dependencies
-    jsedrop_python3_yum_package: "python34"
-    jsedrop_python3: "/usr/bin/python3.4"

--- a/inventories/mintaka/production.yml
+++ b/inventories/mintaka/production.yml
@@ -22,3 +22,6 @@ mintaka:
     enable_https: yes
     ssl_certificate: "/etc/letsencrypt/live/{{ galaxy_server_name }}/fullchain.pem"
     ssl_certificate_key: "/etc/letsencrypt/live/{{ galaxy_server_name }}/privkey.pem"
+    # Local JSE-drop dependencies
+    jsedrop_python3_yum_package: "python34"
+    jsedrop_python3: "/usr/bin/python3.4"

--- a/mintaka.yml
+++ b/mintaka.yml
@@ -163,11 +163,13 @@
       - "data/chrom/mm10.len"
       - "data/chrom/mm9.len"
   # uWSGI and handler configuration
-  # Set number of uWSGI & handler processes in inventory file
+  # *** Set number of uWSGI & handler processes in inventory file ***
   # Job configuration
   # (Always uses a local JSE-Drop service)
   - enable_jse_drop: yes
   - enable_local_jse_drop: yes
+  - jsedrop_python3_yum_package: "python34"
+  - jsedrop_python3: "/usr/bin/python3.4"
   - galaxy_jse_drop_dir: "{{ galaxy_install_dir }}/jse-drop-local"
   - galaxy_default_runner: "jse_drop_serial"
   - galaxy_job_destinations:

--- a/roles/jsedrop/defaults/main.yml
+++ b/roles/jsedrop/defaults/main.yml
@@ -2,4 +2,5 @@
 # jsedrop.py installation defaults
 jsedrop_install_dir: "/usr/bin"
 jsedrop_drop_dir: "/usr/share/drop-off"
+jsedrop_python3: "/usr/bin/python3"
 jsedrop_python3_yum_package: "python3"

--- a/roles/jsedrop/defaults/main.yml
+++ b/roles/jsedrop/defaults/main.yml
@@ -2,3 +2,4 @@
 # jsedrop.py installation defaults
 jsedrop_install_dir: "/usr/bin"
 jsedrop_drop_dir: "/usr/share/drop-off"
+jsedrop_python3_yum_package: "python3"

--- a/roles/jsedrop/tasks/main.yml
+++ b/roles/jsedrop/tasks/main.yml
@@ -1,15 +1,15 @@
 ---
 # Install jsedrop.py as a service on the remote host
 
+- name: "Install jsedrop.py dependencies"
+  yum:
+    state=present
+    name="{{item}}"
+  with_items:
+    - "{{ jsedrop_python3_yum_package }}"
+
 - name: "Install and start local JSE-Drop service (SL6)"
   block:
-    - name: "Install jsedrop.py dependencies"
-      yum:
-        state=present
-        name="{{item}}"
-      with_items:
-        - python34
-
     - name: "Install jsedrop.py"
       copy:
         src="jsedrop.py"
@@ -31,13 +31,6 @@
 
 - name: "Install and start local JSE-Drop service (SL7)"
   block:
-    - name: "Install jsedrop.py dependencies"
-      yum:
-        state=present
-        name="{{item}}"
-      with_items:
-        - python3
-
     - name: "Install jsedrop.py"
       copy:
         src="jsedrop.py"

--- a/roles/jsedrop/templates/jsedrop.init.j2
+++ b/roles/jsedrop/templates/jsedrop.init.j2
@@ -28,7 +28,7 @@ case $1 in
 	fi
 
         echo "Starting jsedrop..."
-        /usr/bin/python3 $JSEDROP_BIN {{ jsedrop_drop_dir }} --log $LOGFILE --pid_file $PIDFILE --run-as-user &
+        {{ jsedrop_python3 }} $JSEDROP_BIN {{ jsedrop_drop_dir }} --log $LOGFILE --pid_file $PIDFILE --run-as-user &
 	;;
 
     stop)

--- a/roles/jsedrop/templates/jsedrop.service.j2
+++ b/roles/jsedrop/templates/jsedrop.service.j2
@@ -5,7 +5,7 @@ Conflicts=getty@tty1.service
 
 [Service]
 Type=simple
-ExecStart=/usr/bin/python3 {{ jsedrop_install_dir }}/jsedrop.py {{ jsedrop_drop_dir }} --log /var/log/jsedrop.log --run-as-user
+ExecStart={{ jsedrop_python3 }} {{ jsedrop_install_dir }}/jsedrop.py {{ jsedrop_drop_dir }} --log /var/log/jsedrop.log --run-as-user
 StandardInput=tty-force
 
 [Install]


### PR DESCRIPTION
PR that fixes the `jsedrop` role so that the required Python3 yum package and path to the Python3 executable can be explicitly specified on a per-instance basis.

Additionally `jsedrop.py` has been updated to deal with issues encountered on the production instance of Mintaka when using the `--run-as-user` option with the local JSEDrop (where output and job control files couldn't be written to the drop-off directory due to permission issues).