### PR TITLE
Bugfix for 'galaxyctl.sh' utility when stopping Galaxy

### DIFF
--- a/roles/galaxy-create-users/tasks/main.yml
+++ b/roles/galaxy-create-users/tasks/main.yml
@@ -8,6 +8,10 @@
 - name: "Create and activate Galaxy user accounts"
   block:
     # Create the accounts
+    - name: "Show command line for restarting Galaxy with master API key"
+      debug:
+        msg: "{{ galaxy_utils_dir }}/bin/galaxyctl.sh restart {{ galaxy_name }} -c {{ galaxy_root }}/config/galaxy.yml -u {{ galaxy_user }} --master-api-key {{ master_api_key }}"
+
     - name: "Activate Galaxy master API key for user creation"
       command:
         "{{ galaxy_utils_dir }}/bin/galaxyctl.sh restart {{ galaxy_name }} -c {{ galaxy_root }}/config/galaxy.yml -u {{ galaxy_user }} --master-api-key {{ master_api_key }}"

--- a/roles/galaxy/files/galaxyctl.sh
+++ b/roles/galaxy/files/galaxyctl.sh
@@ -79,7 +79,6 @@ function stop_galaxy() {
 	    if [ ! -z "$children" ] ; then
 		extra_procs="$extra_procs $children"
 	    fi
-	    extra_procs="$extra_procs $galaxy_proc"
 	done
 	galaxy_procs="$galaxy_procs $extra_procs"
 	echo Stopping using supervisord
@@ -88,7 +87,7 @@ function stop_galaxy() {
 	sleep 30
 	if [ ! -z "$galaxy_procs" ] ; then
 	    echo Manually removing leftover processes
-    	    for galaxy_proc in $PROCESSES ; do
+    	    for galaxy_proc in $galaxy_procs ; do
 		if [ ! -z "$(ps --pid $galaxy_proc)" ] ; then
 		    echo ...sending SIG$_SIGNAL to $galaxy_proc
 		    kill -s $_SIGNAL $galaxy_proc
@@ -211,6 +210,7 @@ case $COMMAND in
 	exit 1
 	;;
 esac
+echo Finished: $status
 exit $status
 ##
 #

--- a/roles/galaxy/tasks/halt_galaxy.yml
+++ b/roles/galaxy/tasks/halt_galaxy.yml
@@ -1,5 +1,9 @@
 # Stop Galaxy running
 ---
+- name: "Command to halt running Galaxy"
+  debug:
+    msg: "{{ galaxy_utils_dir }}/bin/galaxyctl.sh stop {{ galaxy_name }}"
+
 - name: "Halt running Galaxy"
   command:
     "{{ galaxy_utils_dir }}/bin/galaxyctl.sh stop {{ galaxy_name }}"


### PR DESCRIPTION
PR which implements a bugfix for the `galaxyctl.sh` utility script in the `galaxy` role, for correctly handling deletion of leftover child processes when attempting to stop a running Galaxy instance.