### PR TITLE
'galaxy' role: fix broken privilege escalation when installing Galaxy-specific Python

### DIFF
--- a/roles/galaxy/tasks/main.yml
+++ b/roles/galaxy/tasks/main.yml
@@ -7,8 +7,6 @@
 - include: halt_galaxy.yml
 
 - include: python.yml
-  become: yes
-  become_user: "{{ galaxy_user }}"
 
 - include: database.yml
   become: yes

--- a/roles/galaxy/tasks/python.yml
+++ b/roles/galaxy/tasks/python.yml
@@ -6,6 +6,8 @@
   vars:
     python_version: "{{ galaxy_python_version }}"
     install_dir: "{{ galaxy_python_dir }}"
+    ansible_become: yes
+    ansible_become_user: "{{ galaxy_user }}"
   when: galaxy_python_version.startswith("2.7")
 
 - name: "Install Galaxy-specific Python 3"
@@ -14,4 +16,6 @@
   vars:
     python_version: "{{ galaxy_python_version }}"
     install_dir: "{{ galaxy_python_dir }}"
+    ansible_become: yes
+    ansible_become_user: "{{ galaxy_user }}"
   when: galaxy_python_version.startswith("3.")


### PR DESCRIPTION
PR to fix the broken privilege escalation when invoking the roles to install Galaxy-specific Python; the installation should be performed as the Galaxy user, but without the fix the escalation wasn't performed and the installation was performed as the root user instead.