### PR TITLE
Drop custom 'git' install for Scientific Linux 7 and higher

### DIFF
--- a/cetus.yml
+++ b/cetus.yml
@@ -62,7 +62,6 @@
   - galaxy-user
   - epel-repo
   - nfslock
-  - git
   - selinux
   - python3
   - nginx

--- a/mintaka.yml
+++ b/mintaka.yml
@@ -202,7 +202,6 @@
   - galaxy-user
   - epel-repo
   - nfslock
-  - git
   - selinux
   - python3
   - nginx

--- a/roles/galaxy/tasks/database.yml
+++ b/roles/galaxy/tasks/database.yml
@@ -6,7 +6,6 @@
     password='{{ galaxy_db_password }}'
     role_attr_flags=NOSUPERUSER
     state=present
-  when: installed_dependencies is success
   register: postgresql_galaxy_user_created
 
 - name: Create PostgreSQL Galaxy database

--- a/roles/galaxy/tasks/dependencies.yml
+++ b/roles/galaxy/tasks/dependencies.yml
@@ -13,7 +13,13 @@
       - 'net-tools'
       - 'hg'
     state: latest
-  register: installed_dependencies
+
+- name: "Install git"
+  yum:
+    name:
+      - 'git'
+    state: latest
+  when: ansible_distribution_major_version != "6"
 
 - name: "Install galaxyctl.sh script"
   copy:

--- a/roles/galaxy/tasks/galaxy.yml
+++ b/roles/galaxy/tasks/galaxy.yml
@@ -19,13 +19,14 @@
   set_fact:
     galaxy_url: "{{ 'https' if enable_https else 'http' }}://{{ galaxy_server_name }}{{ galaxy_proxy_prefix }}/"
 
-- name: Clone Galaxy source
+- name: "Clone Galaxy source"
   git:
-    executable='/usr/local/bin/git'
-    repo='{{ galaxy_repo }}'
-    version='{{ galaxy_version }}'
-    dest={{ galaxy_root }}
-    force=yes
+    repo: '{{ galaxy_repo }}'
+    version: '{{ galaxy_version }}'
+    dest: '{{ galaxy_root }}'
+    force: yes
+  environment:
+    PATH: '/usr/local/bin:{{ ansible_env.PATH }}'
 
 - name: Create additional Galaxy directories
   file:


### PR DESCRIPTION
PR which updates the `galaxy` role and installs and uses the system `git` package for Scientific Linux versions above 6 (i.e. 7 and higher); it also updates the `cetus` and `mintaka` instances to drop installation of custom `git`.

Together these updates should address issue #95.