### PR TITLE
'python3' role: extend to work on Ubuntu as well as SL/CentOS platforms

### DIFF
--- a/roles/python3/tasks/dependencies_redhat.yml
+++ b/roles/python3/tasks/dependencies_redhat.yml
@@ -1,0 +1,23 @@
+---
+- name: "Install Python3 build dependencies for SL/CentOS"
+  yum:
+    name:
+      - 'autoconf'
+      - 'make'
+      - 'automake'
+      - 'gcc'
+      - 'readline'
+      - 'sqlite'
+      - 'zlib'
+      - 'bzip2-devel'
+      - 'bzip2'
+      - 'ncurses-devel'
+      - 'ncurses'
+      - 'openssl-devel'
+      - 'openssl'
+      - 'readline-devel'
+      - 'sqlite-devel'
+      - 'zlib-devel'
+      - 'libffi-devel'
+      - 'tkinter'
+    state: 'present'

--- a/roles/python3/tasks/dependencies_ubuntu.yml
+++ b/roles/python3/tasks/dependencies_ubuntu.yml
@@ -1,0 +1,24 @@
+---
+- name: "Install Python3 build dependencies for Ubuntu"
+  apt:
+    pkg:
+      - 'build-essential'
+      - 'gdb'
+      - 'lcov'
+      - 'pkg-config'
+      - 'libbz2-dev'
+      - 'libffi-dev'
+      - 'libgdbm-dev'
+      - 'libgdbm-compat-dev'
+      - 'liblzma-dev'
+      - 'libncurses5-dev'
+      - 'libreadline6-dev'
+      - 'libsqlite3-dev'
+      - 'libssl-dev'
+      - 'lzma'
+      - 'lzma-dev'
+      - 'tk-dev'
+      - 'uuid-dev'
+      - 'zlib1g-dev'
+    state: 'present'
+    update_cache: yes

--- a/roles/python3/tasks/main.yml
+++ b/roles/python3/tasks/main.yml
@@ -17,28 +17,11 @@
 
 - name: "Build and install Python 3"
   block:
-    - name: "Install Python3 build dependencies"
-      yum:
-        name:
-          - 'autoconf'
-          - 'make'
-          - 'automake'
-          - 'gcc'
-          - 'readline'
-          - 'sqlite'
-          - 'zlib'
-          - 'bzip2-devel'
-          - 'bzip2'
-          - 'ncurses-devel'
-          - 'ncurses'
-          - 'openssl-devel'
-          - 'openssl'
-          - 'readline-devel'
-          - 'sqlite-devel'
-          - 'zlib-devel'
-          - 'libffi-devel'
-          - 'tkinter'
-        state: 'present'
+    - include: "dependencies_redhat.yml"
+      when: ansible_distribution == "Scientific" or ansible_distribution == "CentOS"
+
+    - include: "dependencies_ubuntu.yml"
+      when: ansible_distribution == "Ubuntu"
 
     - name: "Create installation directory"
       file:


### PR DESCRIPTION
PR which extends the `python3` role to work with Ubuntu as well as Scientific Linux/CentOS (RedHat) platforms.