### PR TITLE
'galaxy-utils' role: PyPI 'psycopg2' needs 'libpqxx' and 'libpqxx-devel'

### DIFF
--- a/roles/galaxy-utils/tasks/main.yml
+++ b/roles/galaxy-utils/tasks/main.yml
@@ -1,5 +1,13 @@
 # Install utilities
 ---
+
+- name: "Install system packages for utility scripts"
+  yum:
+    name:
+      - 'libpqxx'
+      - 'libpqxx-devel'
+    state: latest
+
 # Need latest setuptools to install nebulizer
 # Error looks like the one reported here:
 # - https://github.com/rm-hull/luma.examples/issues/45


### PR DESCRIPTION
PR which fixes a bug when running the `galaxy-utils` role  on CentOS 7, specifically that installation of the `psycopg2` package from PyPI requires the `libpqxx` and `libpqxx-devel` packages.