### PR TITLE
'galaxy' role: patches for Galaxy 20.09

### DIFF
--- a/roles/galaxy/tasks/dependencies.yml
+++ b/roles/galaxy/tasks/dependencies.yml
@@ -12,6 +12,7 @@
       - 'python2-pyyaml'
       - 'net-tools'
       - 'hg'
+      - 'libffi-devel'
     state: latest
 
 - name: "Install system-package version of git"

--- a/roles/galaxy/tasks/galaxy.yml
+++ b/roles/galaxy/tasks/galaxy.yml
@@ -210,7 +210,9 @@
   file:
     path: '{{ galaxy_root }}/database/compiled_templates/'
     state: absent
-  when: galaxy_python_version.startswith("3.")
+  when:
+    - galaxy_python_version.startswith("3.")
+    - galaxy_version == "release_20.01"
 
 # Setup/update Galaxy
 - name: "Run common_startup.sh to initialise/update Galaxy installation"

--- a/roles/galaxy/tasks/galaxy.yml
+++ b/roles/galaxy/tasks/galaxy.yml
@@ -92,6 +92,13 @@
       when: venv_python_version.stdout != external_python_version.stdout
   when: galaxy_venv.stat.exists
 
+- name: "Remove futures from pinned-requirements.txt"
+  lineinfile:
+    path: '{{ galaxy_root }}/lib/galaxy/dependencies/pipfiles/default/pinned-requirements.txt'
+    state: absent
+    line: "futures==3.1.1"
+  when: galaxy_version == "release_20.09"
+
 - name: "Make virtualenv in Galaxy root"
   command:
     chdir: '{{ galaxy_root }}'

--- a/roles/python3/tasks/main.yml
+++ b/roles/python3/tasks/main.yml
@@ -36,6 +36,7 @@
           - 'readline-devel'
           - 'sqlite-devel'
           - 'zlib-devel'
+          - 'libffi-devel'
           - 'tkinter'
         state: 'present'
 


### PR DESCRIPTION
PR which implements a number of patches required to install Galaxy 20.09:

* `galaxy` role: remove requirement for `futures` from the pinned requirements (this is needed as the `futures` package is not available for Python 3)
* `galaxy` role: add conditional so that compiled mako templates are only removed for Galaxy 20.01 installations (possibly this wouldn't affect later versions, but probably better not to do it)
* `python3` role: add `libffi-devel` as a system-package dependency