### PR TITLE
'galaxy' role: expose conda options in Galaxy configuration

### DIFF
--- a/roles/galaxy/defaults/main.yml
+++ b/roles/galaxy/defaults/main.yml
@@ -87,6 +87,8 @@ enable_tool_shed_check: no
 
 # Conda options
 galaxy_conda_auto_install: yes
+galaxy_conda_auto_init: yes
+galaxy_conda_copy_dependencies: no
 
 # Dependency caching options
 galaxy_use_cached_depedency_manager: no

--- a/roles/galaxy/templates/galaxy-config.yml.j2
+++ b/roles/galaxy/templates/galaxy-config.yml.j2
@@ -249,7 +249,7 @@ galaxy:
   # Set to True to instruct Galaxy to install Conda from the web
   # automatically if it cannot find a local copy and conda_exec is not
   # configured.
-  #conda_auto_init: true
+  conda_auto_init: {{ galaxy_conda_auto_init }}
 
   # You must set this to True if conda_prefix and job_working_directory
   # are not on the same volume, or some conda dependencies will fail to
@@ -257,7 +257,7 @@ galaxy:
   # creating hardlinks or symlinks. This will prevent problems with some
   # specific packages (perl, R), at the cost of extra disk space usage
   # and extra time spent copying packages.
-  #conda_copy_dependencies: false
+  conda_copy_dependencies: {{ galaxy_conda_copy_dependencies }}
 
   # Certain dependency resolvers (namely Conda) take a considerable
   # amount of time to build an isolated job environment in the


### PR DESCRIPTION
PR which enables setting of 'conda_auto_init' and 'conda_copy_dependencies' in `galaxy.yml` from within the `galaxy` role.