### PR TITLE
roles/galaxy: update handling of git and Python dependencies for Galaxy install

### DIFF
--- a/roles/galaxy/tasks/dependencies.yml
+++ b/roles/galaxy/tasks/dependencies.yml
@@ -32,3 +32,23 @@
     src: 'galaxyctl.sh'
     dest: '{{ galaxy_utils_dir }}/bin/galaxyctl.sh'
     mode: 'ugo+rx'
+
+- name: "Install Galaxy-specific Python 2.7"
+  include_role:
+    name: python27
+  vars:
+    python_version: "{{ galaxy_python_version }}"
+    install_dir: "{{ galaxy_python_dir }}"
+    ansible_become: yes
+    ansible_become_user: "{{ galaxy_user }}"
+  when: galaxy_python_version.startswith("2.7")
+
+- name: "Install Galaxy-specific Python 3"
+  include_role:
+    name: python3
+  vars:
+    python_version: "{{ galaxy_python_version }}"
+    install_dir: "{{ galaxy_python_dir }}"
+    ansible_become: yes
+    ansible_become_user: "{{ galaxy_user }}"
+  when: galaxy_python_version.startswith("3.")

--- a/roles/galaxy/tasks/dependencies.yml
+++ b/roles/galaxy/tasks/dependencies.yml
@@ -14,12 +14,18 @@
       - 'hg'
     state: latest
 
-- name: "Install git"
+- name: "Install system-package version of git"
   yum:
     name:
       - 'git'
     state: latest
   when: ansible_distribution_major_version != "6"
+
+- name: "Install git from source into /usr/local"
+  include_role:
+    name: git
+  vars:
+    git_install_dir: '/usr/local'
 
 - name: "Install galaxyctl.sh script"
   copy:

--- a/roles/galaxy/tasks/main.yml
+++ b/roles/galaxy/tasks/main.yml
@@ -6,8 +6,6 @@
 
 - include: halt_galaxy.yml
 
-- include: python.yml
-
 - include: database.yml
   become: yes
   become_user: postgres

--- a/roles/git/defaults/main.yml
+++ b/roles/git/defaults/main.yml
@@ -3,3 +3,6 @@
 git_version: '2.33.1'
 git_checksum: 'sha256:fa459f95153a2c51af149c062f614018c027caf75a8dd92b3f64defe0a78f42f'
 git_install_dir: '/usr/local'
+
+# Set to 'yes' to remove git installed by yum
+git_remove_system_package: no

--- a/roles/git/tasks/main.yml
+++ b/roles/git/tasks/main.yml
@@ -15,8 +15,22 @@
     path: "{{ git_install_dir }}/bin/git"
   register: git
 
+- name: "Fetch installed git version"
+  shell:
+    "if [ -e {{ git_install_dir }}/bin/git ] ; then {{ git_install_dir }}/bin/git --version | cut -d' ' -f3 ; fi"
+  register: git_installed_version
+
+- name: "Report installed git version"
+  debug:
+    msg: "{{ git_install_dir }}/bin/git version {{ git_installed_version.stdout }}, want {{ git_version }}"
+  when: git.stat.exists
+
 - name: "Build and install git from source"
   block:
+    - name: "Report version of git to be installed"
+      debug:
+        msg: "Installing git version {{ git_version }} from source"
+
     - name: "Determine the user home directory"
       shell:
         "echo $HOME"
@@ -78,4 +92,4 @@
         cmd: "make prefix={{ git_install_dir }} install install-doc install-html install-info"
         chdir: '{{ build_dir }}/git-{{ git_version }}'
         creates: '{{ git_install_dir }}/bin/git'
-  when: not git.stat.exists
+  when: not git.stat.exists or git_installed_version.stdout != git_version

--- a/roles/git/tasks/main.yml
+++ b/roles/git/tasks/main.yml
@@ -8,6 +8,7 @@
   yum:
     name: 'git'
     state: absent
+  when: git_remove_system_package
 
 - name: "Check if git is already installed"
   stat:


### PR DESCRIPTION
PR which moves handling of the `git` and Python dependencies required by the Galaxy installation into the `dependencies.yml` file of the `galaxy` role.

The PR also makes updates to the `git` role, to make removal of the system-package installed `git` optional, and to re-install `git` from source if the currently installed version doesn't match the required version.