### PR TITLE
Galaxy 19.09: update 'certbot' for SSL certificate renewal for Mintaka instance

### DIFF
--- a/mintaka.yml
+++ b/mintaka.yml
@@ -211,7 +211,7 @@
   - supervisord
   - role: postfix-null-client
     when: enable_smtp
-  - lets-encrypt-client
+  - certbot
   # Install local JSEDrop service
   - role: jsedrop
     jsedrop_drop_dir: "{{ galaxy_jse_drop_dir }}"

--- a/roles/certbot/defaults/main.yml
+++ b/roles/certbot/defaults/main.yml
@@ -1,0 +1,10 @@
+---
+# How to install certbot
+# Options are "snap" or "pip"
+certbot_install_using: "pip"
+
+# Location to link certbox exe from
+certbot_dir: /usr/local/bin
+
+# Defaults for "pip" installation only
+certbot_venv_dir: /opt/certbot

--- a/roles/certbot/tasks/install_with_pip.yml
+++ b/roles/certbot/tasks/install_with_pip.yml
@@ -1,0 +1,50 @@
+---
+# Install certbot using pip
+# https://certbot.eff.org/lets-encrypt/nginx
+
+# Get rid of old certbot-auto
+- name: "Remove old certbot-auto"
+  file:
+    path: "/usr/local/bin/certbot-auto"
+    state: absent
+
+- name: "Install dependencies for certbot"
+  yum:
+    name:
+      - python3
+      - augeas-libs
+    state: present
+
+- name: "Make virtualenv for certbot"
+  command:
+    cmd: "python3 -m venv {{ certbot_venv_dir }}"
+    creates: "{{ certbot_venv_dir }}"
+
+- name: "Update pip in certbot virtualenv"
+  pip:
+    name: "pip"
+    executable: '{{ certbot_venv_dir }}/bin/pip'
+    state: latest
+
+- name: "Install certbot into virtualenv"
+  pip:
+    name:
+      - "certbot"
+      - "certbot-nginx"
+    executable: '{{ certbot_venv_dir }}/bin/pip'
+    state: latest
+
+- name: "Create symlink to certbot"
+  file:
+    path: "{{ certbot_dir }}/certbot"
+    src: "{{ certbot_venv_dir }}/bin/certbot"
+    state: link
+
+# Cron job for certificate renewals
+- name: "Add cron job to renew SSL certificates"
+  cron:
+    name: "certbot: renew SSL certificates"
+    job: "{{ certbot_venv_dir }}/bin/python -c 'import random; import time; time.sleep(random.random() * 3600)' && certbot renew -q"
+    hour: '0,12'
+    minute: '0'
+    state: present

--- a/roles/certbot/tasks/install_with_snap.yml
+++ b/roles/certbot/tasks/install_with_snap.yml
@@ -1,0 +1,46 @@
+---
+# Install certbot using snapd
+# https://certbot.eff.org/lets-encrypt/nginx
+
+# Install and configure 'snapd'
+- name: "Install snapd for certbot"
+  yum:
+    name: "snapd"
+    state: present
+
+- name: "Enable main snap communication socket"
+  systemd:
+    name: snapd.socket
+    enabled: True
+    state: started
+
+- name: "Make symlink to /snap to enable classic snap"
+  file:
+    path: "/snap"
+    src: "/var/lib/snapd/snap"
+    state: link
+
+- name: "Install snap core is up to date"
+  command:
+    cmd: "snap install core"
+
+- name: "Refresh snap core"
+  command:
+    cmd: "snap refresh core"
+
+# Get rid of old certbot-auto
+- name: "Remove old certbot-auto"
+  file:
+    path: "/usr/local/bin/certbot-auto"
+    state: absent
+
+# Install and configure 'certbot'
+- name: "Install certbox via snap"
+  command:
+    cmd:  "snap install --classic certbot"
+
+- name: "Create symlink to certbot"
+  file:
+    path: "{{ certbot_dir }}/certbot"
+    src: "/snap/bin/certbot"
+    state: link

--- a/roles/certbot/tasks/main.yml
+++ b/roles/certbot/tasks/main.yml
@@ -1,0 +1,8 @@
+---
+# Install certbot
+
+- include: install_with_snap.yml
+  when: certbot_install_using == "snap"
+
+- include: install_with_pip.yml
+  when: certbot_install_using == "pip"

--- a/roles/galaxy-audit-report/tasks/main.yml
+++ b/roles/galaxy-audit-report/tasks/main.yml
@@ -11,4 +11,3 @@
   when:
     - enable_smtp
     - email_audit_report_to is defined and email_audit_report_to != None
-    - galaxy_yml.stat.exists == True


### PR DESCRIPTION
Bugfix PR which backports the `certbot` role implemented for Galaxy 20.05 (PR #161) and uses this to replace the `lets-encrypt` role used in the Mintaka Galaxy playbook (enabling the Mintaka Galaxy instance to renewl SSL certificates).

The PR also patches the `galaxy-audit-report` role to remove a broken conditional which checks for the existence of the `galaxy.yaml` configuration file.