### PR TITLE
Enable export of Galaxy 20.05 virtualenv to CSF for Centaurus

### DIFF
--- a/inventories/csf/centaurus.yml
+++ b/inventories/csf/centaurus.yml
@@ -12,5 +12,5 @@ csf:
     galaxy_group: "galaxy"
     galaxy_gid: 400
     # Galaxy and Python versions to target
-    galaxy_version: "20.01"
+    galaxy_version: "20.05"
     python_version: "3.6.11"


### PR DESCRIPTION
PR which updates the Galaxy version to 20.05 in the inventory file for building and exporting the CSF Galaxy virtualenv for the Centaurus instance.