### PR TITLE
Update installation of Galaxy-specific Python

### DIFF
--- a/cetus.yml
+++ b/cetus.yml
@@ -17,7 +17,7 @@
   - galaxy_job_working_dir: "/mnt/bmh01-rvmi/bcf-galaxy/cetus/teaching/job_working_directory"
   - galaxy_data_manager_data_path: "/mnt/bmh01-rvmi/bcf-galaxy/cetus/teaching/tool-data"
   # Galaxy-specific Python installation
-  - galaxy_python_dir: "/mnt/rvmi/cetus/galaxy/python"
+  - galaxy_python_version: "2.7.10"
   # Account management
   - allow_user_creation: no
   - allow_user_deletion: no
@@ -72,11 +72,6 @@
   - role: jsedrop
     jsedrop_drop_dir: "{{ galaxy_jse_drop_dir }}"
     when: enable_local_jse_drop
-  # Install Galaxy-specific Python 2.7
-  - role: python27
-    install_dir: "{{ galaxy_python_dir }}"
-    become: yes
-    become_user: "{{ galaxy_user }}"
   # Install and configure Galaxy
   - galaxy
   # Install utilities

--- a/mintaka.yml
+++ b/mintaka.yml
@@ -17,7 +17,7 @@
   - galaxy_job_working_dir: "{{ galaxy_dir }}/job_working_directory"
   - galaxy_data_manager_data_path: "{{ galaxy_dir }}/tool-data"
   # Galaxy-specific Python installation
-  - galaxy_python_dir: "/mnt/rvmi/mintaka/galaxy/python"
+  - galaxy_python_version: "2.7.10"
   # Account management
   - allow_user_creation: yes
   - allow_user_deletion: yes
@@ -214,11 +214,6 @@
   # Install local JSEDrop service
   - role: jsedrop
     jsedrop_drop_dir: "{{ galaxy_jse_drop_dir }}"
-  # Install Galaxy-specific Python 2.7
-  - role: python27
-    install_dir: "{{ galaxy_python_dir }}"
-    become: yes
-    become_user: "{{ galaxy_user }}"
   # Install and configure Galaxy
   - galaxy
   # Install utilities

--- a/palfinder.yml
+++ b/palfinder.yml
@@ -6,11 +6,12 @@
   - galaxy_name: "palfinder"
   - galaxy_version: "release_19.05"
   - galaxy_install_dir: "/mnt/rvmi/palfinder/galaxy"
-  - galaxy_python_dir: "/mnt/rvmi/palfinder/galaxy/python"
   - enable_require_login: yes
   - enable_quotas: yes
   - enable_ftp_upload: yes
   - enable_reports: yes
+  # Galaxy-specific Python installation
+  - galaxy_python_version: "2.7.10"
   # GDPR compliance
   - enable_beta_gdpr: yes
   # Welcome page etc
@@ -105,11 +106,6 @@
   - role: jsedrop
     jsedrop_drop_dir: "{{ galaxy_jse_drop_dir }}"
     when: enable_local_jse_drop
-  # Install Galaxy-specific Python 2.7
-  - role: python27
-    install_dir: "{{ galaxy_python_dir }}"
-    become: yes
-    become_user: "{{ galaxy_user }}"
   # Install and configure Galaxy
   - galaxy
   # Install utilities

--- a/roles/galaxy/defaults/main.yml
+++ b/roles/galaxy/defaults/main.yml
@@ -10,9 +10,6 @@ galaxy_group: "{{ galaxy_user }}"
 # Galaxy admin user
 galaxy_admin_user: "admin@galaxy.org"
 
-# Python for Galaxy
-galaxy_python_dir: '/usr/local'
-
 # Postgresql database
 galaxy_db: "galaxy_{{ galaxy_name }}"
 galaxy_db_user: "{{ galaxy_user }}"
@@ -83,6 +80,10 @@ galaxy_new_file_path: "{{ galaxy_database_dir }}/tmp"
 galaxy_tool_data_path: "{{ galaxy_root }}/tool-data"
 galaxy_shed_tool_data_path: "{{ galaxy_tool_data_path }}"
 galaxy_data_manager_data_path: "{{ galaxy_tool_data_path }}"
+
+# Python for Galaxy
+galaxy_python_version: "2.7.10"
+galaxy_python_dir: '{{ galaxy_dir }}/python/{{ galaxy_python_version }}'
 
 # Toolshed check
 enable_tool_shed_check: no

--- a/roles/galaxy/tasks/galaxy.yml
+++ b/roles/galaxy/tasks/galaxy.yml
@@ -59,11 +59,16 @@
   with_items: "{{ galaxy_custom_scss }}"
   when: galaxy_custom_scss|default(None) != None
 
-- name: Make virtualenv in Galaxy root
+- name: "Remove existing virtualenv from Galaxy root"
+  file:
+    path: '{{ galaxy_root }}/.venv'
+    state: absent
+
+- name: "Make virtualenv in Galaxy root"
   command:
-    chdir={{ galaxy_root }}
-    {{ galaxy_python_dir }}/bin/virtualenv .venv -p {{ galaxy_python_dir }}/bin/python
-    creates='{{ galaxy_root }}/.venv'
+    chdir: '{{ galaxy_root }}'
+    cmd: "{{ galaxy_python_dir }}/bin/virtualenv .venv -p {{ galaxy_python_dir }}/bin/python"
+    creates: '{{ galaxy_root }}/.venv'
 
 - name: Create Galaxy configuration file
   template:

--- a/roles/galaxy/tasks/main.yml
+++ b/roles/galaxy/tasks/main.yml
@@ -4,6 +4,10 @@
 
 - include: dependencies.yml
 
+- include: python.yml
+  become: yes
+  become_user: "{{ galaxy_user }}"
+
 - include: database.yml
   become: yes
   become_user: postgres

--- a/roles/galaxy/tasks/python.yml
+++ b/roles/galaxy/tasks/python.yml
@@ -1,0 +1,9 @@
+# Install Python for Galaxy
+---
+- name: "Install Galaxy-specific Python 2.7"
+  include_role:
+    name: python27
+  vars:
+    python_version: "{{ galaxy_python_version }}"
+    install_dir: "{{ galaxy_python_dir }}"
+  when: galaxy_python_version.startswith("2.7")


### PR DESCRIPTION
PR which updates how the Galaxy-specific Python is installed, specifically:

- Galaxy-specific Python is now installed as part of the `galaxy` role (no longer in the top-level `cetus`, `mintaka` or `palfinder` playbooks);
- The default installation location has changed, and is now in a `python/VERSION/` subdirectory of the top-level Galaxy installation directory (previously it was in parallel with the top-level Galaxy installation, with no `VERSION` level);
- The default Python version is still 2.7.10, but this can be changed by setting the `galaxy_python_version` variable;
- The Galaxy virtual environment `.venv` is always recreated from scratch (previously it was only created if it didn't already exist; this change is to ensure that version changes stick).

NB currently only Python 2.7 is supported.