### PR TITLE
'galaxy-utils' role: update to work with Ubuntu

### DIFF
--- a/roles/galaxy-utils/files/activate_user.sh
+++ b/roles/galaxy-utils/files/activate_user.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Activate a user account
 

--- a/roles/galaxy-utils/files/clean_out_user_data.sh
+++ b/roles/galaxy-utils/files/clean_out_user_data.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Clean out histories for specified user in the Galaxy database
 #

--- a/roles/galaxy-utils/files/create_user.sh
+++ b/roles/galaxy-utils/files/create_user.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Create user using nebulizer & Galaxy API
 

--- a/roles/galaxy-utils/files/delete_old_datasets.sh
+++ b/roles/galaxy-utils/files/delete_old_datasets.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Flag all 'old' datasets in the Galaxy database as deleted
 #

--- a/roles/galaxy-utils/files/install_tool.sh
+++ b/roles/galaxy-utils/files/install_tool.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Install tool using nebulizer & Galaxy API
 

--- a/roles/galaxy-utils/files/populate_data_library.sh
+++ b/roles/galaxy-utils/files/populate_data_library.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Create and populate data library using nebulizer & Galaxy API
 

--- a/roles/galaxy-utils/files/set_default_quota.sh
+++ b/roles/galaxy-utils/files/set_default_quota.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # Set the default quota for registered users
 

--- a/roles/galaxy-utils/tasks/dependencies_redhat.yml
+++ b/roles/galaxy-utils/tasks/dependencies_redhat.yml
@@ -1,0 +1,7 @@
+---
+- name: "Install system packages for utility scripts (RedHat)"
+  yum:
+    name:
+      - 'libpqxx'
+      - 'libpqxx-devel'
+    state: latest

--- a/roles/galaxy-utils/tasks/main.yml
+++ b/roles/galaxy-utils/tasks/main.yml
@@ -1,12 +1,8 @@
 # Install utilities
 ---
 
-- name: "Install system packages for utility scripts"
-  yum:
-    name:
-      - 'libpqxx'
-      - 'libpqxx-devel'
-    state: latest
+- include: "dependencies_redhat.yml"
+  when: ansible_distribution == "Scientific" or ansible_distribution == "CentOS"
 
 # Need latest setuptools to install nebulizer
 # Error looks like the one reported here:

--- a/roles/galaxy-utils/tasks/main.yml
+++ b/roles/galaxy-utils/tasks/main.yml
@@ -13,10 +13,10 @@
     executable='{{ python_install_dir }}/bin/pip3'
     state=latest
 
-- name: Install dependencies for utilities
+- name: "Install pip dependencies for utilities"
   pip:
     name:
-      - "psycopg2==2.6.2"
+      - "psycopg2-binary"
       - "pyyaml"
     executable: '{{ python_install_dir }}/bin/pip3'
     state: present

--- a/roles/galaxy-utils/tasks/main.yml
+++ b/roles/galaxy-utils/tasks/main.yml
@@ -7,7 +7,7 @@
 # Need latest setuptools to install nebulizer
 # Error looks like the one reported here:
 # - https://github.com/rm-hull/luma.examples/issues/45
-- name: Install latest setuptools
+- name: "Install latest setuptools"
   pip:
     name="setuptools"
     executable='{{ python_install_dir }}/bin/pip3'
@@ -21,14 +21,14 @@
     executable: '{{ python_install_dir }}/bin/pip3'
     state: present
 
-- name: Install Nebulizer
+- name: "Install Nebulizer"
   pip:
     name='https://github.com/pjbriggs/nebulizer/archive/v{{ nebulizer_version }}.tar.gz'
     executable='{{ python_install_dir }}/bin/pip3'
     extra_args='--prefix {{ galaxy_utils_dir }} --no-binary :all:'
     state=present
 
-- name: Install utility scripts
+- name: "Install utility scripts"
   copy:
     src={{ item }}
     dest='{{ galaxy_utils_dir }}/bin/{{ item }}'


### PR DESCRIPTION
PR that updates the `galaxy-utils` role to work with Ubuntu as well as Scientific Linux/CentOS target platforms.