### PR TITLE
Update nginx configs for multiple Galaxy instances on same server

### DIFF
--- a/roles/galaxy/templates/nginx-galaxy.conf.j2
+++ b/roles/galaxy/templates/nginx-galaxy.conf.j2
@@ -3,11 +3,6 @@
 #
 # TODO
 # - add compression/caching
-#
-# if using more than one upstream, disable nginx's round-robin
-# scheme to prevent it from submitting POST requests more than
-# once (this is unsafe)
-proxy_next_upstream off;
 
 {% if enable_https %}
 server {

--- a/roles/galaxy/templates/nginx-galaxy.conf.j2
+++ b/roles/galaxy/templates/nginx-galaxy.conf.j2
@@ -27,7 +27,7 @@ server {
         allow all;
     }
 {% else %}
-    listen 80 default;
+    listen 80;
 {% endif %}
     client_body_temp_path {{ nginx_client_body_temp_path }};
     client_max_body_size {{ nginx_client_max_body_size }};

--- a/roles/nginx/templates/nginx.conf.j2
+++ b/roles/nginx/templates/nginx.conf.j2
@@ -30,6 +30,11 @@ http {
     include             {{ nginx_conf_dir }}/mime.types;
     default_type        application/octet-stream;
 
+    # if using more than one upstream, disable nginx's round-robin
+    # scheme to prevent it from submitting POST requests more than
+    # once (this is unsafe)
+    proxy_next_upstream off;
+
     # Load modular configuration files from the /etc/nginx/conf.d directory.
     # See http://nginx.org/en/docs/ngx_core_module.html#include
     # for more information.


### PR DESCRIPTION
PR which updates the `nginx` configurations to handle multiple Galaxy instances being proxied from the same server.

Specifically:

* The `upstream_next_proxy` directive needed to be moved from the config file for each Galaxy instance into the main `nginx` config, and
* The `default` qualifier on the `listen 80` directive in the Galaxy `nginx` proxy config needed to be removed for multiple instances.