### PR TITLE
'nginx' role: update to work with Ubuntu

### DIFF
--- a/roles/nginx/tasks/install_nginx_redhat.yml
+++ b/roles/nginx/tasks/install_nginx_redhat.yml
@@ -1,0 +1,23 @@
+---
+- name: "Install Nginx for SL/CentOS"
+  yum:
+    name:
+      - "{{ nginx_yum_package }}"
+      - "libselinux-python"
+      - "libsemanage-python"
+      - "python-passlib"
+    state: present
+
+- name: "Get status of SELinux"
+  command: getenforce
+  register: sestatus
+  changed_when: false
+
+- name: "Set sebooleans for httpd"
+  seboolean:
+    name={{ item }} state=yes persistent=yes
+  with_items:
+    - httpd_can_network_connect
+    - httpd_enable_homedirs
+    - httpd_use_nfs
+  when: "'Disabled' not in sestatus.stdout"

--- a/roles/nginx/tasks/install_nginx_ubuntu.yml
+++ b/roles/nginx/tasks/install_nginx_ubuntu.yml
@@ -1,0 +1,6 @@
+---
+- name: "Install Nginx for Ubuntu"
+  apt:
+    pkg:
+      - "nginx"
+    state: present

--- a/roles/nginx/tasks/main.yml
+++ b/roles/nginx/tasks/main.yml
@@ -1,27 +1,10 @@
 ---
 # Install, configure and start Nginx on remote server
-- name: "Install Nginx"
-  yum:
-    name:
-      - "{{ nginx_yum_package }}"
-      - "libselinux-python"
-      - "libsemanage-python"
-      - "python-passlib"
-    state: present
+- include: "install_nginx_redhat.yml"
+  when: (ansible_distribution == "Scientific" or ansible_distribution == "CentOS") and ansible_distribution_major_version == "7"
 
-- name: "Get status of SELinux"
-  command: getenforce
-  register: sestatus
-  changed_when: false
-
-- name: "Set sebooleans for httpd"
-  seboolean:
-    name={{ item }} state=yes persistent=yes
-  with_items:
-  - httpd_can_network_connect
-  - httpd_enable_homedirs
-  - httpd_use_nfs
-  when: "'Disabled' not in sestatus.stdout"
+- include: "install_nginx_ubuntu.yml"
+  when: ansible_distribution == "Ubuntu"
 
 - name: "Check if default Nginx configuration is present"
   stat: path={{ nginx_conf_dir }}/conf.d/default.conf
@@ -34,12 +17,12 @@
 # On Scientific Linux 7 the default nginx.conf file contains
 # a 'server' block which clashes with the one in the Galaxy
 # conf file, so need to replace it
-- name: "Replace main Nginx conf file"
+- name: "Replace main Nginx conf file (SL7)"
   template:
     src: "nginx.conf.j2"
     dest: "{{ nginx_conf_dir }}/nginx.conf"
     mode: "u=rw,go=r"
-  when: ansible_distribution_major_version == "7"
+  when: ansible_distribution == "Scientific" and ansible_distribution_major_version == "7"
   notify:
   - "Restart Nginx"
 


### PR DESCRIPTION
PR which updates the `nginx` role to operate on Ubuntu as well as Scientific Linux/CentOS (RedHat) platforms.