### PR TITLE
'galaxy' role: ensure latest version of 'ca-certificates' package

### DIFF
--- a/roles/galaxy/tasks/dependencies.yml
+++ b/roles/galaxy/tasks/dependencies.yml
@@ -13,6 +13,7 @@
       - 'net-tools'
       - 'hg'
       - 'libffi-devel'
+      - 'ca-certificates'
     state: latest
 
 - name: "Install system-package version of git"


### PR DESCRIPTION
PR which fixes a bug seen with the `cetus` instance installing on Vagrant VM running Scientific Linux 7, where the default `ca-certificates` package is too old (at version `2014.1.98`) for Galaxy tool installation. This results in errors of the form:

    ssl.SSLError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:852)

and

    urllib.error.URLError: <openurl error [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:852)>

appearing in the Galaxy log.

Ensuring that the newest `ca-certificates` package (e.g. version `2021.2.50`) fixes this problem.