### PR TITLE
Set job cleanup to 'never' for Vagrant Galaxy instances

### DIFF
--- a/inventories/cetus/vagrant.yml
+++ b/inventories/cetus/vagrant.yml
@@ -20,6 +20,8 @@ cetus:
     galaxy_job_destinations:
       - id: "jse_drop_serial"
         runner: "jse_drop"
+    # Job cleanup
+    galaxy_cleanup_job: "never"
     # Postfix/email configuration
     enable_smtp: no
     # Audit report

--- a/inventories/mintaka/vagrant.yml
+++ b/inventories/mintaka/vagrant.yml
@@ -9,7 +9,9 @@ mintaka:
     mintaka_secrets: vagrant.yml
     # Server configuration
     galaxy_server_name: 192.168.60.6
+    # Galaxy configuration
     enable_user_activation: no
+    galaxy_cleanup_job: "never"
     # Postfix/email configuration
     enable_smtp: no
     # SSL configuration

--- a/inventories/palfinder/vagrant.yml
+++ b/inventories/palfinder/vagrant.yml
@@ -18,6 +18,8 @@ palfinder:
     galaxy_job_destinations:
       - id: "jse_drop_default"
         runner: "jse_drop"
+    # Job cleanup
+    galaxy_cleanup_job: "never"
     # Postfix/email configuration
     enable_smtp: no
     # SSL configuration


### PR DESCRIPTION
PR which updates the inventories for all the instances (Palfinder, Cetus and Mintaka) so that the Vagrant instances used for testing explicitly set the job cleanup to `never`.