### PR TITLE
'export-galaxy-for-cluster': exclude Galaxy source code from the exported archive

### DIFF
--- a/roles/export-galaxy-for-cluster/tasks/export.yml
+++ b/roles/export-galaxy-for-cluster/tasks/export.yml
@@ -2,7 +2,7 @@
 
 - name: "Build tgz archive for export"
   shell:
-    cmd: tar czf {{ galaxy_root_dir }}/shared/{{ archive_name }}.tgz -C {{ galaxy_root_dir }}/shared csf/galaxy/{{ galaxy_version }} csf/python/{{ python_version }}
+    cmd: tar czf {{ galaxy_root_dir }}/shared/{{ archive_name }}.tgz -C {{ galaxy_root_dir }}/shared csf/galaxy/{{ galaxy_version }}/{{ galaxy_venv }} csf/python/{{ python_version }}
 
 - name: "Export tgz from remote"
   fetch:


### PR DESCRIPTION
PR which updates the `export-galaxy-for-cluster` role so that the Galaxy source code is no longer included in the exported archive (only the Python installation and Galaxy virtualenv).

It appears that the source code is not required for using the virtualenv on the cluster system, so this update should make the archive/export operations more efficient and reduce the amount of space required for the second Galaxy install.