### PR TITLE
'jsedrop' role: fix template for 'jsedrop.service' for Centos 7

### DIFF
--- a/roles/jsedrop/templates/jsedrop.service.j2
+++ b/roles/jsedrop/templates/jsedrop.service.j2
@@ -6,7 +6,6 @@ Conflicts=getty@tty1.service
 [Service]
 Type=simple
 ExecStart={{ jsedrop_python3 }} {{ jsedrop_install_dir }}/jsedrop.py {{ jsedrop_drop_dir }} --log /var/log/jsedrop.log --run-as-user
-StandardInput=tty-force
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
PR which fixes a bug in the template for the local JSEDrop service (in the `jsedrop` role), specifically removing the line:

    StandardInput=tty-force

from the `Service` section (which broke the service under Centos 7).