### PR TITLE
Fixes for compatibility with ansible 2.10.3

### DIFF
--- a/roles/epel-repo/tasks/main.yml
+++ b/roles/epel-repo/tasks/main.yml
@@ -17,10 +17,9 @@
 # - https://stackoverflow.com/a/55851121
 - name: "Update curl and nss to work with EPEL"
   yum:
-    name: "{{ item }}"
+    name:
+      - nss
+      - curl
+      - libcurl
     state: "latest"
     disablerepo: "epel"
-  with_items:
-  - nss
-  - curl
-  - libcurl

--- a/roles/galaxy-utils/tasks/main.yml
+++ b/roles/galaxy-utils/tasks/main.yml
@@ -11,12 +11,11 @@
 
 - name: Install dependencies for utilities
   pip:
-    name="{{ item }}"
-    executable='{{ python_install_dir }}/bin/pip'
-    state=present
-  with_items:
-    - "psycopg2==2.6.2"
-    - "pyyaml"
+    name:
+      - "psycopg2==2.6.2"
+      - "pyyaml"
+    executable: '{{ python_install_dir }}/bin/pip'
+    state: present
 
 - name: Install Nebulizer
   pip:

--- a/roles/galaxy/tasks/dependencies.yml
+++ b/roles/galaxy/tasks/dependencies.yml
@@ -1,14 +1,15 @@
 # Install dependencies
 ---
 - name: Install Galaxy dependencies
-  yum: name={{ item }} state=latest
-  with_items:
-  - python-psycopg2
-  - libtool
-  - libtool-ltdl
-  - libtool-ltdl-devel
-  - java-1.8.0-openjdk
-  - samtools
-  - python2-pyyaml
-  - net-tools
+  yum:
+    name:
+      - python-psycopg2
+      - libtool
+      - libtool-ltdl
+      - libtool-ltdl-devel
+      - java-1.8.0-openjdk
+      - samtools
+      - python2-pyyaml
+      - net-tools
+    state: latest
   register: installed_dependencies

--- a/roles/git/tasks/main.yml
+++ b/roles/git/tasks/main.yml
@@ -29,18 +29,17 @@
 
 - name: Install build dependencies
   yum:
-    name={{ item }}
-    state=present
-  with_items:
-    - gcc
-    - openssl-devel
-    - libcurl-devel
-    - expat-devel
-    - tcl
-    - gettext
-    - asciidoc
-    - xmlto
-    - docbook2X
+    name:
+      - gcc
+      - openssl-devel
+      - libcurl-devel
+      - expat-devel
+      - tcl
+      - gettext
+      - asciidoc
+      - xmlto
+      - docbook2X
+    state: present
 
 # Need to make link to docbook2x-text to build
 # git documentation, see

--- a/roles/jsedrop/tasks/main.yml
+++ b/roles/jsedrop/tasks/main.yml
@@ -3,10 +3,9 @@
 
 - name: "Install jsedrop.py dependencies"
   yum:
-    state=present
-    name="{{item}}"
-  with_items:
-    - "{{ jsedrop_python3_yum_package }}"
+    name:
+      - "{{ jsedrop_python3_yum_package }}"
+    state: present
 
 - name: "Install and start local JSE-Drop service (SL6)"
   block:

--- a/roles/lets-encrypt-client/tasks/main.yml
+++ b/roles/lets-encrypt-client/tasks/main.yml
@@ -1,21 +1,22 @@
 ---
 # Fetch the Let's Encrypt 'certbot' client
 - name: Install certbot system dependencies
-  yum: state=present name={{item}}
-  with_items:
-  - gcc
-  - dialog
-  - augeas-libs
-  - openssl
-  - openssl-devel
-  - libffi-devel
-  - redhat-rpm-config
-  - ca-certificates
-  - python
-  - python-devel
-  - python-virtualenv
-  - python-tools
-  - python-pip
+  yum:
+    name:
+      - gcc
+      - dialog
+      - augeas-libs
+      - openssl
+      - openssl-devel
+      - libffi-devel
+      - redhat-rpm-config
+      - ca-certificates
+      - python
+      - python-devel
+      - python-virtualenv
+      - python-tools
+      - python-pip
+    state: present
   register: installed_certbot_dependencies
 
 - name: Fetch certbot-auto

