### PR TITLE
'galaxy' role: handle Mercurial required for tool install

### DIFF
--- a/roles/galaxy-install-tools/tasks/main.yml
+++ b/roles/galaxy-install-tools/tasks/main.yml
@@ -6,24 +6,6 @@
   set_fact:
     galaxy_url: "{{ 'https' if enable_https else 'http' }}://{{ galaxy_server_name }}{{ galaxy_proxy_prefix }}/"
 
-- name: "Check if Galaxy Mercurial is executable"
-  stat:
-    path: '{{ galaxy_root }}/.venv/bin/hg'
-  register: galaxy_hg
-  become: yes
-  become_user: "{{ galaxy_user }}"
-
-- name: "Add execute permission to Galaxy Mercurial"
-  file:
-    path='{{ galaxy_root }}/.venv/bin/hg'
-    state='file'
-    mode='u+rwx,go+rx'
-  become: yes
-  become_user: "{{ galaxy_user }}"
-  when:
-    - galaxy_tools|default(None) != None
-    - galaxy_hg.stat.executable == False
-
 - name: "Install tools from Galaxy toolshed"
   block:
     - name: "Activate Galaxy master API key for tool installation"

--- a/roles/galaxy/tasks/dependencies.yml
+++ b/roles/galaxy/tasks/dependencies.yml
@@ -11,6 +11,7 @@
       - 'samtools'
       - 'python2-pyyaml'
       - 'net-tools'
+      - 'hg'
     state: latest
   register: installed_dependencies
 

--- a/roles/galaxy/tasks/galaxy.yml
+++ b/roles/galaxy/tasks/galaxy.yml
@@ -75,6 +75,27 @@
     dest='{{ galaxy_root }}/config/galaxy.yml'
     src=galaxy-config.yml.j2
 
+# Deal with possible bug when Galaxy installs Mercurial in
+# the virtualenv without execute permission
+- name: "Check for Galaxy Mercurial"
+  stat:
+    path: '{{ galaxy_root }}/.venv/bin/hg'
+  register: galaxy_hg
+  become: yes
+  become_user: "{{ galaxy_user }}"
+
+- name: "Add execute permission to Galaxy Mercurial"
+  file:
+    path='{{ galaxy_root }}/.venv/bin/hg'
+    state='file'
+    mode='u+rwx,go+rx'
+  become: yes
+  become_user: "{{ galaxy_user }}"
+  when:
+    - galaxy_tools|default(None) != None
+    - galaxy_hg.stat.exists == True
+    - galaxy_hg.stat.executable == False
+
 # Import or create tool_conf files
 - name: "Import base tool_conf.xml"
   copy:


### PR DESCRIPTION
PR which updates the `galaxy` role to handle the requirement for Mercurial which is needed for tool installation in Galaxy.

Specifically:

* Adds `hg` as a system dependency to install, and
* Relocates the check/update of the Galaxy-installed Mercurial from the `galaxy-install-tool` role.

The latter update (which ensures that any `hg` installed in the Galaxy virtualenv has execute permission) is a legacy bugfix which may no longer be required but has been retained for the time being.