### PR TITLE
roles/git: update to build the latest version 2.33.1

### DIFF
--- a/roles/git/defaults/main.yml
+++ b/roles/git/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
 # git defaults
-git_version: '2.20.0'
-git_checksum: 'sha256:7cc724cd9ea54b73f41ed53edbc75703df8a3108b9e30367bcf5c3a1daa3cee2'
+git_version: '2.33.1'
+git_checksum: 'sha256:fa459f95153a2c51af149c062f614018c027caf75a8dd92b3f64defe0a78f42f'
 git_install_dir: '/usr/local'


### PR DESCRIPTION
PR which updates the default version of `git` installed by the `git` role to the latest version (2.33.1).