### PR TITLE
Make cron jobs for clean-up and audit reporting Galaxy-instance-specific

### DIFF
--- a/roles/galaxy-audit-report/tasks/main.yml
+++ b/roles/galaxy-audit-report/tasks/main.yml
@@ -1,10 +1,10 @@
 ---
 # Cron job to email audit report
 
-- name: Set up cron jobs to email audit reports
+- name: "Set up cron job to email audit report"
   cron:
     user="{{ galaxy_user }}"
-    name="Email audit report"
+    name="{{ galaxy_name }} email audit report"
     job="{{ galaxy_utils_dir }}/bin/audit_report.py -c {{ galaxy_root }}/config/galaxy.yml -i '7 days' {{ email_audit_report_to }} 2>&1 >> {{ galaxy_dir }}/logs/audit_report.log"
     hour=22 minute=35 weekday=0
     state=present

--- a/roles/galaxy-auto-delete-datasets/tasks/main.yml
+++ b/roles/galaxy-auto-delete-datasets/tasks/main.yml
@@ -1,10 +1,10 @@
 ---
 # Automatic deletion of datasets older than certain age
 
-- name: Set up cron jobs to delete old datasets
+- name: "Set up cron job to auto-delete expired datasets"
   cron:
     user="{{ galaxy_user }}"
-    name="Delete old datasets"
+    name="{{ galaxy_name }} auto-delete expired datasets"
     job="{{ galaxy_utils_dir }}/bin/delete_old_datasets.sh {{ galaxy_db }} {{ galaxy_db_user }} {{ galaxy_db_password }} '{{ delete_datasets_after }}' >> {{ galaxy_dir }}/logs/delete_datasets.log"
     hour=23 minute=00
     state=present

--- a/roles/galaxy/tasks/cleanup.yml
+++ b/roles/galaxy/tasks/cleanup.yml
@@ -1,45 +1,62 @@
 # See https://galaxyproject.org/admin/config/performance/purge-histories-and-datasets/
 ---
+- name: "Remove legacy clean up cron jobs for Galaxy"
+  cron:
+    user: '{{ galaxy_user }}'
+    name: '{{ item }}'
+    state: absent
+  with_items:
+    - 'Delete userless histories'
+    - 'Purge histories'
+    - 'Purge libraries'
+    - 'Purge folders'
+    - 'Delete datasets'
+    - 'Purge datasets'
+    - 'Clean up files from job working directory'
+    - 'Clean up empty directories from job working directory'
+
 - name: "Set up daily cron jobs to purge deleted data in Galaxy"
   cron:
-    user='{{ galaxy_user }}'
-    name='{{ item.name }}'
-    job=". {{ galaxy_root }}/.venv/bin/activate && sh {{ galaxy_root }}/scripts/cleanup_datasets/{{ item.script }}"
-    hour={{ item.hour }} minute={{ item.minute }}
-    state=present
+    user: '{{ galaxy_user }}'
+    name: '{{ item.name }}'
+    job: ". {{ galaxy_root }}/.venv/bin/activate && sh {{ galaxy_root }}/scripts/cleanup_datasets/{{ item.script }}"
+    hour: '{{ item.hour }}'
+    minute: '{{ item.minute }}'
+    state: present
   with_items:
-  - { name: 'Delete userless histories',
-      script: 'delete_userless_histories.sh',
-      hour: 03, minute: 00 }
-  - { name: 'Purge histories',
-      script: 'purge_histories.sh',
-      hour: 03, minute: 10 }
-  - { name: 'Purge libraries',
-      script: 'purge_libraries.sh',
-      hour: 03, minute: 20 }
-  - { name: 'Purge folders',
-      script: 'purge_folders.sh',
-      hour: 03, minute: 30 }
-  - { name: 'Delete datasets',
-      script: 'delete_datasets.sh',
-      hour: 03, minute: 40 }
-  - { name: 'Purge datasets',
-      script: 'purge_datasets.sh',
-      hour: 04, minute: 00 }
+    - { name: '{{ galaxy_name }} delete userless histories',
+        script: 'delete_userless_histories.sh',
+        hour: 03, minute: 00 }
+    - { name: '{{ galaxy_name }} purge histories',
+        script: 'purge_histories.sh',
+        hour: 03, minute: 10 }
+    - { name: '{{ galaxy_name }} purge libraries',
+        script: 'purge_libraries.sh',
+        hour: 03, minute: 20 }
+    - { name: '{{ galaxy_name }} purge folders',
+        script: 'purge_folders.sh',
+        hour: 03, minute: 30 }
+    - { name: '{{ galaxy_name }} delete datasets',
+        script: 'delete_datasets.sh',
+        hour: 03, minute: 40 }
+    - { name: '{{ galaxy_name }} purge datasets',
+        script: 'purge_datasets.sh',
+        hour: 04, minute: 00 }
 
 - name: "Clean up Galaxy job working directory"
   cron:
