### PR TITLE
'galaxy' role: update user authentication in proftpd configuration

### DIFF
--- a/roles/galaxy/templates/proftpd-galaxy.conf.j2
+++ b/roles/galaxy/templates/proftpd-galaxy.conf.j2
@@ -69,7 +69,7 @@ SQLEngine                       on
 SQLBackend                      postgres
 SQLConnectInfo                  {{ galaxy_db }}@localhost:5432 {{ galaxy_ftp_user }} {{ galaxy_ftp_password }}
 SQLAuthTypes			PBKDF2
-SQLPasswordPBKDF2		SHA256 10000 24
+SQLPasswordPBKDF2		SHA256 100000 24
 SQLPasswordEncoding             base64
 SQLAuthenticate                 users
 
@@ -80,7 +80,7 @@ SQLPasswordUserSalt sql:/GetUserSalt
 #  UID and GID should match your Galaxy user.
 SQLUserInfo                     custom:/LookupGalaxyUser
 
-SQLNamedQuery LookupGalaxyUser SELECT "email, (CASE WHEN substring(password from 1 for 6) = 'PBKDF2' THEN substring(password from 38 for 69) ELSE password END) AS password2,400,400,'{{ galaxy_ftp_upload_dir }}/%U','/bin/bash' FROM galaxy_user WHERE email='%U'"
+SQLNamedQuery LookupGalaxyUser SELECT "email, (CASE WHEN substring(password from 1 for 6) = 'PBKDF2' THEN substring(password from 39 for 70) ELSE password END) AS password2,400,400,'{{ galaxy_ftp_upload_dir }}/%U','/bin/bash' FROM galaxy_user WHERE email='%U'"
 
 # Define custom query to fetch the password salt
-SQLNamedQuery GetUserSalt SELECT "(CASE WHEN SUBSTRING (password from 1 for 6) = 'PBKDF2' THEN SUBSTRING (password from 21 for 16) END) AS salt FROM galaxy_user WHERE email='%U'"
+SQLNamedQuery GetUserSalt SELECT "(CASE WHEN SUBSTRING (password from 1 for 6) = 'PBKDF2' THEN SUBSTRING (password from 22 for 16) END) AS salt FROM galaxy_user WHERE email='%U'"


### PR DESCRIPTION
PR which updates the template configuration file for ProFTPd, specifically the SQL functions used to authenticate the user password against the hash stored in the Galaxy database.

This is required as the "cost factor" used in the PBKDF2 hashing was increased as part of PR https://github.com/galaxyproject/galaxy/pull/9642/commits from 10,000 to 100,000, which impacts the position of the string that contains the salt and the hashed password itself.

This change appears to affect Galaxy releases from at least 20.05; users with accounts created in earlier releases will find that their password is not recognised when attempting to connect to the FTP server. They will need to do a password reset (it can be the same password) to update the hash in the database so that it is compatible with the scheme expected after this change.