### PR TITLE
Add support for 'env' tags in job destinations in 'job_conf.xml'

### DIFF
--- a/roles/galaxy/defaults/main.yml
+++ b/roles/galaxy/defaults/main.yml
@@ -153,6 +153,12 @@ galaxy_jse_drop_cleanup_grace_period: "600"
 # Define entries as a dictionary with:
 # - id     (destination ID)
 # - runner (target runner)
+# - jse_drop_qsub_options (optional, JSE-drop 'qsub_options')
+# - jse_drop_slots (optional, JSE-drop 'galaxy_slots')
+# - envs (optional dictionary defining <env...> elements)
+# 'envs' should be a dictionary with:
+# - id     (ID for env element)
+# - value  (corresponding env value)
 galaxy_job_destinations:
 
 # Tool destinations

--- a/roles/galaxy/templates/job_conf.xml.j2
+++ b/roles/galaxy/templates/job_conf.xml.j2
@@ -36,6 +36,11 @@
 {% if dest.jse_drop_slots is defined %}
 	  <param id="galaxy_slots">{{ dest.jse_drop_slots }}</param>
 {% endif %}
+{% if dest.envs is defined %}
+{% for env in dest.envs %}
+	  <env id="{{ env.id }}">{{ env.value }}</env>
+{% endfor %}
+{% endif %}
 	</destination>
 {% endfor %}
 {% endif %}


### PR DESCRIPTION
PR which updates the `job_conf.xml.j2` template in the `galaxy` role, to allow `<env id="…" ...>` tags to be defined for job destinations when generating the `job_conf.xml` config file.