### PR TITLE
'galaxy' role: update default Galaxy version to 'release_20.01'

### DIFF
--- a/roles/galaxy/defaults/main.yml
+++ b/roles/galaxy/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # Name for Galaxy instance
 galaxy_name: "palfinder"
-galaxy_version: 'release_19.09'
+galaxy_version: 'release_20.01'
 
 # User running Galaxy service
 galaxy_user: "galaxy"


### PR DESCRIPTION
PR which bumps the default Galaxy version to `release_20.01` in the `galaxy` role.