### PR TITLE
Update instance playbooks to Galaxy 19.09 & Python 3

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -219,9 +219,9 @@ Variables for handling special cases:
 
 Versions of installed components:
 
- - ``python_version`` (2.7.10)
+ - ``python_version`` (3.6.11)
  - ``proftpd_version`` (1.3.5a)
- - ``supervisor_version`` (3.2.2)
+ - ``supervisor_version`` (4.2.2)
  - ``git`` (2.20.0)
 
 Playbooks

--- a/cetus.yml
+++ b/cetus.yml
@@ -9,7 +9,7 @@
   - galaxy_gid: 400
   # Galaxy configuration
   - galaxy_name: "cetus"
-  - galaxy_version: "release_19.05"
+  - galaxy_version: "release_19.09"
   - galaxy_install_dir: "/mnt/rvmi/cetus/galaxy"
   - galaxy_dir: "/mnt/rvmi/cetus/galaxy/teaching"
   # Database and reference data
@@ -17,7 +17,7 @@
   - galaxy_job_working_dir: "/mnt/bmh01-rvmi/bcf-galaxy/cetus/teaching/job_working_directory"
   - galaxy_data_manager_data_path: "/mnt/bmh01-rvmi/bcf-galaxy/cetus/teaching/tool-data"
   # Galaxy-specific Python installation
-  - galaxy_python_version: "2.7.10"
+  - galaxy_python_version: "3.6.11"
   # Account management
   - allow_user_creation: no
   - allow_user_deletion: no
@@ -36,6 +36,9 @@
       # Colour for navbar/masthead
       - var: "brand-dark"
         value: "#660099"
+      # Colour for text
+      - var: "text-color"
+        value: "#2c3143"
   # uWSGI and handler configuration
   # Set number of uWSGI & handler processes in inventory file
   # Running jobs
@@ -61,7 +64,7 @@
   - nfslock
   - git
   - selinux
-  - python27
+  - python3
   - nginx
   - postgresql
   - proftpd

--- a/inventories/palfinder/vagrant.yml
+++ b/inventories/palfinder/vagrant.yml
@@ -13,8 +13,6 @@ palfinder:
     # Job configuration
     enable_jse_drop: yes
     enable_local_jse_drop: yes
-    jsedrop_python3_yum_package: "python34"
-    jsedrop_python3: "/usr/bin/python3.4"
     galaxy_jse_drop_dir: "{{ galaxy_install_dir }}/palfinder/jse-drop-csf3"
     galaxy_default_runner: "jse_drop_default"
     galaxy_job_destinations:

--- a/mintaka.yml
+++ b/mintaka.yml
@@ -9,7 +9,7 @@
   - galaxy_gid: 400
   # Galaxy configuration
   - galaxy_name: "mintaka"
-  - galaxy_version: "release_19.05"
+  - galaxy_version: "release_19.09"
   - galaxy_install_dir: "/mnt/rvmi/mintaka/galaxy"
   - galaxy_dir: "{{ galaxy_install_dir }}/production"
   # Database and reference data
@@ -17,7 +17,7 @@
   - galaxy_job_working_dir: "{{ galaxy_dir }}/job_working_directory"
   - galaxy_data_manager_data_path: "{{ galaxy_dir }}/tool-data"
   # Galaxy-specific Python installation
-  - galaxy_python_version: "2.7.10"
+  - galaxy_python_version: "3.6.11"
   # Account management
   - allow_user_creation: yes
   - allow_user_deletion: yes
@@ -41,6 +41,9 @@
       # Colour for navbar/masthead
       - var: "brand-dark"
         value: "#660099"
+      # Colour for text
+      - var: "text-color"
+        value: "#2c3143"
   # Users
   - galaxy_admin_user: "admin@galaxy.org"
   - galaxy_users:
@@ -168,8 +171,6 @@
   # (Always uses a local JSE-Drop service)
   - enable_jse_drop: yes
   - enable_local_jse_drop: yes
-  - jsedrop_python3_yum_package: "python34"
-  - jsedrop_python3: "/usr/bin/python3.4"
   - galaxy_jse_drop_dir: "{{ galaxy_install_dir }}/jse-drop-local"
   - galaxy_default_runner: "jse_drop_serial"
   - galaxy_job_destinations:
@@ -203,7 +204,7 @@
   - nfslock
   - git
   - selinux
-  - python27
+  - python3
   - nginx
   - postgresql
   - proftpd

--- a/palfinder.yml
+++ b/palfinder.yml
@@ -4,14 +4,14 @@
   vars:
   # Galaxy configuration
   - galaxy_name: "palfinder"
-  - galaxy_version: "release_19.05"
+  - galaxy_version: "release_19.09"
   - galaxy_install_dir: "/mnt/rvmi/palfinder/galaxy"
   - enable_require_login: yes
   - enable_quotas: yes
   - enable_ftp_upload: yes
   - enable_reports: yes
   # Galaxy-specific Python installation
-  - galaxy_python_version: "2.7.10"
+  - galaxy_python_version: "3.6.11"
   # GDPR compliance
   - enable_beta_gdpr: yes
   # Welcome page etc
@@ -94,7 +94,7 @@
   - nfslock
   - git
   - selinux
-  - python27
+  - python3
   - nginx
   - postgresql
   - proftpd


### PR DESCRIPTION
PR which updates the ansible playbooks for the `palfinder`, `cetus` and `mintaka` instances to Galaxy 19.09 and Python 3.6.11.

Note that the `palfinder` playbook can no longer be tested on the Scientific Linux 6.8 Vagrant VM; this version of the OS was EOL in November 2020 and the required `sl` and `epel` no longer seem to be available.