### PR TITLE
Add new Vagrant definition for Centaurus Vagrant VM (CentOS 8)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -297,6 +297,7 @@ virtual machines for testing the deployment.
 
 The following servers are defined in the ``Vagrantfile``:
 
+ - ``centaurus``: CentOS Linux 8 VM (http://192.168.60.3)
  - ``palfinder``: Scientific Linux 6 VM (uses the address
    http://192.168.60.4)
  - ``cetus``: Scientific Linux 7 VM (uses the address
@@ -430,6 +431,7 @@ The following Vagrant VirtualBox images are recommended for use with the
 playbooks:
 
  - **CentOS 7**: ``centos/7`` https://app.vagrantup.com/centos/boxes/7/versions/2004.01/providers/virtualbox.box
+ - **CentOS 8**: ``centos/8`` https://app.vagrantup.com/centos/boxes/8/versions/2011.0/providers/virtualbox.box
 
 To install a VirtualBox image for use with Vagrant, do:
 
@@ -441,7 +443,6 @@ For example:
 
 ::
    vagrant box add --name centos/7 https://app.vagrantup.com/centos/boxes/7/versions/2004.01/providers/virtualbox.box
-
 
 Known Issues
 ------------

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -17,6 +17,16 @@ Vagrant.configure(VAGRANT_API_VERSION) do |config|
     v.cpus = 4
     v.linked_clone = true
   end
+  # Centaurus VM
+  config.vm.define "centaurus" do |centaurus|
+    centaurus.vm.box = "centos/8"
+    centaurus.vm.hostname = "centaurus"
+    centaurus.vm.network :private_network, ip: "192.168.60.3"
+    centaurus.vm.provision "shell", inline: <<-SHELL
+    mkdir -p /mnt/rvmi
+    chmod ugo+rwX /mnt/rvmi/
+  SHELL
+  end
   # Palfinder VM
   config.vm.define "palfinder" do |palfinder|
     palfinder.vm.box = "ringo/scientific-linux-6.5"


### PR DESCRIPTION
PR which updates the `Vagrantfile` to add a new definition for a Centaurus VM, based on CentOS 8, which will be used to test implementation of playbooks to migrate and support the Centaurus production and test Galaxy server deployments (see issue #80).