-    user='{{ galaxy_user }}'
-    name='{{ item.name }}'
-    job='{{ item.job }}'
-    hour={{ item.hour }} minute={{ item.minute }}
-    state=present
+    user: '{{ galaxy_user }}'
+    name: '{{ item.name }}'
+    job: '{{ item.job }}'
+    hour: '{{ item.hour }}'
+    minute: '{{ item.minute }}'
+    state: present
   with_items:
-  - { name: "Clean up files from job working directory",
-      job: "find {{ galaxy_job_working_dir }} -mindepth 2 -type f -mtime +28 -exec rm -rf {} \\;",
-      hour: 00,
-      minute: 10 }
-  - { name: "Clean up empty directories from job working directory",
-      job: "find {{ galaxy_job_working_dir }} -mindepth 2 -type d -mtime +28 -empty -exec rmdir {} \\;",
-      hour: 00,
-      minute: 15 }
+    - { name: "{{ galaxy_name }} clean up files from job working directory",
+        job: "find {{ galaxy_job_working_dir }} -mindepth 2 -type f -mtime +28 -exec rm -rf {} \\;",
+        hour: 00,
+        minute: 10 }
+    - { name: "{{ galaxy_name }} clean up empty directories from job working directory",
+        job: "find {{ galaxy_job_working_dir }} -mindepth 2 -type d -mtime +28 -empty -exec rmdir {} \\;",
+        hour: 00,
+        minute: 15 }

--- a/roles/galaxy/tasks/cleanup.yml
+++ b/roles/galaxy/tasks/cleanup.yml
@@ -1,20 +1,5 @@
 # See https://galaxyproject.org/admin/config/performance/purge-histories-and-datasets/
 ---
-- name: "Remove legacy clean up cron jobs for Galaxy"
-  cron:
-    user: '{{ galaxy_user }}'
-    name: '{{ item }}'
-    state: absent
-  with_items:
-    - 'Delete userless histories'
-    - 'Purge histories'
-    - 'Purge libraries'
-    - 'Purge folders'
-    - 'Delete datasets'
-    - 'Purge datasets'
-    - 'Clean up files from job working directory'
-    - 'Clean up empty directories from job working directory'
-
 - name: "Set up daily cron jobs to purge deleted data in Galaxy"
   cron:
     user: '{{ galaxy_user }}'

--- a/roles/galaxy/tasks/main.yml
+++ b/roles/galaxy/tasks/main.yml
@@ -1,5 +1,7 @@
 ---
 
+- include: remove_legacy_cron_jobs.yml
+
 - include: dependencies.yml
 
 - include: database.yml

--- a/roles/galaxy/tasks/remove_legacy_cron_jobs.yml
+++ b/roles/galaxy/tasks/remove_legacy_cron_jobs.yml
@@ -1,0 +1,17 @@
+# Remove 'legacy' cron jobs set up pre-19.09
+# These will be replaced by instance-specific versions
+---
+- name: "Remove legacy cron jobs for Galaxy"
+  cron:
+    user: '{{ galaxy_user }}'
+    name: '{{ item }}'
+    state: absent
+  with_items:
+    - 'Delete userless histories'
+    - 'Purge histories'
+    - 'Purge libraries'
+    - 'Purge folders'
+    - 'Delete datasets'
+    - 'Purge datasets'
+    - 'Clean up files from job working directory'
+    - 'Clean up empty directories from job working directory'

--- a/roles/galaxy/tasks/remove_legacy_cron_jobs.yml
+++ b/roles/galaxy/tasks/remove_legacy_cron_jobs.yml
@@ -15,3 +15,4 @@
     - 'Purge datasets'
     - 'Clean up files from job working directory'
     - 'Clean up empty directories from job working directory'
+    - 'Delete old datasets'

--- a/roles/galaxy/tasks/remove_legacy_cron_jobs.yml
+++ b/roles/galaxy/tasks/remove_legacy_cron_jobs.yml
@@ -16,3 +16,4 @@
     - 'Clean up files from job working directory'
     - 'Clean up empty directories from job working directory'
     - 'Delete old datasets'
+    - 'Email audit report'


### PR DESCRIPTION
PR which updates the `cron` jobs for Galaxy clean up and audit reporting in the `galaxy`, `galaxy-auto-delete-datasets` and `galaxy-audit-report` roles so that they are specific to the Galaxy instance being installed or updated.

Also removes "legacy" versions of these `cron` jobs (via a new YAML file in the `galaxy` role).