### PR TITLE
'galaxy' role: use instance-specific names in supervisor and nginx config files

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -86,7 +86,10 @@ Variables
 
 Key variables:
 
- - ``galaxy_name``: name for the Galaxy instance
+ - ``galaxy_name``: name for the Galaxy instance (NB this is also used
+   as the name for the instance-specific Supervisor and Nginx
+   configuration files, and for naming the Supervisor processes and
+   process groups)
  - ``galaxy_version``: version of Galaxy to install
  - ``galaxy_install_dir``: top-level directory to use; by default Galaxy
    will be installed under ``${galaxy_install_dir}/${galaxy_name}``

--- a/roles/galaxy/tasks/nginxproxy.yml
+++ b/roles/galaxy/tasks/nginxproxy.yml
@@ -1,6 +1,18 @@
 # Configure Nginx proxying
 # See https://wiki.galaxyproject.org/Admin/Config/nginxProxy
 ---
+# Remove old 'galaxy.conf' file
+- name: "Check for legacy Nginx proxy file 'galaxy.conf'"
+  stat:
+    path: '{{ nginx_conf_dir }}/conf.d/galaxy.conf'
+  register: 'legacy_conf_file'
+
+- name: "Remove legacy Nginx proxy file 'galaxy.conf'"
+  file:
+    path='{{ nginx_conf_dir }}/conf.d/galaxy.conf'
+    state='absent'
+  when: legacy_conf_file.stat.exists == true
+
 # Create conf file for Galaxy and put into Nginx conf.d/
 - name: "Configure Nginx proxy"
   template:

--- a/roles/galaxy/tasks/nginxproxy.yml
+++ b/roles/galaxy/tasks/nginxproxy.yml
@@ -4,7 +4,7 @@
 # Create conf file for Galaxy and put into Nginx conf.d/
 - name: "Configure Nginx proxy"
   template:
-    dest: "{{ nginx_conf_dir }}/conf.d/galaxy.conf"
+    dest: "{{ nginx_conf_dir }}/conf.d/{{ galaxy_name }}.conf"
     src: nginx-galaxy.conf.j2
   notify:
   - Restart Nginx

--- a/roles/galaxy/tasks/supervisor.yml
+++ b/roles/galaxy/tasks/supervisor.yml
@@ -1,14 +1,14 @@
 # Set up Supervisor config for Galaxy
 # See https://wiki.galaxyproject.org/Admin/Config/Performance/Scaling#Starting_and_Stopping
 ---
-- name: Set up Galaxy supervisord conf file
+- name: "Set up Galaxy supervisord conf file"
   template:
-    dest='/usr/local/etc/supervisord.d/galaxy.ini'
+    dest='/usr/local/etc/supervisord.d/{{ galaxy_name }}.ini'
     src=supervisord-galaxy.ini.j2
   notify:
     - Restart Supervisord
 
-- name: Force restart of supervisord
+- name: "Force restart of supervisord"
   service:
     name='supervisord'
     state='restarted'

--- a/roles/galaxy/tasks/supervisor.yml
+++ b/roles/galaxy/tasks/supervisor.yml
@@ -1,12 +1,25 @@
 # Set up Supervisor config for Galaxy
 # See https://wiki.galaxyproject.org/Admin/Config/Performance/Scaling#Starting_and_Stopping
 ---
+# Remove old 'galaxy.ini' file
+- name: "Check for legacy 'galaxy.ini' supervisord conf file"
+  stat:
+    path: '/usr/local/etc/supervisord.d/galaxy.ini'
+  register: 'legacy_conf_file'
+
+- name: "Remove legacy 'galaxy.ini' supervisord conf file"
+  file:
+    path='/usr/local/etc/supervisord.d/galaxy.ini'
+    state='absent'
+  when: legacy_conf_file.stat.exists == true
+
+# Create supervisor configuration file
 - name: "Set up Galaxy supervisord conf file"
   template:
     dest='/usr/local/etc/supervisord.d/{{ galaxy_name }}.ini'
-    src=supervisord-galaxy.ini.j2
+    src='supervisord-galaxy.ini.j2'
   notify:
-    - Restart Supervisord
+    - "Restart Supervisord"
 
 - name: "Force restart of supervisord"
   service:

--- a/roles/galaxy/templates/supervisord-galaxy.ini.j2
+++ b/roles/galaxy/templates/supervisord-galaxy.ini.j2
@@ -1,7 +1,7 @@
 # Supervisord configuration for Galaxy (using uWSGI + Mules job handling)
 # See https://docs.galaxyproject.org/en/master/admin/scaling.html#supervisord
 
-[program:galaxy_uwsgi]
+[program:{{ galaxy_name }}_uwsgi]
 command         = {{ galaxy_root }}/.venv/bin/uwsgi --yaml {{ galaxy_root }}/config/galaxy.yml --logto {{ galaxy_log_dir }}/galaxy_uwsgi.log
 directory       = {{ galaxy_root }}
 umask           = 022
@@ -14,7 +14,7 @@ stopsignal      = INT
 environment     = VIRTUAL_ENV="{{ galaxy_root }}/.venv",PATH="{{ galaxy_root }}/.venv/bin:%(ENV_PATH)s"
 
 {% if enable_reports %}
-[program:galaxy_reports]
+[program:{{ galaxy_name }}_reports]
 command         = {{ galaxy_root }}/.venv/bin/uwsgi --yaml {{ galaxy_root }}/config/reports.yml --logto {{ galaxy_log_dir }}/reports_webapp.log
 directory       = {{ galaxy_root }}
 umask           = 022
@@ -28,4 +28,4 @@ environment     = VIRTUAL_ENV="{{ galaxy_root }}/.venv",PATH="{{ galaxy_root }}/
 {% endif %}
 
 [group:{{ galaxy_name }}]
-programs = galaxy_uwsgi{% if enable_reports %},galaxy_reports{% endif %}
+programs = {{ galaxy_name }}_uwsgi{% if enable_reports %},{{ galaxy_name }}_reports{% endif %}

--- a/roles/galaxy/templates/supervisord-galaxy.ini.j2
+++ b/roles/galaxy/templates/supervisord-galaxy.ini.j2
@@ -27,5 +27,5 @@ stopsignal      = INT
 environment     = VIRTUAL_ENV="{{ galaxy_root }}/.venv",PATH="{{ galaxy_root }}/.venv/bin:%(ENV_PATH)s"
 {% endif %}
 
-[group:galaxy]
+[group:{{ galaxy_name }}]
 programs = galaxy_uwsgi{% if enable_reports %},galaxy_reports{% endif %}

--- a/roles/restart-galaxy/tasks/main.yml
+++ b/roles/restart-galaxy/tasks/main.yml
@@ -21,4 +21,4 @@
 
 - name: Restart Galaxy
   command:
-    "{{ galaxy_utils_dir }}/bin/restart_galaxy.sh galaxy"
+    "{{ galaxy_utils_dir }}/bin/restart_galaxy.sh {{ galaxy_name }}"


### PR DESCRIPTION
PR which updates the `galaxy` role to use instance-specific names for the `supervisor` and `nginx` configuration files, to potentially enable multiple Galaxy instances to co-exist on the same virtual machine or server.

The PR also updates the names of the `supervisor` processes and groups defined in the config, to make them instance-specific.