### PR TITLE
'galaxy' role: enable custom configuration of dependency resolvers

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -151,6 +151,13 @@ Job runner configuration:
    the ``tools`` section of ``job_conf.xml`` (default: no
    tool destinations are defined)
 
+Dependency resolvers:
+
+- ``galaxy_dependency_resolvers``: a list where each item
+  should be a dictionary defining a dependency resolver to
+  to be added to ``dependency_resolvers.xml`` (default: no
+  resolvers are defined)
+
 Custom colour scheme:
 
  - ``galaxy_custom_scss``: a list where each item should be

--- a/roles/galaxy/defaults/main.yml
+++ b/roles/galaxy/defaults/main.yml
@@ -152,6 +152,21 @@ galaxy_job_destinations:
 # - destination (target destination)
 galaxy_tool_destinations:
 
+# Dependency resolvers
+# Define entries as a dictionary with:
+# - type        (required; one of 'tool_shed_packages', 'galaxy_packages',
+#                'conda')
+# - versionless (optional; sets 'versionless' attribute to 'true' or 'false')
+# - base_path   (optional; sets 'base_path' attribute)
+galaxy_dependency_resolvers:
+  - type: 'tool_shed_packages'
+  - type: 'galaxy_packages'
+  - type: 'galaxy_packages'
+    versionless: 'true'
+  - type: 'conda'
+  - type: 'conda'
+    versionless: 'true'
+
 # Limits for number of concurrent running jobs
 galaxy_registered_user_concurrent_jobs: 2
 galaxy_unregistered_user_concurrent_jobs: 0

--- a/roles/galaxy/tasks/galaxy.yml
+++ b/roles/galaxy/tasks/galaxy.yml
@@ -94,6 +94,12 @@
     dest='{{ galaxy_root }}/config/job_conf.xml'
     src=job_conf.xml.j2
 
+# Create/update dependency_resolvers.xml file
+- name: "Update Galaxy dependency_resolvers.xml"
+  template:
+    dest='{{ galaxy_root }}/config/dependency_resolvers.xml'
+    src='dependency_resolvers.xml.j2'
+
 # Create/update tool_data_table_conf.xml file
 - name: Update tool_data_table_conf XML file
   template:

--- a/roles/galaxy/templates/dependency_resolvers.xml.j2
+++ b/roles/galaxy/templates/dependency_resolvers.xml.j2
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<dependency_resolvers>
+{% if galaxy_dependency_resolvers %}
+{% for resolver in galaxy_dependency_resolvers %}
+  <{{ resolver.type }}{% if resolver.versionless is defined %} versionless="{{ resolver.versionless }}"{% endif %}{% if resolver.base_path is defined %} base_path="{{ resolver.base_path }}"{% endif %} />
+{% endfor %}
+{% else %}
+  <!-- Defaults -->
+  <tool_shed_packages />
+  <galaxy_packages />
+  <galaxy_packages versionless="true" />
+  <conda />
+  <conda versionless="true" />
+{% endif %}
+</dependency_resolvers>


### PR DESCRIPTION
PR which updates the `galaxy` role to enable custom dependency resolver configuration to be specified via the `galaxy_dependency_resolvers` variable, which is used to build the `dependency_resolvers.xml` file.