### PR TITLE
Galaxy 19.05: update JSE-Drop components for changes to reference implementation

### DIFF
--- a/roles/galaxy/files/jse_drop.py
+++ b/roles/galaxy/files/jse_drop.py
@@ -199,7 +199,11 @@ class JSEDrop(object):
         # Try qacct
         qacct = self.qacct(name)
         if qacct:
-            return qacct['jobnumber']
+            try:
+                return qacct['jobnumber']
+            except KeyError:
+                # Unable to extract job number
+                pass
         # Fallback to qstat
         qstat = self.qstat(name)
         if qstat:

--- a/roles/galaxy/files/jse_drop_runner.py
+++ b/roles/galaxy/files/jse_drop_runner.py
@@ -334,11 +334,23 @@ class JSEDropJobRunner(AsynchronousJobRunner):
                 log.warn("%s: no such job in JSE-drop?" % job_name)
                 message = "%s: no such job in JSE-drop?" % job_name
             job_state.fail_message = message
-            self.fail_job(job_state)
+            try:
+               self.fail_job(job_state)
+            except Exception as ex:
+               log.warn("%s: JSE-drop status '%s': exception from "
+                        "fail_job (ignored): %s" % (job_name,
+                                                    jse_drop_status,
+                                                    ex))
             # Remove the JSE-drop files
-            cleanup_job = self.app.config.cleanup_job
-            if cleanup_job == "always":
-                jse_drop.cleanup(job_name)
+            try:
+               cleanup_job = self.app.config.cleanup_job
+               if cleanup_job == "always":
+                   jse_drop.cleanup(job_name)
+            except Exception as ex:
+               log.warn("%s: JSE-drop status '%s': exception from "
+                        "jse_drop.cleanup (ignored): %s" % (job_name,
+                                                            jse_drop_status,
+                                                            ex))
             return None
         if jse_drop_status == JSEDropStatus.RUNNING and not job_state.running:
             # Job started running

--- a/roles/jsedrop/files/jsedrop.py
+++ b/roles/jsedrop/files/jsedrop.py
@@ -421,7 +421,9 @@ STDERR:
                 self._write_qfile(job,"qstat",output)
             else:
                 # Job has completed, write qacct file
-                self._write_qfile(job,"qacct",output)
+                self._write_qfile(job,"qacct",
+                                  """Job accounting (hostname, jobname, end_time, etc) info can be obtained by running: qacct -j \"{job_id}\"
+""".format(job_id=job_id))
                 self.log("-- Job '%s' has completed" % job)
         
     def process(self):


### PR DESCRIPTION
PR which updates the JSE-Drop components to reflect changes to the reference JSE-Drop implementation, specifically:

* `qacct` output in the local JSE-Drop implementation (`jsedrop` role) no longer includes job information (to match reference implementation)
* JSE-Drop client traps for exception when trying to acquire job number from `qacct` output, and falls back to alternative methods (`galaxy` role)
* JSE-Drop runner traps for exceptions for job failure and cleanup handling (`galaxy` role)

NB this PR addresses issue #153 for Galaxy release 19.05.