### PR TITLE
'galaxy' role: fix job_conf.xml template for setting JSE-Drop Galaxy ID

### DIFF
--- a/roles/galaxy/templates/job_conf.xml.j2
+++ b/roles/galaxy/templates/job_conf.xml.j2
@@ -9,7 +9,7 @@
 	<plugin id="jse_drop" type="runner" load="galaxy.jobs.runners.jse_drop_runner:JSEDropJobRunner">
 	  <param id="drop_dir">{{ galaxy_jse_drop_dir }}</param>
 	  <param id="virtual_env">{{ galaxy_jse_drop_virtual_env }}</param>
-{% if galaxy_jse_drop_name is defined %}
+{% if galaxy_jse_drop_id is defined %}
 	  <param id="galaxy_id">{{ galaxy_jse_drop_galaxy_id }}</param>
 {% endif %}
         </plugin>


### PR DESCRIPTION
PR which fixes a bug in the `job_conf.xml` template in the `galaxy` role, which meant that the Galaxy ID was not being set when defining the JSE-Drop runner plugin.