### PR TITLE
Bump Galaxy version to 20.01 for building Galaxy virtualenv for 'centaurus'

### DIFF
--- a/inventories/csf/centaurus.yml
+++ b/inventories/csf/centaurus.yml
@@ -12,5 +12,5 @@ csf:
     galaxy_group: "galaxy"
     galaxy_gid: 400
     # Galaxy and Python versions to target
-    galaxy_version: "19.09"
+    galaxy_version: "20.01"
     python_version: "3.6.11"


### PR DESCRIPTION
PR which updates the inventory for building CentOS-compatible Galaxy virtualenvs for the 'centaurus' instances to build Galaxy 20.01.