### PR TITLE
'supervisor' role: refactor and update to Supervisor 4.2.2 with Python 3

### DIFF
--- a/roles/supervisord/defaults/main.yml
+++ b/roles/supervisord/defaults/main.yml
@@ -1,8 +1,8 @@
 ---
 # Supervisord defaults
-supervisor_version: '3.2.2'
+supervisor_version: '4.2.2'
 supervisor_install_dir: '/usr/local'
 
 # Location of Python installation to use
-supervisor_python_dir: '/usr/local'
-supervisor_python_exe: '{{ supervisor_python_dir }}/bin/python'
+supervisor_python_dir: '{{ supervisor_install_dir }}'
+supervisor_python_exe: '{{ supervisor_python_dir }}/bin/python3'

--- a/roles/supervisord/defaults/main.yml
+++ b/roles/supervisord/defaults/main.yml
@@ -5,3 +5,4 @@ supervisor_install_dir: '/usr/local'
 
 # Location of Python installation to use
 supervisor_python_dir: '/usr/local'
+supervisor_python_exe: '{{ supervisor_python_dir }}/bin/python'

--- a/roles/supervisord/handlers/main.yml
+++ b/roles/supervisord/handlers/main.yml
@@ -1,4 +1,4 @@
 ---
 # Handlers for supervisord role
 - name: Restart Supervisord
-  service: name=supervisord state=reloaded
+  service: name=supervisord state=restarted

--- a/roles/supervisord/tasks/main.yml
+++ b/roles/supervisord/tasks/main.yml
@@ -51,7 +51,7 @@
   - name: "Install Supervisor"
     command:
       chdir: '{{ build_dir }}/supervisor-{{ supervisor_version }}'
-      cmd: "{{ supervisor_python_dir }}/bin/python setup.py install --prefix={{ supervisor_install_dir }}"
+      cmd: "{{ supervisor_python_exe }} setup.py install --prefix={{ supervisor_install_dir }}"
       creates: '{{ supervisor_install_dir }}/bin/supervisord'
 
   - name: "Create Supervisord conf file"

--- a/roles/supervisord/tasks/main.yml
+++ b/roles/supervisord/tasks/main.yml
@@ -14,8 +14,34 @@
     path: "{{ supervisor_install_dir }}/bin/supervisord"
   register: supervisord
 
+- name: "Determine if Supervisor should be installed"
+  set_fact:
+    install_supervisor: not supervisord.stat.exists
+
+- name: "Determine if Supervisor should be reinstalled"
+  block:
+  - name: "Get installed Supervisor version"
+    shell:
+      "{{ supervisor_install_dir }}/bin/supervisord --version"
+    register: supervisord_installed_version
+
+  - name: "Check if new version is different"
+    set_fact:
+      install_supervisor: "{{ supervisord_installed_version.stdout is version(supervisor_version,'!=') }}"
+
+  - name: "Report Supervisord versions"
+    debug:
+      msg: "Supervisord: current version {{ supervisord_installed_version.stdout }} -> {{ supervisor_version }}"
+  when: supervisord.stat.exists
+
 - name: "Build and install local version of Supervisor"
   block:
+  - name: "Disable Supervisord service"
+    service:
+      name: 'supervisord'
+      enabled: false
+      state: stopped
+
   - name: "Determine the user home directory"
     shell:
       "echo $HOME"
@@ -52,7 +78,6 @@
     command:
       chdir: '{{ build_dir }}/supervisor-{{ supervisor_version }}'
       cmd: "{{ supervisor_python_exe }} setup.py install --prefix={{ supervisor_install_dir }}"
-      creates: '{{ supervisor_install_dir }}/bin/supervisord'
 
   - name: "Create Supervisord conf file"
     shell: >-
@@ -87,21 +112,15 @@
         option: 'files'
         value: '/usr/local/etc/supervisord.d/*.ini'
     notify: "Restart Supervisord"
-  when: not supervisord.stat.exists
 
-# Set up as a service
-- name: "Check for Supervisord init.d script"
-  stat:
-    path: '/etc/init.d/supervisord'
-  register: init_d
-
-- name: "Create init.d script for Supervisord"
-  copy:
-    dest: '/etc/init.d/supervisord'
-    src: 'supervisord.init.sh'
-    mode: 'ugo+x'
-  when: not init_d.stat.exists
-  notify: "Restart Supervisord"
+  - name: "Create init.d script for Supervisord"
+    copy:
+      dest: '/etc/init.d/supervisord'
+      src: 'supervisord.init.sh'
+      mode: 'ugo+x'
+    when: not init_d.stat.exists
+    notify: "Restart Supervisord"
+  when: install_supervisor == True
 
 - name: "Start Supervisord service"
   service:

--- a/roles/supervisord/tasks/main.yml
+++ b/roles/supervisord/tasks/main.yml
@@ -36,8 +36,8 @@
 
   - name: "Download Supervisor source"
     get_url:
-      url: 'https://pypi.python.org/packages/source/s/supervisor/supervisor-{{supervisor_version}}.tar.gz'
-      dest: '{{ build_dir }}'
+      url: 'https://github.com/Supervisor/supervisor/archive/{{ supervisor_version }}.tar.gz'
+      dest: '{{ build_dir }}/supervisor-{{ supervisor_version }}.tar.gz'
 
   - name: "Unpack Supervisor source"
     unarchive:

--- a/roles/supervisord/tasks/main.yml
+++ b/roles/supervisord/tasks/main.yml
@@ -16,7 +16,7 @@
 
 - name: "Determine if Supervisor should be installed"
   set_fact:
-    install_supervisor: not supervisord.stat.exists
+    install_supervisor: "{{ not supervisord.stat.exists }}"
 
 - name: "Determine if Supervisor should be reinstalled"
   block:
@@ -41,6 +41,7 @@
       name: 'supervisord'
       enabled: false
       state: stopped
+    when: supervisord.stat.exists
 
   - name: "Determine the user home directory"
     shell:
@@ -112,6 +113,11 @@
         option: 'files'
         value: '/usr/local/etc/supervisord.d/*.ini'
     notify: "Restart Supervisord"
+
+  - name: "Check existence of Supervisord init.d script"
+    stat:
+      path: "/etc/init.d/supervisord"
+    register: init_d
 
   - name: "Create init.d script for Supervisord"
     copy:

--- a/roles/supervisord/tasks/main.yml
+++ b/roles/supervisord/tasks/main.yml
@@ -1,9 +1,6 @@
 ---
-# Install, configure and start Supervisord on remote server
-#
-# NOTE: we need a newer version of Supervisord than is available
-# via yum on Scientific Linux 6, hence installing it this way
-# rather than pulling in from yum
+# Install, configure and start Supervisord
+
 - name: "Uninstall yum version of Supervisor"
   yum:
     name: 'supervisor'


### PR DESCRIPTION
PR which substantially updates the `supervisor` role and updates the default Supervisor version to 4.2.2 installed under Python 3.

This PR addresses issue #122.