### PR TITLE
Refactor and parameterise Nginx and proxy configuration

### DIFF
--- a/roles/galaxy/defaults/main.yml
+++ b/roles/galaxy/defaults/main.yml
@@ -166,6 +166,11 @@ galaxy_sanitize_whitelist_tools:
 # nginx configuration
 nginx_client_body_temp_path: "/tmp/nginx"
 nginx_client_max_body_size: "10G"
+nginx_service: "nginx"
+nginx_user: "nginx"
+nginx_group: "nginx"
+nginx_conf_dir: "/etc/nginx"
+nginx_share_dir: "/usr/share/nginx"
 
 # uWSGI configuration
 galaxy_uwsgi_processes: 8

--- a/roles/galaxy/handlers/main.yml
+++ b/roles/galaxy/handlers/main.yml
@@ -1,9 +1,15 @@
 ---
-- name: Restart Nginx
-  service: name=nginx state=reloaded
+- name: "Restart Nginx"
+  service:
+    name: "{{ nginx_service }}"
+    state: reloaded
 
-- name: Restart Supervisord
-  service: name=supervisord state=reloaded
+- name: "Restart Supervisord"
+  service:
+    name: supervisord
+    state: restarted
 
-- name: Restart Galaxy reports
-  service: name=galaxy_reports state=restarted
+- name: "Restart Galaxy reports"
+  service:
+    name: galaxy_reports
+    state: restarted

--- a/roles/galaxy/tasks/nginxproxy.yml
+++ b/roles/galaxy/tasks/nginxproxy.yml
@@ -2,49 +2,52 @@
 # See https://wiki.galaxyproject.org/Admin/Config/nginxProxy
 ---
 # Create conf file for Galaxy and put into Nginx conf.d/
-- name: Configure Nginx proxy
+- name: "Configure Nginx proxy"
   template:
-    dest="/etc/nginx/conf.d/galaxy.conf"
-    src=nginx-galaxy.conf.j2
+    dest: "{{ nginx_conf_dir }}/conf.d/galaxy.conf"
+    src: nginx-galaxy.conf.j2
   notify:
   - Restart Nginx
 
 # Need write permission on home so that static content
 # can be read by Nginx proxy
-- name: Allow group read on Galaxy user home
+- name: "Allow group read on Galaxy user home"
   file:
-    path=/home/{{ galaxy_user }}
-    mode='g+rx'
+    path: "/home/{{ galaxy_user }}"
+    mode: 'g+rx'
   become: yes
   become_user: '{{ galaxy_user }}'
   register: set_group_read_on_galaxy_home
 
 # Required to allow Nginx to read static content
 # from Galaxy's home directory
-- name: Add Nginx user to galaxy group
+- name: "Add Nginx user to galaxy group"
   user:
-    name=nginx
-    groups='nginx,{{ galaxy_group }}'
+    name: "{{ nginx_user }}"
+    groups: '{{ nginx_group }},{{ galaxy_group }}'
   notify:
   - Restart Nginx
 
 # Set up strong Diffie-Hellman group for TLS/SSL
-- name: Check for Diffie-Hellman parameter file
-  stat: path=/etc/ssl/certs/dhparam.pem
+- name: "Check for Diffie-Hellman parameter file"
+  stat:
+    path: "/etc/ssl/certs/dhparam.pem"
   register: dhparam_file
 
-- name: Create strong Diffie-Hellman parameter group
-  command: openssl dhparam -out /etc/ssl/certs/dhparam.pem 2048
+- name: "Create strong Diffie-Hellman parameter group"
+  command: "openssl dhparam -out /etc/ssl/certs/dhparam.pem 2048"
   when: enable_https and dhparam_file.stat.exists == False
 
 # Make sure that the .well-know directory exists for certbot
 # Let's Encrypt client
-- name: Add certbot .well-known web directory
+- name: "Add certbot .well-known web directory"
   file:
-    path=/usr/share/nginx/html/.well-known
-    state=directory
+    path: "{{ nginx_share_dir }}/html/.well-known"
+    state: directory
   when: enable_https
 
 # Force restart of nginx
-- name: Restart Nginx
-  service: name=nginx state=reloaded
+- name: "Restart Nginx"
+  service:
+    name: "{{ nginx_service }}"
+    state: reloaded

--- a/roles/galaxy/tasks/nginxproxy.yml
+++ b/roles/galaxy/tasks/nginxproxy.yml
@@ -1,24 +1,6 @@
 # Configure Nginx proxying
 # See https://wiki.galaxyproject.org/Admin/Config/nginxProxy
 ---
-- name: Check if default Nginx configuration is present
-  stat: path=/etc/nginx/conf.d/default.conf
-  register: nginx_default_conf
-
-- name: Move default Nginx configuration
-  command: mv /etc/nginx/conf.d/default.conf /etc/nginx/conf.d/default.conf.bak
-  when: nginx_default_conf.stat.exists
-
-# On Scientific Linux 7 the default nginx.conf file contains
-# a 'server' block which clashes with the one in the Galaxy
-# conf file, so need to replace it
-- name: Replace main Nginx conf file
-  copy:
-    src="nginx.conf"
-    dest="/etc/nginx/nginx.conf"
-    mode="u=rw,go=r"
-  when: ansible_distribution_major_version == "7"
-
 # Create conf file for Galaxy and put into Nginx conf.d/
 - name: Configure Nginx proxy
   template:

