### PR TITLE
'supervisord' role: update to work with Ubuntu

### DIFF
--- a/roles/supervisord/handlers/main.yml
+++ b/roles/supervisord/handlers/main.yml
@@ -1,4 +1,6 @@
 ---
 # Handlers for supervisord role
-- name: Restart Supervisord
-  service: name=supervisord state=restarted
+- name: "Restart supervisord.service"
+  service:
+    name: 'supervisord'
+    state: restarted

--- a/roles/supervisord/tasks/dependencies_redhat.yml
+++ b/roles/supervisord/tasks/dependencies_redhat.yml
@@ -1,0 +1,5 @@
+---
+- name: "Uninstall yum version of Supervisor (RedHat)"
+  yum:
+    name: 'supervisor'
+    state: 'absent'

--- a/roles/supervisord/tasks/dependencies_ubuntu.yml
+++ b/roles/supervisord/tasks/dependencies_ubuntu.yml
@@ -1,0 +1,5 @@
+---
+- name: "Uninstall apt version of Supervisor (Ubuntu)"
+  apt:
+    pkg: 'supervisor'
+    state: 'absent'

--- a/roles/supervisord/tasks/main.yml
+++ b/roles/supervisord/tasks/main.yml
@@ -1,10 +1,11 @@
 ---
 # Install, configure and start Supervisord
 
-- name: "Uninstall yum version of Supervisor"
-  yum:
-    name: 'supervisor'
-    state: absent
+- include: "dependencies_redhat.yml"
+  when: ansible_distribution == "Scientific" or ansible_distribution == "CentOS"
+
+- include: "dependencies_ubuntu.yml"
+  when: ansible_distribution == "Ubuntu"
 
 - name: "Check if Supervisor is already installed"
   stat:
@@ -81,7 +82,7 @@
     shell: >-
       {{ supervisor_install_dir }}/bin/echo_supervisord_conf > {{ supervisor_install_dir }}/etc/supervisord.conf
       creates={{ supervisor_install_dir }}/etc/supervisord.conf
-    notify: "Restart Supervisord"
+    notify: "Restart supervisord.service"
 
   - name: "Create supervisord.d directory"
     file:
@@ -109,24 +110,11 @@
       - section: 'include'
         option: 'files'
         value: '/usr/local/etc/supervisord.d/*.ini'
-    notify: "Restart Supervisord"
-
-  - name: "Check existence of Supervisord init.d script"
-    stat:
-      path: "/etc/init.d/supervisord"
-    register: init_d
-
-  - name: "Create init.d script for Supervisord"
-    copy:
-      dest: '/etc/init.d/supervisord'
-      src: 'supervisord.init.sh'
-      mode: 'ugo+x'
-    when: not init_d.stat.exists
-    notify: "Restart Supervisord"
+    notify: "Restart supervisord.service"
   when: install_supervisor == True
 
-- name: "Start Supervisord service"
-  service:
-    name: 'supervisord'
-    enabled: on
-    state: started
+- include: "supervisord_initd.yml"
+  when: ansible_distribution == "Scientific" or ansible_distribution == "CentOS"
+
+- include: "supervisord_service.yml"
+  when: ansible_distribution == "Ubuntu"

--- a/roles/supervisord/tasks/supervisord_initd.yml
+++ b/roles/supervisord/tasks/supervisord_initd.yml
@@ -1,0 +1,22 @@
+---
+- name: "Install Supervisord init.d script"
+  block:
+    - name: "Check existence of Supervisord init.d script"
+      stat:
+        path: "/etc/init.d/supervisord"
+      register: init_d
+
+    - name: "Create init.d script for Supervisord"
+      copy:
+        dest: '/etc/init.d/supervisord'
+        src: 'supervisord.init.sh'
+        mode: 'ugo+x'
+      when: not init_d.stat.exists
+      notify: "Restart supervisord.service"
+  when: install_supervisor == True
+
+- name: "Start Supervisord service via init.d script"
+  service:
+    name: 'supervisord'
+    enabled: on
+    state: started

--- a/roles/supervisord/tasks/supervisord_service.yml
+++ b/roles/supervisord/tasks/supervisord_service.yml
@@ -1,0 +1,13 @@
+---
+- name: "Create service file for Supervisord"
+  template:
+    src: 'supervisord.service.j2'
+    dest: '/lib/systemd/system/supervisord.service'
+  notify: "Restart supervisord.service"
+  when: install_supervisor == True
+
+- name: "Start Supervisord service"
+  systemd:
+    name: 'supervisord'
+    enabled: on
+    state: restarted

--- a/roles/supervisord/templates/supervisord.service.j2
+++ b/roles/supervisord/templates/supervisord.service.j2
@@ -1,0 +1,15 @@
+[Unit]
+Description=Supervisor process control system for UNIX
+Documentation=http://supervisord.org
+After=network.target
+
+[Service]
+ExecStart=/usr/local/bin/supervisord -n -c {{ supervisor_install_dir }}/etc/supervisord.conf -j /var/run/supervisord.pid
+ExecStop=/usr/local/bin/supervisorctl $OPTIONS shutdown
+ExecReload=/usr/local/bin/supervisorctl $OPTIONS reload
+KillMode=process
+Restart=on-failure
+RestartSec=20s
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
PR which updates the `supervisord` role to work with Ubuntu as well as with Scientific Linux/CentOS (RedHat) platforms.