### PR TITLE
Update 'galaxy' and 'galaxy-utils' roles to default to Python 3

### DIFF
--- a/roles/galaxy-utils/defaults/main.yml
+++ b/roles/galaxy-utils/defaults/main.yml
@@ -2,4 +2,4 @@
 # Default location to install the utilities
 python_install_dir: '/usr/local'
 galaxy_utils_dir: '/usr/local'
-nebulizer_version: '0.4.3'
+nebulizer_version: '0.6.0'

--- a/roles/galaxy-utils/files/audit_report.py
+++ b/roles/galaxy-utils/files/audit_report.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Generate and email report on Galaxy usage
 import sys

--- a/roles/galaxy-utils/tasks/main.yml
+++ b/roles/galaxy-utils/tasks/main.yml
@@ -6,7 +6,7 @@
 - name: Install latest setuptools
   pip:
     name="setuptools"
-    executable='{{ python_install_dir }}/bin/pip'
+    executable='{{ python_install_dir }}/bin/pip3'
     state=latest
 
 - name: Install dependencies for utilities
@@ -14,13 +14,13 @@
     name:
       - "psycopg2==2.6.2"
       - "pyyaml"
-    executable: '{{ python_install_dir }}/bin/pip'
+    executable: '{{ python_install_dir }}/bin/pip3'
     state: present
 
 - name: Install Nebulizer
   pip:
     name='https://github.com/pjbriggs/nebulizer/archive/v{{ nebulizer_version }}.tar.gz'
-    executable='{{ python_install_dir }}/bin/pip'
+    executable='{{ python_install_dir }}/bin/pip3'
     extra_args='--prefix {{ galaxy_utils_dir }} --no-binary :all:'
     state=present
 

--- a/roles/galaxy/defaults/main.yml
+++ b/roles/galaxy/defaults/main.yml
@@ -82,7 +82,7 @@ galaxy_shed_tool_data_path: "{{ galaxy_tool_data_path }}"
 galaxy_data_manager_data_path: "{{ galaxy_tool_data_path }}"
 
 # Python for Galaxy
-galaxy_python_version: "2.7.10"
+galaxy_python_version: "3.6.11"
 galaxy_python_dir: '{{ galaxy_dir }}/python/{{ galaxy_python_version }}'
 
 # Toolshed check


### PR DESCRIPTION
PR which updates the `galaxy` and `galaxy-utils` roles to default to using Python 3.

Specifically:

* `galaxy` role: default Python version updated to 3.6.11;
* `galaxy-utils` role: update the `audit_report.py` utility to use Python 3 by default, and update default `nebulizer` version to 0.6.0 (which supports Python 2/3) and install using `pip3`.