### PR TITLE
Fix bugs in user creation and tool installation when using 'galaxy_clone_dir'

### DIFF
--- a/roles/galaxy-create-users/defaults/main.yml
+++ b/roles/galaxy-create-users/defaults/main.yml
@@ -24,7 +24,7 @@ galaxy_utils_dir: "/usr/local"
 galaxy_users: null
 
 # Galaxy installation location
-galaxy_root: "{{ galaxy_dir }}/galaxy"
+galaxy_root: "{{ galaxy_dir }}/{{ galaxy_clone_dir }}"
 
 # Postgresql database
 galaxy_db: "galaxy_{{ galaxy_name }}"

--- a/roles/galaxy-install-tools/default/main.yml
+++ b/roles/galaxy-install-tools/default/main.yml
@@ -67,7 +67,7 @@ galaxy_tool_data_tables: null
 galaxy_loc_file_data: null
 
 # Galaxy installation location
-galaxy_root: "{{ galaxy_dir }}/galaxy"
+galaxy_root: "{{ galaxy_dir }}/{{ galaxy_clone_dir }}"
 
 # Is https enabled
 enable_https: no


### PR DESCRIPTION
PR which fixes bugs in the `galaxy-create-users` and `galaxy-install-tools`  roles when the `galaxy_clone_dir` parameter (which allows a non-default directory name to be used for the cloned Galaxy `git` repository to be specified) is set to something other than the default name `galaxy`.