### PR TITLE
'certbot' role: update pip installation route to work with Ubuntu

### DIFF
--- a/roles/certbot/tasks/dependencies_pip_redhat.yml
+++ b/roles/certbot/tasks/dependencies_pip_redhat.yml
@@ -1,0 +1,7 @@
+---
+- name: "Install certbot dependencies for RedHat"
+  yum:
+    name:
+      - 'python3'
+      - 'augeas-libs'
+    state: 'present'

--- a/roles/certbot/tasks/dependencies_pip_ubuntu.yml
+++ b/roles/certbot/tasks/dependencies_pip_ubuntu.yml
@@ -1,0 +1,6 @@
+---
+- name: "Install certbot dependencies for Ubuntu"
+  apt:
+    pkg:
+      - 'python3'
+    state: 'present'

--- a/roles/certbot/tasks/install_with_pip.yml
+++ b/roles/certbot/tasks/install_with_pip.yml
@@ -8,12 +8,11 @@
     path: "/usr/local/bin/certbot-auto"
     state: absent
 
-- name: "Install dependencies for certbot"
-  yum:
-    name:
-      - python3
-      - augeas-libs
-    state: present
+- include: "dependencies_pip_redhat.yml"
+  when: ansible_distribution == "Scientific" or ansible_distribution == "CentOS"
+
+- include: "dependencies_pip_ubuntu.yml"
+  when: ansible_distribution == "Ubuntu"
 
 - name: "Make virtualenv for certbot"
   command:


### PR DESCRIPTION
PR which updates the `certbot` role to enable the `pip` installation route to work with Ubuntu as well as RedHat platforms.