### PR TITLE
'galaxy' role: parameterise port numbers

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -97,6 +97,8 @@ Key variables:
 Webserver:
 
  - ``galaxy_server_name``: URL for the Galaxy web service
+ - ``galaxy_http_port``: port to communicate with Galaxy via
+   (default: 8080)
 
 Admin user:
 
@@ -112,6 +114,15 @@ Database passwords:
  - ``galaxy_ftp_password``: password used by FTP server for
    authenticating users against Postgresql database
    (default: same name as the FTP database user)
+
+UWSGI settings:
+
+ - ``galaxy_uwsgi_processes``: number of UWSGI processes to
+   use (default: 8)
+ - ``galaxy_uwsgi_socket``: socket for Galaxy to use to
+   communicate with UWSGI (default: 4001)
+ - ``galaxy_reports_uwsgi_socket``: socket for Galaxy reporting
+   interface to use to communicate with UWSGI (default: 9001)
 
 Job runner configuration:
 

--- a/roles/galaxy/defaults/main.yml
+++ b/roles/galaxy/defaults/main.yml
@@ -21,6 +21,7 @@ galaxy_db_password: "{{ galaxy_db_user }}"
 # Web server
 galaxy_server_name: "galaxy.example.org"
 galaxy_id_secret:
+galaxy_http_port: 8080
 
 # Proxy prefix
 # Leave blank for no prefix, otherwise must start
@@ -174,6 +175,8 @@ nginx_share_dir: "/usr/share/nginx"
 
 # uWSGI configuration
 galaxy_uwsgi_processes: 8
+galaxy_uwsgi_socket: 4001
+galaxy_reports_uwsgi_socket: 9001
 
 # Galaxy handler processes
 galaxy_handler_processes: 1

--- a/roles/galaxy/templates/galaxy-config.yml.j2
+++ b/roles/galaxy/templates/galaxy-config.yml.j2
@@ -5,7 +5,7 @@ uwsgi:
   # The address and port on which to listen.  By default, only listen to
   # localhost (galaxy will not be accessible over the network).  Use
   # ':8080' to listen on all available network interfaces.
-  http: 127.0.0.1:8080
+  http: 127.0.0.1:{{ galaxy_http_port }}
 
   # By default uWSGI allocates a very small buffer (4096 bytes) for the
   # headers of each request. If you start receiving "invalid request
@@ -19,7 +19,7 @@ uwsgi:
   processes: {{ galaxy_uwsgi_processes }}
 
   # Socket to communicate with uwsgi using
-  socket: 127.0.0.1:4001
+  socket: 127.0.0.1:{{ galaxy_uwsgi_socket }}
 
   # Number of threads for each web server process.
   threads: 4

--- a/roles/galaxy/templates/galaxy-reports.yml.j2
+++ b/roles/galaxy/templates/galaxy-reports.yml.j2
@@ -6,7 +6,7 @@ uwsgi:
   #http: 127.0.0.1:9001
 
   # Socket to communicate with uwsgi using
-  socket: 127.0.0.1:9001
+  socket: 127.0.0.1:{{ galaxy_reports_uwsgi_socket }}
 
   # By default uWSGI allocates a very small buffer (4096 bytes) for the
   # headers of each request. If you start receiving "invalid request

--- a/roles/galaxy/templates/nginx-galaxy.conf.j2
+++ b/roles/galaxy/templates/nginx-galaxy.conf.j2
@@ -55,7 +55,7 @@ server {
 {% if enable_reports %}
     # Galaxy reporting interface
     location ^~ {{ galaxy_proxy_prefix }}/reports/ {
-        uwsgi_pass 127.0.0.1:9001;
+        uwsgi_pass 127.0.0.1:{{ galaxy_reports_uwsgi_socket }};
         uwsgi_param UWSGI_SCHEME $scheme;
         include uwsgi_params;
         auth_basic "Restricted";
@@ -64,7 +64,7 @@ server {
 {% endif %}
     # Galaxy server
     location {{ galaxy_proxy_prefix }}/ {
-        uwsgi_pass 127.0.0.1:4001;
+        uwsgi_pass 127.0.0.1:{{ galaxy_uwsgi_socket }};
         uwsgi_param UWSGI_SCHEME $scheme;
         include uwsgi_params;
     }


### PR DESCRIPTION
PR which updates the `galaxy` role to parameterise the values of the ports used for HTTP and UWSGI communications for the main Galaxy server and the reporting interface. This should enable multiple Galaxy services to co-exist on the same server.