### PR TITLE
Update Cetus to Galaxy 20.05

### DIFF
--- a/cetus.yml
+++ b/cetus.yml
@@ -9,7 +9,7 @@
   - galaxy_gid: 400
   # Galaxy configuration
   - galaxy_name: "cetus"
-  - galaxy_version: "release_19.09"
+  - galaxy_version: "release_20.05"
   - galaxy_install_dir: "/mnt/rvmi/cetus/galaxy"
   - galaxy_dir: "/mnt/rvmi/cetus/galaxy/teaching"
   # Database and reference data

--- a/inventories/cetus/production.yml
+++ b/inventories/cetus/production.yml
@@ -62,4 +62,5 @@ cetus:
       - "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.70"
       - "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.72"
       - "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.72+galaxy1"
+      - "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.73+galaxy0"
       - "toolshed.g2.bx.psu.edu/repos/iuc/multiqc/multiqc/1.7.1"

--- a/inventories/cetus/vagrant.yml
+++ b/inventories/cetus/vagrant.yml
@@ -42,4 +42,4 @@ cetus:
         section: "NGS: QC and manipulation"
     # Whitelisted tools for rendering HTML correctly
     galaxy_sanitize_whitelist_tools:
-      - "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.72+galaxy1"
+      - "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.73+galaxy0"


### PR DESCRIPTION
PR which updates the playbooks for Cetus to use Galaxy version 20.05.