### PR TITLE
Build and export Galaxy virtualenvs for use on compute cluster

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 *.vagrant
 motd
 message
+assets/*.tgz

--- a/README.rst
+++ b/README.rst
@@ -83,6 +83,10 @@ The following roles are defined:
  - ``galaxy-audit-report``: sets up weekly emailing of audit
    reports
 
+ - ``export-galaxy-for-cluster``: installs Galaxy into a Python
+   virtualenv which is then exported for use when submitting
+   jobs to the local cluster system
+
 Variables
 ---------
 
@@ -240,6 +244,12 @@ to edit (use the ``view`` command just to see the contents).
 Use the ``--ask-vault`` option to prompt for the encryption password
 when running the playbook.
 
+In addition there is a playbook ``export_galaxy_for_cluster.yml``
+which is used to install Galaxy into virtualenvs which can then be
+installed on the local cluster system for running Galaxy jobs in the
+production environment (see "Building Galaxy virtualenvs for the
+cluster system" below).
+
 Inventory files
 ---------------
 
@@ -271,8 +281,8 @@ use the ``-i`` option e.g.::
 
 will target the production Palfinder service instance.
    
-Running the playbook
---------------------
+Running the playbooks
+---------------------
 
 You must pass in the hosts that the playbooks will be run on via
 the ``ansible-playbook`` command line, for example::
@@ -294,6 +304,12 @@ The following servers are defined in the ``Vagrantfile``:
  - ``mintaka``: Scientific Linux 7 VM (uses the address
    http://192.168.60.6)
 
+An additional VM is used to build Galaxy virtual environment for
+deployment on the compute cluster:
+
+ - ``csf``: CentOS 7.8 (http://192.168.60.8) - see below ("Building
+   Galaxy virtualenvs for the cluster system")
+
 To create and log into a Vagrant VM instance for testing Palfinder do
 e.g.::
 
@@ -307,6 +323,37 @@ these are not as fully-featured as the production versions), e.g.::
 
 Point your browser at the appropriate address to access the local
 test instance once it has been deployed.
+
+Building Galaxy virtualenvs for the cluster system
+--------------------------------------------------
+
+For some production instances where jobs are submitted to the cluster
+system, there can be issues when the Galaxy VM OS is substantially
+different to that of the cluster.
+
+In these cases a workaround is to build a Galaxy virtualenv that is
+installed on the cluster and which is used by the jobs submitted to it;
+the ``export_galaxy_for_cluster.yml`` playbook can be used to build
+Galaxy virtualenvs on a CentOS 7 Vagrant box for this purpose.
+
+The inventory files in ``inventories/csf/`` target specific production
+Galaxy instances; to generate a Galaxy virtualenv for the ``centaurus``
+instance do e.g.:
+
+::
+
+   ansible-playbook export_galaxy_for_cluster.yml -b -i inventories/csf/centaurus.yml
+
+This will generate a .tgz archive in the ``assets`` directory, which will
+contain the Galaxy virtualenv to be unpacked and used on the target VM.
+
+Note:
+
+ - To install a CentOS 7 VirtualBox image for the ``csf`` instance use:
+
+   ::
+
+       vagrant box add --name centos/7 https://app.vagrantup.com/centos/boxes/7/versions/2004.01/providers/virtualbox.box
 
 Notes on the deployment
 -----------------------

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -51,4 +51,14 @@ Vagrant.configure(VAGRANT_API_VERSION) do |config|
     chmod ugo+rwX /mnt/rvmi/
   SHELL
   end
+  # CSF compute cluster VM
+  config.vm.define "csf" do |csf|
+    csf.vm.box = "centos/7"
+    csf.vm.hostname = "csf"
+    csf.vm.network :private_network, ip: "192.168.60.8"
+    csf.vm.provision "shell", inline: <<-SHELL
+    mkdir -p /mnt/rvmi
+    chmod ugo+rwX /mnt/rvmi/
+  SHELL
+  end
 end

--- a/export_galaxy_for_cluster.yml
+++ b/export_galaxy_for_cluster.yml
@@ -1,0 +1,5 @@
+---
+- hosts: csf
+
+  roles:
+  - export-galaxy-for-cluster

--- a/inventories/csf/centaurus.yml
+++ b/inventories/csf/centaurus.yml
@@ -1,0 +1,16 @@
+csf:
+  hosts:
+    192.168.60.8
+  vars:
+    # Ansible-specific settings
+    ansible_ssh_user: vagrant
+    ansible_ssh_private_key_file: ~/.vagrant.d/insecure_private_key
+    # Centaurus Galaxy settings
+    galaxy_name: "centaurus"
+    galaxy_user: "centaurus-galaxy"
+    galaxy_uid: 22223
+    galaxy_group: "galaxy"
+    galaxy_gid: 400
+    # Galaxy and Python versions to target
+    galaxy_version: "19.09"
+    python_version: "3.6.11"

--- a/roles/export-galaxy-for-cluster/defaults/main.yml
+++ b/roles/export-galaxy-for-cluster/defaults/main.yml
@@ -1,0 +1,26 @@
+---
+# Galaxy name and version
+galaxy_name: "csf"
+galaxy_version: "19.09"
+
+# Galaxy user
+galaxy_user: "galaxy"
+galaxy_uid: 400
+galaxy_group: "{{ galaxy_user }}"
+galaxy_gid: 400
+
+# Galaxy source code
+galaxy_repo: "https://github.com/galaxyproject/galaxy.git"
+galaxy_version_tag: "release_{{ galaxy_version }}"
+
+# Galaxy installation directory
+galaxy_root_dir: "/mnt/rvmi/{{ galaxy_name }}/galaxy"
+galaxy_install_dir: "{{ galaxy_root_dir }}/shared/csf/galaxy/{{ galaxy_version }}"
+
+# Python for Galaxy
+python_version: "3.6.11"
+python_install_dir: '{{ galaxy_root_dir }}/shared/csf/python/{{ python_version }}'
+
+# Exported tgz
+archive_name: "{{ galaxy_name }}-virtualenv-galaxy-{{ galaxy_version }}-python-{{ python_version }}"
+assets_dir: "assets/"

--- a/roles/export-galaxy-for-cluster/tasks/dependencies.yml
+++ b/roles/export-galaxy-for-cluster/tasks/dependencies.yml
@@ -1,0 +1,23 @@
+---
+- name: "Install build dependencies"
+  yum:
+    name:
+      - 'git'
+      - 'autoconf'
+      - 'make'
+      - 'automake'
+      - 'gcc'
+      - 'readline'
+      - 'sqlite'
+      - 'zlib'
+      - 'bzip2-devel'
+      - 'bzip2'
+      - 'ncurses-devel'
+      - 'ncurses'
+      - 'openssl-devel'
+      - 'openssl'
+      - 'readline-devel'
+      - 'sqlite-devel'
+      - 'zlib-devel'
+      - 'tkinter'
+    state: 'present'

--- a/roles/export-galaxy-for-cluster/tasks/export.yml
+++ b/roles/export-galaxy-for-cluster/tasks/export.yml
@@ -1,0 +1,11 @@
+---
+
+- name: "Build tgz archive for export"
+  shell:
+    cmd: tar czf {{ galaxy_root_dir }}/shared/{{ archive_name }}.tgz -C {{ galaxy_root_dir }}/shared csf/galaxy/{{ galaxy_version }} csf/python/{{ python_version }}
+
+- name: "Export tgz from remote"
+  fetch:
+    src: "{{ galaxy_root_dir }}/shared/{{ archive_name }}.tgz"
+    dest: "{{ assets_dir }}"
+    flat: yes

--- a/roles/export-galaxy-for-cluster/tasks/galaxy.yml
+++ b/roles/export-galaxy-for-cluster/tasks/galaxy.yml
@@ -29,18 +29,26 @@
   set_fact:
     python_exe: "{{ python_install_dir }}/bin/python{{ python_version.split('.')[:2] | join('.') }}"
 
+- name: "Galaxy: set name for virtualenv"
+  set_fact:
+    galaxy_venv: "venv_py{{ python_version.split('.')[:2] | join('.') }}"
+
+- name: "Galaxy: show virtualenv name"
+  debug:
+    msg: "Galaxy virtualenv: {{ galaxy_venv }}"
+
 - name: "Galaxy: remove previous virtualenv"
   file:
-    path: '{{ galaxy_install_dir }}/venv'
+    path: '{{ galaxy_install_dir }}/{{ galaxy_venv }}'
     state: absent
 
 - name: "Galaxy: make new virtualenv"
   command:
     chdir: '{{ galaxy_install_dir }}'
-    cmd: "{{ python_install_dir }}/bin/virtualenv venv -p {{ python_exe }}"
+    cmd: "{{ python_install_dir }}/bin/virtualenv {{ galaxy_venv }} -p {{ python_exe }}"
     creates: '{{ galaxy_install_dir }}/venv'
 
 - name: "Galaxy: run common_startup.sh --skip-venv to install into virtualenv"
   shell:
-    cmd: source {{ galaxy_install_dir }}/venv/bin/activate && ./scripts/common_startup.sh --skip-venv
+    cmd: source {{ galaxy_install_dir }}/{{ galaxy_venv }}/bin/activate && ./scripts/common_startup.sh --skip-venv
     chdir: '{{ galaxy_install_dir }}/galaxy-src'

--- a/roles/export-galaxy-for-cluster/tasks/galaxy.yml
+++ b/roles/export-galaxy-for-cluster/tasks/galaxy.yml
@@ -7,12 +7,23 @@
   with_items:
   - '{{ galaxy_install_dir }}'
 
+# Clone the base repository first and then checkout the
+# required tag in a separate command
+
+# We would prefer to let Ansible clone with the correct
+# tag using the 'git' module, but this doesn't seem to
+# work in practice (cloned repository contains modified
+# files which break the subsequent checkout)
 - name: "Galaxy: clone source code from GitHub"
   git:
     repo: '{{ galaxy_repo }}'
-    version: '{{ galaxy_version_tag }}'
     dest: '{{ galaxy_install_dir }}/galaxy-src'
     force: yes
+
+- name: "Galaxy: checkout required version"
+  shell:
+    chdir: '{{ galaxy_install_dir }}/galaxy-src'
+    cmd: git fetch origin && git checkout {{ galaxy_version_tag }} && git pull --ff-only origin {{ galaxy_version_tag }}
 
 - name: "Galaxy: determine Python executable for setting up virtualenev"
   set_fact:

--- a/roles/export-galaxy-for-cluster/tasks/galaxy.yml
+++ b/roles/export-galaxy-for-cluster/tasks/galaxy.yml
@@ -1,0 +1,35 @@
+# Install Galaxy
+---
+- name: "Galaxy: create top-level directories"
+  file:
+    path: '{{ item }}'
+    state: 'directory'
+  with_items:
+  - '{{ galaxy_install_dir }}'
+
+- name: "Galaxy: clone source code from GitHub"
+  git:
+    repo: '{{ galaxy_repo }}'
+    version: '{{ galaxy_version_tag }}'
+    dest: '{{ galaxy_install_dir }}/galaxy-src'
+    force: yes
+
+- name: "Galaxy: determine Python executable for setting up virtualenev"
+  set_fact:
+    python_exe: "{{ python_install_dir }}/bin/python{{ python_version.split('.')[:2] | join('.') }}"
+
+- name: "Galaxy: remove previous virtualenv"
+  file:
+    path: '{{ galaxy_install_dir }}/venv'
+    state: absent
+
+- name: "Galaxy: make new virtualenv"
+  command:
+    chdir: '{{ galaxy_install_dir }}'
+    cmd: "{{ python_install_dir }}/bin/virtualenv venv -p {{ python_exe }}"
+    creates: '{{ galaxy_install_dir }}/venv'
+
+- name: "Galaxy: run common_startup.sh --skip-venv to install into virtualenv"
+  shell:
+    cmd: source {{ galaxy_install_dir }}/venv/bin/activate && ./scripts/common_startup.sh --skip-venv
+    chdir: '{{ galaxy_install_dir }}/galaxy-src'

--- a/roles/export-galaxy-for-cluster/tasks/galaxy_user.yml
+++ b/roles/export-galaxy-for-cluster/tasks/galaxy_user.yml
@@ -1,0 +1,15 @@
+---
+# Create the 'galaxy' user and group with specified UID/GIDs
+- name: "Create Galaxy group"
+  group:
+    name: '{{ galaxy_group }}'
+    gid: '{{ galaxy_gid }}'
+    state: present
+
+- name: "Create Galaxy user"
+  user:
+    name: '{{ galaxy_user }}'
+    group: '{{ galaxy_group }}'
+    home: '/home/{{ galaxy_user }}'
+    uid: '{{ galaxy_uid }}'
+    state: present

--- a/roles/export-galaxy-for-cluster/tasks/main.yml
+++ b/roles/export-galaxy-for-cluster/tasks/main.yml
@@ -1,0 +1,19 @@
+# Install Galaxy
+---
+
+- include: dependencies.yml
+
+- include: galaxy_user.yml
+
+- include: python.yml
+  become: yes
+  become_user: "{{ galaxy_user }}"
+
+- include: galaxy.yml
+  become: yes
+  become_user: "{{ galaxy_user }}"
+
+- include: export.yml
+  become: yes
+  become_user: "{{ galaxy_user }}"
+  

--- a/roles/export-galaxy-for-cluster/tasks/python.yml
+++ b/roles/export-galaxy-for-cluster/tasks/python.yml
@@ -1,0 +1,70 @@
+---
+# Build and install Python 3 for Galaxy
+
+- name: "Python: create installation directory"
+  file:
+    path: '{{ python_install_dir }}'
+    state: 'directory'
+
+- name: "Python: determine the user home directory"
+  shell:
+    "echo $HOME"
+  register: 'user_home'
+  changed_when: False
+
+- name: "Python: determine the build directory"
+  set_fact:
+    build_dir: "{{ user_home.stdout }}/build"
+
+- name: "Python: report version"
+  debug:
+    msg: "Python version {{ python_version }}"
+
+- name: "Python: report installation directory path"
+  debug:
+    msg: "Install directory {{ python_install_dir }}"
+
+- name: "Python: report build directory path"
+  debug:
+    msg: "Build directory {{ build_dir }}"
+
+- name: "Python: create build directory"
+  file:
+    path: '{{ build_dir }}'
+    state: 'directory'
+
+- name: "Python: download source code archive"
+  get_url:
+    url: 'https://www.python.org/ftp/python/{{ python_version }}/Python-{{ python_version }}.tgz'
+    dest: '{{ build_dir }}'
+
+- name: "Python: unpack source code archive"
+  unarchive:
+    src: '{{ build_dir }}/Python-{{ python_version }}.tgz'
+    dest: '{{ build_dir }}'
+    copy: no
+    creates: '{{ build_dir }}/Python-{{ python_version }}'
+
+- name: "Python: build and install"
+  command:
+    cmd: '{{item}}'
+    chdir: '{{ build_dir }}/Python-{{ python_version }}'
+    creates: '{{ python_install_dir }}/bin/python3'
+  with_items:
+    - './configure --prefix={{ python_install_dir }}'
+    - 'make install'
+
+- name: "Python: install Pip"
+  command:
+    cmd: '{{ python_install_dir }}/bin/python3 -m ensurepip'
+    creates: '{{ python_install_dir }}/bin/pip3'
+
+- name: "Python: upgrade Pip"
+  command:
+    cmd: '{{ python_install_dir }}/bin/pip3 install --upgrade pip'
+
+- name: "Python: install Virtualenv"
+  pip:
+    name: 'virtualenv'
+    state: 'present'
+    executable: '{{ python_install_dir }}/bin/pip3'


### PR DESCRIPTION
PR which implements a new role `export-galaxy-for-cluster`, which enables a Galaxy `virtualenv` to be build for specific Galaxy and Python versions on a local VM, and then exported for use on a compute cluster (where the OS might be different from the VM hosting the Galaxy instance).

The role is executed with a new playbook `export_galaxy_for_cluster.yml`. A new Vagrant VM definition has been added (`csf`) which is based on CentOS 7 (and stands in for the compute cluster used at UoM); the inventory files under `inventories/csf/` target specific production Galaxy instances (currently only the 'centaurus' instance).

Generated `.tgz` files are exported from the VM and placed in the `assets` subdirectory.