### PR TITLE
'export-galaxy-for-cluster': fix 'git' cloning of Galaxy source code

### DIFF
--- a/roles/export-galaxy-for-cluster/tasks/galaxy.yml
+++ b/roles/export-galaxy-for-cluster/tasks/galaxy.yml
@@ -14,16 +14,12 @@
 # tag using the 'git' module, but this doesn't seem to
 # work in practice (cloned repository contains modified
 # files which break the subsequent checkout)
-- name: "Galaxy: clone source code from GitHub"
-  git:
-    repo: '{{ galaxy_repo }}'
-    dest: '{{ galaxy_install_dir }}/galaxy-src'
-    force: yes
-
-- name: "Galaxy: checkout required version"
+#
+# Instead clone directly to the required branch
+- name: "Galaxy: clone source code from branch from GitHub"
   shell:
-    chdir: '{{ galaxy_install_dir }}/galaxy-src'
-    cmd: git fetch origin && git checkout {{ galaxy_version_tag }} && git pull --ff-only origin {{ galaxy_version_tag }}
+    chdir: '{{ galaxy_install_dir }}'
+    cmd: git clone -b {{ galaxy_version_tag }} {{ galaxy_repo }} galaxy-src
 
 - name: "Galaxy: determine Python executable for setting up virtualenev"
   set_fact:


### PR DESCRIPTION
PR which updates how the `git` clone and checkout of the required Galaxy release branch is performed, to deal with problems encountered under CentOS 7.

Initially the Ansible `git` module was used with the `version` attribute set to the required branch. However under CentOS 7 failed due to the initial clone of the `dev` branch apparently modifying some of the files in the working directory (changing some line endings from CRLF to LF, maybe due to a rule in `.gitattributes`?).

The subsequent version used the `git` module to clone the default branch and then used the `shell` module to run `git fetch origin && git checkout BRANCH && git pull --ff-only origin BRANCH`, however this now seems to fail in the same way as before.

The latest workaround uses the `shell` module to run `git clone -b BRANCH URL`, which so far appears to work.