### PR TITLE
'galaxy' role: drop support for custom CSS

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -53,6 +53,7 @@ The following roles are defined:
    * (Optionally) set up the JSE-drop job runner plugin
    * Configure uWSGI for Galaxy
    * Configure Supervisord for Galaxy
+   * (Optionally) set up custom colour scheme via SCSS
 
  - ``galaxy-utils``: installs utility scripts for Galaxy
    user creation, tool installation etc
@@ -125,6 +126,14 @@ Job runner configuration:
    be a dictionary defining a tool destination to be added to
    the ``tools`` section of ``job_conf.xml`` (default: no
    tool destinations are defined)
+
+Custom colour scheme:
+
+ - ``galaxy_custom_scss``: a list where each item should be
+   a dictionary defining an SCSS variable (``item``) and a
+   corresponding ``value``. (See "Adjusting styles" in the
+   tutorial presentation:
+   https://training.galaxyproject.org/training-material/topics/admin/tutorials/advanced-galaxy-customisation/slides.html#20)
 
 Other configuration settings:
 

--- a/roles/galaxy/defaults/main.yml
+++ b/roles/galaxy/defaults/main.yml
@@ -38,11 +38,6 @@ galaxy_citations:
 # - value (Value e.g. 'red', '#660099')
 galaxy_custom_scss: null
 
-# Pre-built base CSS file to import for this
-# instance (overwrites existing CSS file)
-# !!!DEPRECATED: use 'galaxy_custom_scss' instead!!!
-galaxy_base_css: null
-
 # Message of the day
 # This message will be displayed under the masthead
 # on the Galaxy site

--- a/roles/galaxy/tasks/galaxy.yml
+++ b/roles/galaxy/tasks/galaxy.yml
@@ -56,12 +56,6 @@
   with_items: "{{ galaxy_custom_scss }}"
   when: galaxy_custom_scss|default(None) != None
 
-- name: "DEPRECATED: import base CSS styles file"
-  copy:
-    src='{{ galaxy_base_css }}'
-    dest='{{ galaxy_root }}/static/style/blue/base.css'
-  when: galaxy_base_css|default(None) != None
-
 - name: Make virtualenv in Galaxy root
   command:
     chdir={{ galaxy_root }}


### PR DESCRIPTION
PR to address issue #85 and drop support for including a custom CSS file to set colours and styles in a Galaxy instance; now customisation can only be done using SCSS variables.