### PR TITLE
cetus: update whitelisted version of FastQC for Vagrant testing

### DIFF
--- a/inventories/cetus/vagrant.yml
+++ b/inventories/cetus/vagrant.yml
@@ -40,4 +40,4 @@ cetus:
         section: "NGS: QC and manipulation"
     # Whitelisted tools for rendering HTML correctly
     galaxy_sanitize_whitelist_tools:
-      - "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.70"
+      - "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.72+galaxy1"


### PR DESCRIPTION
PR that updates the version of the `FastQC` tool which is added to the sanitization whitelist file when testing using Vagrant.