### PR TITLE
'galaxy' role: fix stopping Galaxy services before doing updates

### DIFF
--- a/roles/galaxy/tasks/galaxy.yml
+++ b/roles/galaxy/tasks/galaxy.yml
@@ -1,9 +1,5 @@
 # Install and configure Galaxy
 ---
-- name: "Halt running Galaxy"
-  command:
-    "{{ galaxy_utils_dir }}/bin/galaxyctl.sh stop {{ galaxy_name }}"
-
 - name: Create top-level Galaxy directories
   file:
     path='{{ item }}'

--- a/roles/galaxy/tasks/halt_galaxy.yml
+++ b/roles/galaxy/tasks/halt_galaxy.yml
@@ -1,0 +1,5 @@
+# Stop Galaxy running
+---
+- name: "Halt running Galaxy"
+  command:
+    "{{ galaxy_utils_dir }}/bin/galaxyctl.sh stop {{ galaxy_name }}"

--- a/roles/galaxy/tasks/main.yml
+++ b/roles/galaxy/tasks/main.yml
@@ -4,6 +4,8 @@
 
 - include: dependencies.yml
 
+- include: halt_galaxy.yml
+
 - include: python.yml
   become: yes
   become_user: "{{ galaxy_user }}"


### PR DESCRIPTION
PR which fixes the halting of running Galaxy services in the `galaxy` role prior to performing tasks to update the source code, configuration etc.

Essentially the `galaxyctl.sh` which is used to stop Galaxy needs to run by root (as it calls `supervisorctl`), but it was previously being run by the Galaxy user. The fix moves the task to a different part of the role so that it is invoked with the appropriate privileges.