### PR TITLE
palfinder: add inventory file to build CSF-compatible Galaxy virtualenv

### DIFF
--- a/inventories/csf/palfinder.yml
+++ b/inventories/csf/palfinder.yml
@@ -1,0 +1,16 @@
+csf:
+  hosts:
+    192.168.60.8
+  vars:
+    # Ansible-specific settings
+    ansible_ssh_user: vagrant
+    ansible_ssh_private_key_file: ~/.vagrant.d/insecure_private_key
+    # Centaurus Galaxy settings
+    galaxy_name: "palfinder"
+    galaxy_user: "galaxy"
+    galaxy_uid: 400
+    galaxy_group: "galaxy"
+    galaxy_gid: 400
+    # Galaxy and Python versions to target
+    galaxy_version: "19.09"
+    python_version: "3.6.11"


### PR DESCRIPTION
PR which adds an new inventory file `inventories/csf/palfinder.yml` to build and export a CentOS 7 Galaxy virtualenv for the CSF compute cluster which is compatible with the Palfinder Galaxy instance.