### PR TITLE
'galaxy' role: update the Nginx config for Galaxy 20.05

### DIFF
--- a/roles/galaxy/templates/nginx-galaxy.conf.j2
+++ b/roles/galaxy/templates/nginx-galaxy.conf.j2
@@ -73,10 +73,6 @@ server {
         alias {{ galaxy_root }}/static;
         expires 24h;
     }
-    location {{ galaxy_proxy_prefix }}/static/style {
-        alias {{ galaxy_root }}/static/style/blue;
-        expires 24h;
-    }
     location {{ galaxy_proxy_prefix }}/favicon.ico {
         alias {{ galaxy_root }}/static/favicon.ico;
         expires 24h;


### PR DESCRIPTION
PR which updates the Nginx proxy configuration for serving Galaxy, to bring it in line with the required configuration needed for Galaxy 20.05.

The changes are outlined in the 20.05 release notes:
https://docs.galaxyproject.org/en/release_20.05/releases/20.05_announce.html#upgrade-warning-for-admins