### PR TITLE
'galaxy' role: update jse_drop_runner.py for compatibility with Galaxy 20.01

### DIFF
--- a/roles/galaxy/files/jse_drop_runner.py
+++ b/roles/galaxy/files/jse_drop_runner.py
@@ -369,7 +369,8 @@ class JSEDropJobRunner(AsynchronousJobRunner):
             # Exit code
             exit_code = job_state.read_exit_code()
             # Stdout
-            outputs_directory = job_wrapper.working_directory
+            outputs_directory = os.path.join(job_wrapper.working_directory,
+                                             "outputs")
             tool_stdout_path = os.path.join(outputs_directory,"tool_stdout")
             if os.path.exists(tool_stdout_path):
                 log.debug("finish_job %s: reading stdout from %s" %


### PR DESCRIPTION
PR which updates the JSE-Drop job runner (file `jse_drop_runner.py` in the `galaxy` role) to look for the `tool_stdout` and `tool_stderr` files in the `outputs` subdirectory of the job working directory; previously these were written to the top level of the working directory, and without this change jobs report `unable to acquire tool output`.