### PR TITLE
'python3' role: update to handle system dependency installation by non-root user

### DIFF
--- a/roles/python3/tasks/dependencies_redhat.yml
+++ b/roles/python3/tasks/dependencies_redhat.yml
@@ -21,3 +21,4 @@
       - 'libffi-devel'
       - 'tkinter'
     state: 'present'
+  when: python_user_id == "root"

--- a/roles/python3/tasks/dependencies_redhat.yml
+++ b/roles/python3/tasks/dependencies_redhat.yml
@@ -21,4 +21,4 @@
       - 'libffi-devel'
       - 'tkinter'
     state: 'present'
-  when: python_user_id == "root"
+  when: python_user_id.stdout == "root"

--- a/roles/python3/tasks/dependencies_ubuntu.yml
+++ b/roles/python3/tasks/dependencies_ubuntu.yml
@@ -22,4 +22,4 @@
       - 'zlib1g-dev'
     state: 'present'
     update_cache: yes
-  when: python_user_id == "root"
+  when: python_user_id.stdout == "root"

--- a/roles/python3/tasks/dependencies_ubuntu.yml
+++ b/roles/python3/tasks/dependencies_ubuntu.yml
@@ -22,3 +22,4 @@
       - 'zlib1g-dev'
     state: 'present'
     update_cache: yes
+  when: python_user_id == "root"

--- a/roles/python3/tasks/main.yml
+++ b/roles/python3/tasks/main.yml
@@ -2,6 +2,15 @@
 # Build and install Python 3 on the remote host
 # Also installs pip and virtualenv packages
 
+- name: "Get current user name"
+  command:
+    id -u -n
+  register: python_user_id
+
+- name: "Report current user name"
+  debug:
+    msg: "User from 'id' is {{ python_user_id.stdout }}"
+
 - name: "Set major.minor Python version"
   set_fact:
     python_major_minor_version: "{{ python_version.split('.')[:2] | join('.') }}"


### PR DESCRIPTION
PR which fixes a bug observed in some cases using the `python3` role to install Python for a non-root user, whereby the user executing the role doesn't have sufficient privileges to install the system dependencies (e.g. via `apt`).

The PR implements a workaround which involves acquiring the name of the current user via the `id` command, and then only attempting to install system dependencies if the user is `root`.

(It feels like there should be a more elegant solution using Ansible built-ins or facts, but I couldn't find one.)