### PR TITLE
'galaxy-utils' role: fix 'install_tool.sh' to work with Nebulizer 0.7.1

### DIFF
--- a/roles/galaxy-utils/files/install_tool.sh
+++ b/roles/galaxy-utils/files/install_tool.sh
@@ -48,9 +48,9 @@ fi
 
 # Install the tool
 if [ -z "$SECTION" ] ; then
-    $NEBULIZER -k $APIKEY install_tool $URL $SHED $OWNER $TOOL
+    $NEBULIZER -k $APIKEY install_tool -y $URL $SHED $OWNER $TOOL
 else
-    $NEBULIZER -k $APIKEY install_tool --tool-panel-section "$SECTION" $URL $SHED $OWNER $TOOL
+    $NEBULIZER -k $APIKEY install_tool -y --tool-panel-section "$SECTION" $URL $SHED $OWNER $TOOL
 fi
 retcode=$?
 echo Tool installation returned $retcode


### PR DESCRIPTION
PR which fixes a bug in the `install_tool.sh` utility script installed as part of the `galaxy-utils` role; without the fix the utility hangs waiting for manual confirmation when invoking `nebulizer` 0.7.1 to perform tool installation. The fix adds the `-y` command line argument to the invocation to automatically approve the tool install.