### PR TITLE
'galaxy' role: update location of SCSS files for Galaxy 20.09

### DIFF
--- a/roles/galaxy/defaults/main.yml
+++ b/roles/galaxy/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # Name for Galaxy instance
 galaxy_name: "palfinder"
-galaxy_version: 'release_20.01'
+galaxy_version: 'release_20.09'
 
 # User running Galaxy service
 galaxy_user: "galaxy"

--- a/roles/galaxy/tasks/galaxy.yml
+++ b/roles/galaxy/tasks/galaxy.yml
@@ -54,7 +54,7 @@
 
 - name: "Set up custom colours in SCSS file"
   replace:
-    path: '{{ galaxy_root }}/client/galaxy/style/scss/theme/blue.scss'
+    path: '{{ galaxy_root }}/client/src/style/scss/theme/blue.scss'
     regexp: "^\\$({{ item.var }}): (.*);"
     replace: "${{ item.var }}: {{ item.value }};"
   with_items: "{{ galaxy_custom_scss }}"


### PR DESCRIPTION
PR which changes the location of the SCSS files (used to set the Galaxy colour scheme) in the `galaxy` role from `style/scss/blue.scss` to `client/src/style/scss/theme/blue.scss`, to match the new location in Galaxy `release_20.09`.