### PR TITLE
'python3' role: update default install location to '/usr/local'

### DIFF
--- a/roles/python3/defaults/main.yml
+++ b/roles/python3/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
 # Python defaults
 python_version: '3.6.11'
-install_dir: '/usr/local/python/{{ python_version }}'
+install_dir: '/usr/local'


### PR DESCRIPTION
PR which updates the `python3` role to switch the default install location to be directly under `/usr/local` (previously it was `/usr/local/python/PYTHON_VERSION`).

The new default means the role works more as expected out-of-the-box.