### PR TITLE
'galaxy' role: add a check that proxy prefix includes leading slash

### DIFF
--- a/roles/galaxy/tasks/galaxy.yml
+++ b/roles/galaxy/tasks/galaxy.yml
@@ -15,6 +15,13 @@
   - '{{ galaxy_dir }}/logs'
   - '{{ galaxy_dir }}/backups'
 
+- name: "Stop if proxy prefix is set but is missing leading slash"
+  fail:
+    msg: "'galaxy_proxy_prefix' is missing a leading slash (currently set to '{{ galaxy_proxy_prefix }}')"
+  when:
+    - galaxy_proxy_prefix|default(None) != None
+    - galaxy_proxy_prefix is not regex("^/.*")
+
 - name: Set Galaxy URL
   set_fact:
     galaxy_url: "{{ 'https' if enable_https else 'http' }}://{{ galaxy_server_name }}{{ galaxy_proxy_prefix }}/"


### PR DESCRIPTION
PR which adds a sanity check in the `galaxy` role that if `galaxy_proxy_prefix` is set then the path starts with a backslash (e.g. `/galaxy`), hopefully making it quicker to figure out what's going wrong when this is missing.