### PR TITLE
roles/galaxy: allowing naming of directory that Galaxy is cloned into

### DIFF
--- a/roles/galaxy/defaults/main.yml
+++ b/roles/galaxy/defaults/main.yml
@@ -67,7 +67,8 @@ galaxy_repo: https://github.com/galaxyproject/galaxy.git
 # Galaxy installation directories
 galaxy_install_dir: "/home/galaxy/galaxies"
 galaxy_dir: "{{ galaxy_install_dir }}/{{ galaxy_name }}"
-galaxy_root: "{{ galaxy_dir }}/galaxy"
+galaxy_clone_dir: "galaxy"
+galaxy_root: "{{ galaxy_dir }}/{{ galaxy_clone_dir }}"
 galaxy_tool_dependency_dir: '{{ galaxy_dir }}/tool_dependencies'
 galaxy_database_dir: '{{ galaxy_root }}/database'
 


### PR DESCRIPTION
PR which adds a new variable `galaxy_clone_dir` in the `galaxy` role, to set the name of the directory that the Galaxy code is cloned into from Github.

By default this is `galaxy`, however it can be used for compatibility with legacy Galaxy installs where the cloned directory was called `galaxy-dist`.