### PR TITLE
'galaxy' role: update SE Linux context for static Galaxy content

### DIFF
--- a/roles/galaxy/tasks/nginxproxy.yml
+++ b/roles/galaxy/tasks/nginxproxy.yml
@@ -40,6 +40,25 @@
   notify:
   - Restart Nginx
 
+# Fix SELinux contexts for Galaxy content
+- name: "Check if SELinux is enforcing"
+  command:
+    "getenforce"
+  register: sestatus
+
+- name: "Fix SELinux contexts for Galaxy content"
+  block:
+
+    - name: "Update SELinux contexts for static content"
+      command:
+        "semanage fcontext -a -t httpd_sys_content_t '{{ galaxy_root }}/static(/.*)?'"
+
+    - name: "Apply updated SELinux contexts for static content"
+      command:
+        "restorecon -Rv {{ galaxy_root }}/static"
+
+  when: '"Disabled" not in sestatus.stdout'
+
 # Set up strong Diffie-Hellman group for TLS/SSL
 - name: "Check for Diffie-Hellman parameter file"
   stat:


### PR DESCRIPTION
PR which updates the SE Linux context for the static Galaxy content, so that it can be served by `nginx` (required on CentOS 7).