--- a/roles/nginx/defaults/main.yml
+++ b/roles/nginx/defaults/main.yml
@@ -1,0 +1,22 @@
+# Defaults for setting up Nginx server
+---
+# Yum package to install Nginx
+nginx_yum_package: nginx
+
+# Name of the Nginx service
+nginx_service: nginx
+
+# Nginx user
+nginx_user: nginx
+
+# Top level location for Nginx conf file
+nginx_conf_dir: /etc/nginx
+
+# Location for log files
+nginx_log_dir: /var/log/nginx
+
+# Location for shared files
+nginx_share_dir: /usr/share/nginx
+
+# Path to PID file
+nginx_pid_file: /var/run/nginx.pid

--- a/roles/nginx/handlers/main.yml
+++ b/roles/nginx/handlers/main.yml
@@ -1,9 +1,5 @@
 ---
-- name: Restart Nginx
-  service: name=nginx state=reloaded
-
-- name: Restart Supervisord
-  service: name=supervisord state=reloaded
-
-- name: Restart Galaxy reports
-  service: name=galaxy_reports state=restarted
+- name: "Restart Nginx"
+  service:
+    name: "{{ nginx_service }}"
+    state: reloaded

--- a/roles/nginx/handlers/main.yml
+++ b/roles/nginx/handlers/main.yml
@@ -1,0 +1,9 @@
+---
+- name: Restart Nginx
+  service: name=nginx state=reloaded
+
+- name: Restart Supervisord
+  service: name=supervisord state=reloaded
+
+- name: Restart Galaxy reports
+  service: name=galaxy_reports state=restarted

--- a/roles/nginx/tasks/main.yml
+++ b/roles/nginx/tasks/main.yml
@@ -1,20 +1,20 @@
 ---
 # Install, configure and start Nginx on remote server
-- name: Install Nginx
+- name: "Install Nginx"
   yum:
     name:
-      - nginx
-      - libselinux-python
-      - libsemanage-python
-      - python-passlib
+      - "{{ nginx_yum_package }}"
+      - "libselinux-python"
+      - "libsemanage-python"
+      - "python-passlib"
     state: present
 
-- name: Get status of SELinux
+- name: "Get status of SELinux"
   command: getenforce
   register: sestatus
   changed_when: false
 
-- name: Set sebooleans for httpd
+- name: "Set sebooleans for httpd"
   seboolean:
     name={{ item }} state=yes persistent=yes
   with_items:
@@ -23,8 +23,28 @@
   - httpd_use_nfs
   when: "'Disabled' not in sestatus.stdout"
 
-- name: Start Nginx
+- name: "Check if default Nginx configuration is present"
+  stat: path={{ nginx_conf_dir }}/conf.d/default.conf
+  register: nginx_default_conf
+
+- name: "Move default Nginx configuration"
+  command: "mv {{ nginx_conf_dir }}/conf.d/default.conf {{ nginx_conf_dir }}/conf.d/default.conf.bak"
+  when: nginx_default_conf.stat.exists
+
+# On Scientific Linux 7 the default nginx.conf file contains
+# a 'server' block which clashes with the one in the Galaxy
+# conf file, so need to replace it
+- name: "Replace main Nginx conf file"
+  template:
+    src: "nginx.conf.j2"
+    dest: "{{ nginx_conf_dir }}/nginx.conf"
+    mode: "u=rw,go=r"
+  when: ansible_distribution_major_version == "7"
+  notify:
+  - "Restart Nginx"
+
+- name: "Start Nginx"
   service:
-    name=nginx
-    state=started
-    enabled=on
+    name: "{{ nginx_service }}"
+    state: started
+    enabled: on

--- a/roles/nginx/templates/nginx.conf.j2
+++ b/roles/nginx/templates/nginx.conf.j2
@@ -2,13 +2,13 @@
 #   * Official English Documentation: http://nginx.org/en/docs/
 #   * Official Russian Documentation: http://nginx.org/ru/docs/
 
-user nginx;
+user {{ nginx_user }};
 worker_processes auto;
-error_log /var/log/nginx/error.log;
-pid /var/run/nginx.pid;
+error_log {{ nginx_log_dir }}/error.log;
+pid {{ nginx_pid_file }};
 
 # Load dynamic modules. See /usr/share/nginx/README.dynamic.
-include /usr/share/nginx/modules/*.conf;
+include {{ nginx_share_dir }}/modules/*.conf;
 
 events {
     worker_connections  1024;
@@ -19,7 +19,7 @@ http {
                       '$status $body_bytes_sent "$http_referer" '
                       '"$http_user_agent" "$http_x_forwarded_for"';
 
-    access_log  /var/log/nginx/access.log  main;
+    access_log  {{ nginx_log_dir }}/access.log  main;
 
     sendfile            on;
     tcp_nopush          on;
@@ -27,11 +27,11 @@ http {
     keepalive_timeout   65;
     types_hash_max_size 2048;
 
-    include             /etc/nginx/mime.types;
+    include             {{ nginx_conf_dir }}/mime.types;
     default_type        application/octet-stream;
 
     # Load modular configuration files from the /etc/nginx/conf.d directory.
     # See http://nginx.org/en/docs/ngx_core_module.html#include
     # for more information.
-    include /etc/nginx/conf.d/*.conf;
+    include {{ nginx_conf_dir }}/conf.d/*.conf;
 }


### PR DESCRIPTION
PR which refactors the `nginx` role (which installs the Nginx server on the target VM) and the configuration of the Nginx proxy in the `galaxy` task (which sets up the configuration for serving Galaxy).

The main changes are:

* Implementation of extensive parameterisation of the Nginx service name, user and group, and installation locations, to enable compatibility with non-standard VM setups (e.g. where Nginx is not installed from a standard repository)
* Moving the general configuration of the Nginx server from the `galaxy` role into the `nginx` role (which seems more appropriate)