### PR TITLE
Cetus: update max concurrent jobs and Freebayes runner

### DIFF
--- a/inventories/cetus/production.yml
+++ b/inventories/cetus/production.yml
@@ -59,6 +59,10 @@ cetus:
     ssl_certificate_key: "/etc/letsencrypt/live/{{ galaxy_server_name }}/privkey.pem"
     # Users
     galaxy_admin_user: "peter.briggs@manchester.ac.uk"
+    # Concurrent jobs
+    galaxy_registered_user_concurrent_jobs: 2
+    galaxy_unregistered_user_concurrent_jobs: 0
+    galaxy_concurrent_jobs: 8
     # Whitelisted tools for rendering HTML correctly
     galaxy_sanitize_whitelist_tools:
       - "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.70"

--- a/inventories/cetus/production.yml
+++ b/inventories/cetus/production.yml
@@ -39,6 +39,8 @@ cetus:
         destination: "jse_drop_smp_4"
       - id: "bowtie2"
         destination: "jse_drop_smp_4"
+      - id: "freebayes"
+        destination: "jse_drop_smp_8"
       - id: "tophat"
         destination: "jse_drop_smp_12"
       - id: "trimmomatic"

--- a/inventories/cetus/production.yml
+++ b/inventories/cetus/production.yml
@@ -62,7 +62,7 @@ cetus:
     # Concurrent jobs
     galaxy_registered_user_concurrent_jobs: 2
     galaxy_unregistered_user_concurrent_jobs: 0
-    galaxy_concurrent_jobs: 8
+    galaxy_concurrent_jobs: 24
     # Whitelisted tools for rendering HTML correctly
     galaxy_sanitize_whitelist_tools:
       - "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.70"


### PR DESCRIPTION
PR that updates the `job_conf.xml` configuration for the Cetus server:

* Update the maximum concurrent jobs to 24;
* Target an 8 core destination for `freebayes` jobs.