### PR TITLE
Add support for Galaxy to run using Python 3

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,6 +24,8 @@ The following roles are defined:
 
  - ``python27``: builds and installs Python 2.7 from source
 
+ - ``python3``: builds and installs Python 3 from source
+
  - ``nginx``: installs Nginx
 
  - ``postgresql``: installs and configures PostgreSQL
@@ -41,6 +43,7 @@ The following roles are defined:
  - ``galaxy``: install and configure a Galaxy instance:
 
    * Install Galaxy dependencies
+   * Install Galaxy-specific Python
    * Set up database
    * Clone and configure specified Galaxy version
    * Uploads ``welcome``, ``terms`` and ``citation`` pages,
@@ -202,8 +205,11 @@ Reference data (``.loc`` file contents):
 Variables for handling special cases:
 
  - ``galaxy_python_dir``: location to install Galaxy-specific
-   version of Python (e.g. if default installation of Python
-   isn't accessible across cluster nodes)
+   version of Python (this is required for example if the
+   default installation of Python isn't accessible across compute
+   cluster nodes) (default: install Galaxy-specific Python in
+   a ``python/VERSION`` directory parallel to the Galaxy code
+   cloned from GitHub)
 
 Versions of installed components:
 

--- a/roles/galaxy/tasks/galaxy.yml
+++ b/roles/galaxy/tasks/galaxy.yml
@@ -148,6 +148,14 @@
   with_items: "{{ galaxy_sanitize_whitelist_tools }}"
   when: galaxy_sanitize_whitelist_tools|default(None) != None
 
+# Remove compiled .mako templates for Python 3 updates
+# See https://docs.galaxyproject.org/en/release_20.01/admin/python.html
+- name: "Remove compiled .mako templates"
+  file:
+    path: '{{ galaxy_root }}/database/compiled_templates/'
+    state: absent
+  when: galaxy_python_version.startswith("3.")
+
 # Setup/update Galaxy
 - name: "Run common_startup.sh to initialise/update Galaxy installation"
   command:

--- a/roles/galaxy/tasks/galaxy.yml
+++ b/roles/galaxy/tasks/galaxy.yml
@@ -55,6 +55,10 @@
   with_items: "{{ galaxy_custom_scss }}"
   when: galaxy_custom_scss|default(None) != None
 
+- name: "Determine Python executable for setting up virtualenev"
+  set_fact:
+    python_exe: "{{ galaxy_python_dir }}/bin/python{{ galaxy_python_version.split('.')[:2] | join('.') }}"
+
 - name: "Remove existing virtualenv from Galaxy root"
   file:
     path: '{{ galaxy_root }}/.venv'
@@ -63,7 +67,7 @@
 - name: "Make virtualenv in Galaxy root"
   command:
     chdir: '{{ galaxy_root }}'
-    cmd: "{{ galaxy_python_dir }}/bin/virtualenv .venv -p {{ galaxy_python_dir }}/bin/python"
+    cmd: "{{ galaxy_python_dir }}/bin/virtualenv .venv -p {{ python_exe }}"
     creates: '{{ galaxy_root }}/.venv'
 
 - name: Create Galaxy configuration file

--- a/roles/galaxy/tasks/python.yml
+++ b/roles/galaxy/tasks/python.yml
@@ -7,3 +7,11 @@
     python_version: "{{ galaxy_python_version }}"
     install_dir: "{{ galaxy_python_dir }}"
   when: galaxy_python_version.startswith("2.7")
+
+- name: "Install Galaxy-specific Python 3"
+  include_role:
+    name: python3
+  vars:
+    python_version: "{{ galaxy_python_version }}"
+    install_dir: "{{ galaxy_python_dir }}"
+  when: galaxy_python_version.startswith("3.")

--- a/roles/python3/defaults/main.yml
+++ b/roles/python3/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+# Python defaults
+python_version: '3.6.11'
+install_dir: '/usr/local/python/{{ python_version }}'

--- a/roles/python3/tasks/main.yml
+++ b/roles/python3/tasks/main.yml
@@ -1,0 +1,109 @@
+---
+# Build and install Python 3 on the remote host
+# Also installs pip and virtualenv packages
+
+- name: "Set major.minor Python version"
+  set_fact:
+    python_major_minor_version: "{{ galaxy_python_version.split('.')[:2] | join('.') }}"
+
+- name: "Report major.minor Python version"
+  debug:
+    msg: "Python version {{ galaxy_python_version }} ({{ python_major_minor_version }})"
+
+- name: "Check if Python3 is already installed"
+  stat:
+    path: "{{ install_dir }}/bin/python{{ python_major_minor_version }}"
+  register: python
+
+- name: "Build and install Python 3"
+  block:
+    - name: "Install Python3 build dependencies"
+      yum:
+        name:
+          - 'autoconf'
+          - 'make'
+          - 'automake'
+          - 'gcc'
+          - 'readline'
+          - 'sqlite'
+          - 'zlib'
+          - 'bzip2-devel'
+          - 'bzip2'
+          - 'ncurses-devel'
+          - 'ncurses'
+          - 'openssl-devel'
+          - 'openssl'
+          - 'readline-devel'
+          - 'sqlite-devel'
+          - 'zlib-devel'
+          - 'tkinter'
+        state: 'present'
+
+    - name: "Create installation directory"
+      file:
+        path: '{{ install_dir }}'
+        state: 'directory'
+
+    - name: "Determine the user home directory"
+      shell:
+        "echo $HOME"
+      register: 'user_home'
+      changed_when: False
+
+    - name: "Determine the build directory"
+      set_fact:
+        build_dir: "{{ user_home.stdout }}/build"
+
+    - name: "Report Python version"
+      debug:
+        msg: "Python version {{ python_version }}"
+
+    - name: "Report installation directory path"
+      debug:
+        msg: "Install directory {{ install_dir }}"
+
+    - name: "Report build directory path"
+      debug:
+        msg: "Build directory {{ build_dir }}"
+
+    - name: "Create build directory"
+      file:
+        path: '{{ build_dir }}'
+        state: 'directory'
+
+    - name: "Download Python 3"
+      get_url:
+        url: 'https://www.python.org/ftp/python/{{ python_version }}/Python-{{ python_version }}.tgz'
+        dest: '{{ build_dir }}'
+
+    - name: "Unpack Python 3"
+      unarchive:
+        src: '{{ build_dir }}/Python-{{ python_version }}.tgz'
+        dest: '{{ build_dir }}'
+        copy: no
+        creates: '{{ build_dir }}/Python-{{ python_version }}'
+
+    - name: "Install Python 3"
+      command:
+        cmd: '{{item}}'
+        chdir: '{{ build_dir }}/Python-{{ python_version }}'
+        creates: '{{ install_dir }}/bin/python{{ python_major_minor_version }}'
+      with_items:
+        - './configure --prefix={{ install_dir }}'
+        - 'make install'
+  when: not python.stat.exists
+
+- name: "Install Pip"
+  command:
+    cmd: '{{ install_dir }}/bin/python{{ python_major_minor_version }} -m ensurepip'
+    creates: '{{ install_dir }}/bin/pip'
+
+- name: "Upgrade Pip"
+  command:
+    cmd: '{{ install_dir }}/bin/pip3 install --upgrade pip'
+
+- name: "Install Virtualenv"
+  pip:
+    name: 'virtualenv'
+    state: 'present'
+    executable: '{{ install_dir }}/bin/pip3'


### PR DESCRIPTION
PR which adds support for Galaxy installations running under Python 3:

* Adds a new role `python3` which builds and installs a local version of Python 3 (default is 3.6.11, but this can be changed by setting the `python_version` variable when invoking the role);
* Updates the `galaxy` role to use this role when installing Python with `galaxy_python_version` 3.*

The default is still to use Python 2.7.10 for Galaxy installations.

