### PR TITLE
roles/galaxy: allow custom SQL file to be supplied

### DIFF
--- a/roles/galaxy/defaults/main.yml
+++ b/roles/galaxy/defaults/main.yml
@@ -77,6 +77,13 @@ galaxy_job_working_dir: "{{ galaxy_database_dir }}/jobs_directory"
 galaxy_file_path: "{{ galaxy_database_dir }}/files"
 galaxy_new_file_path: "{{ galaxy_database_dir }}/tmp"
 
+# Database SQL file
+# Set to a pg_dump SQL file from a previous Galaxy DB
+# to reload data from that DB
+# NB only used when creating a new DB (will not overwrite
+# an existing database)
+galaxy_new_db_sql:
+
 # Tool data locations
 galaxy_tool_data_path: "{{ galaxy_root }}/tool-data"
 galaxy_shed_tool_data_path: "{{ galaxy_tool_data_path }}"

--- a/roles/galaxy/tasks/galaxy.yml
+++ b/roles/galaxy/tasks/galaxy.yml
@@ -219,27 +219,39 @@
     "PGPASSWORD={{ galaxy_db_password }} psql -c '\\dt' '{{ galaxy_db }}' {{ galaxy_db_user }}"
   register: dbstatus
 
-- name: "Initialise Galaxy database from template SQL"
+- name: "Initialise Galaxy database from SQL file"
   block:
-    - name: "Make tmp directory for template Galaxy DB SQL"
+
+    - name: "Make tmp directory for Galaxy DB SQL file"
       file:
         path: "{{ galaxy_install_dir }}/tmp"
         state: "directory"
 
-    - name: "Copy template Galaxy database SQL"
+    - name: "Copy default template Galaxy database SQL file"
       copy:
         src: 'galaxy_database-v153.sql'
-        dest: '{{ galaxy_install_dir }}/tmp/galaxy_database-v153.sql'
+        dest: '{{ galaxy_install_dir }}/tmp/galaxy_database.sql'
+        remote_src: no
+        force: yes
+      when: galaxy_new_db_sql|default(None) == None
 
-    - name: "Update Galaxy database user in template SQL"
+    - name: "Copy user Galaxy database SQL file"
+      copy:
+        src: '{{ galaxy_new_db_sql }}'
+        dest: '{{ galaxy_install_dir }}/tmp/galaxy_database.sql'
+        remote_src: yes
+        force: yes
+      when: galaxy_new_db_sql|default(None) != None
+
+    - name: "Update Galaxy database user in DB SQL"
       replace:
-        path: '{{ galaxy_install_dir }}/tmp/galaxy_database-v153.sql'
+        path: '{{ galaxy_install_dir }}/tmp/galaxy_database.sql'
         regexp: "__GALAXY_DB_USER__"
         replace: "{{ galaxy_db_user }}"
 
     - name: "Import empty Galaxy database from template SQL"
       shell:
-        "PGPASSWORD={{ galaxy_db_password }} psql -U {{ galaxy_db_user }} {{ galaxy_db}} < {{ galaxy_install_dir }}/tmp/galaxy_database-v153.sql"
+        "PGPASSWORD={{ galaxy_db_password }} psql -U {{ galaxy_db_user }} {{ galaxy_db}} < {{ galaxy_install_dir }}/tmp/galaxy_database.sql"
 
     - name: "Update the Galaxy database"
       command:


### PR DESCRIPTION
PR updating the `galaxy` role, to address issue #149 and allow a new database to be initialised using an SQL dump from a different database. The SQL file can be supplied via the `galaxy_new_db_sql` variable.