### PR TITLE
'jsedrop' role: switch to using Python3 from /usr/local

### DIFF
--- a/roles/jsedrop/defaults/main.yml
+++ b/roles/jsedrop/defaults/main.yml
@@ -1,6 +1,5 @@
 ---
 # jsedrop.py installation defaults
-jsedrop_install_dir: "/usr/bin"
+jsedrop_install_dir: "/usr/local/bin"
 jsedrop_drop_dir: "/usr/share/drop-off"
-jsedrop_python3: "/usr/bin/python3"
-jsedrop_python3_yum_package: "python3"
+jsedrop_python3: "/usr/local/bin/python3"

--- a/roles/jsedrop/tasks/main.yml
+++ b/roles/jsedrop/tasks/main.yml
@@ -1,12 +1,6 @@
 ---
 # Install jsedrop.py as a service on the remote host
 
-- name: "Install jsedrop.py dependencies"
-  yum:
-    name:
-      - "{{ jsedrop_python3_yum_package }}"
-    state: present
-
 - name: "Install and start local JSE-Drop service (SL6)"
   block:
     - name: "Install jsedrop.py"


### PR DESCRIPTION
PR which switches the default Python for running the JSEDrop service in the `jsedrop` role to be in `/usr/local`, and drops the installation of a system Python3 package from `yum`.