--- a/roles/nfslock/tasks/main.yml
+++ b/roles/nfslock/tasks/main.yml
@@ -2,10 +2,10 @@
 # Install and start the nfslock service
 - name: Install NFS dependencies
   yum:
-    name={{ item }} state=present
-  with_items:
-  - nfs-utils
-  - rpcbind  
+    name:
+      - nfs-utils
+      - rpcbind
+    state: present
   register: installed_nfs_dependencies
 
 - name: Start rpcbind and enable on boot

--- a/roles/nginx/tasks/main.yml
+++ b/roles/nginx/tasks/main.yml
@@ -1,12 +1,13 @@
 ---
 # Install, configure and start Nginx on remote server
 - name: Install Nginx
-  yum: name={{item}} state=present
-  with_items:
-  - nginx
-  - libselinux-python
-  - libsemanage-python
-  - python-passlib
+  yum:
+    name:
+      - nginx
+      - libselinux-python
+      - libsemanage-python
+      - python-passlib
+    state: present
 
 - name: Get status of SELinux
   command: getenforce

--- a/roles/postgresql/tasks/main.yml
+++ b/roles/postgresql/tasks/main.yml
@@ -1,10 +1,11 @@
 ---
 # Install, configure and start PostgreSQL on remote server
 - name: Install PostgreSQL server
-  yum: name={{item}} state=present
-  with_items:
-  - postgresql
-  - postgresql-server
+  yum:
+    name:
+      - postgresql
+      - postgresql-server
+    state: present
   register: postgresql_installed
 
 - name: Check if PostgreSQL is initialised

--- a/roles/proftpd/tasks/main.yml
+++ b/roles/proftpd/tasks/main.yml
@@ -4,13 +4,14 @@
 # See http://galacticengineer.blogspot.co.uk/2015/02/ftp-upload-to-galaxy-using-proftpd-and.html
 
 - name: Install ProFTPd build dependencies
-  yum: state=present name={{item}}
-  with_items:
-  - gcc
-  - postgresql-devel
-  - openssl-devel
-  - pam-devel
-  - libnetfilter_conntrack
+  yum:
+    name:
+      - gcc
+      - postgresql-devel
+      - openssl-devel
+      - pam-devel
+      - libnetfilter_conntrack
+    state: present
 
 - name: Determine the user home directory
   shell:

--- a/roles/python27/tasks/main.yml
+++ b/roles/python27/tasks/main.yml
@@ -3,25 +3,26 @@
 # Also installs pip and virtualenv packages
 
 - name: Install Python build dependencies
-  yum: state="present" name="{{item}}"
-  with_items:
-  - autoconf
-  - make
-  - automake
-  - gcc
-  - readline
-  - sqlite
-  - zlib
-  - bzip2-devel
-  - bzip2
-  - ncurses-devel
-  - ncurses
-  - openssl-devel
-  - openssl
-  - readline-devel
-  - sqlite-devel
-  - zlib-devel
-  - tkinter
+  yum:
+    name:
+      - autoconf
+      - make
+      - automake
+      - gcc
+      - readline
+      - sqlite
+      - zlib
+      - bzip2-devel
+      - bzip2
+      - ncurses-devel
+      - ncurses
+      - openssl-devel
+      - openssl
+      - readline-devel
+      - sqlite-devel
+      - zlib-devel
+      - tkinter
+    state: "present"
 
 - name: Create installation directory
   file:

--- a/roles/selinux/tasks/main.yml
+++ b/roles/selinux/tasks/main.yml
@@ -6,9 +6,9 @@
   changed_when: false
 
 - name: Install dependencies for managing SELinux
-  yum: name={{item}} state=present
-  with_items:
-  - policycoreutils-python
+  yum:
+    name: policycoreutils-python
+    state: present
   when: "'Disabled' not in sestatus.stdout"
 
 - name: Allow logrotate to operate on NFS


### PR DESCRIPTION
PR which updates roles to remove deprecation warnings when the playbooks are executed using ansible 2.10.3 (latest version from PyPI at this time).

NB full compatibility also requires the updates from PR #99 to work correctly.

This PR should address issue #87.