### PR TITLE
'postgresql' role: update to work with newer versions of PostgreSQL server on Ubuntu

### DIFF
--- a/roles/postgresql/defaults/main.yml
+++ b/roles/postgresql/defaults/main.yml
@@ -1,0 +1,7 @@
+---
+# Set version to 'legacy' to install unversioned
+# PostgreSQL server
+# Otherwise set a specific version, see
+# https://www.postgresql.org/support/versioning/
+# for supported versions
+postgresql_version: "legacy"

--- a/roles/postgresql/files/pg_hba.conf
+++ b/roles/postgresql/files/pg_hba.conf
@@ -1,0 +1,21 @@
+##
+## This file is maintained by Ansible - CHANGES WILL BE OVERWRITTEN
+##
+
+# DO NOT DISABLE!
+# If you change this first entry you will need to make sure that the
+# database superuser can access the database using some other method.
+# Noninteractive access to all databases is required during automatic
+# maintenance (custom daily cronjobs, replication, and similar tasks).
+#
+# Database administrative login by Unix domain socket
+local   all             postgres                                peer
+
+# "local" is for Unix domain socket connections only
+local   all             all                                     md5
+
+# IPv4 local connections:
+host    all             all             127.0.0.1/32            md5
+
+# IPv6 local connections:
+host    all             all             ::1/128                 md5

--- a/roles/postgresql/tasks/main.yml
+++ b/roles/postgresql/tasks/main.yml
@@ -1,6 +1,10 @@
 ---
 # Install, configure and start PostgreSQL on remote server
 
+- name: "Report PostgreSQL version"
+  debug:
+    msg: "PostgreSQL version: '{{ postgresql_version }}'"
+
 - name: "Install PostgreSQL server"
   block:
     - name: "Install PostgreSQL server (Ubuntu)"

--- a/roles/postgresql/tasks/main.yml
+++ b/roles/postgresql/tasks/main.yml
@@ -1,47 +1,88 @@
 ---
 # Install, configure and start PostgreSQL on remote server
-- name: Install PostgreSQL server
-  yum:
-    name:
-      - postgresql
-      - postgresql-server
-    state: present
-  register: postgresql_installed
 
-- name: Check if PostgreSQL is initialised
-  stat: path=/var/lib/pgsql/data/postgresql.conf
-  register: postgresql_conf
+- name: "Install PostgreSQL server"
+  block:
+    - name: "Install PostgreSQL server (Ubuntu)"
+      block:
+        - name: "Install PostgreSQL signing key (Ubuntu)"
+          apt_key:
+            url: https://www.postgresql.org/media/keys/ACCC4CF8.asc
+            id: ACCC4CF8
 
-# ansible wants us to use the 'service' module for
-# this but it doesn't work for 'initdb'
-- name: Initialise PostgreSQL cluster
-  command:
-    service postgresql initdb
-  when: postgresql_conf.stat.exists == False
-  register: postgresql_initialised
+        - name: "Get PostgreSQL repository (Ubuntu)"
+          apt_repository:
+            repo: "deb http://apt.postgresql.org/pub/repos/apt/ {{ ansible_distribution_release }}-pgdg main"
+            update_cache: yes
 
-- name: Update PostgreSQL authentication for postgres user
-  lineinfile:
-    dest=/var/lib/pgsql/data/pg_hba.conf
-    line='local\tall\t    postgres\t\t\t      ident'
-    insertafter='^# "local" is for Unix domain socket connections only'
-    backup=yes
-  notify:
-    Restart PostgreSQL
+        - name: "Install PostgreSQL server (Ubuntu)"
+          apt:
+            pkg:
+              - "postgresql-client-{{ postgresql_version }}"
+              - "postgresql-{{ postgresql_version }}"
+              - "libpq-dev"
+              - "postgresql-server-dev-{{ postgresql_version }}"
+              - "postgresql-contrib"
+            state: present
+      - when: ansible_distribution == "Ubuntu"
 
-- name: Update PostgreSQL authentication for all other users
-  replace:
-    dest=/var/lib/pgsql/data/pg_hba.conf
-    regexp='^([^\s]+\s+all\s+all\s+.*)ident$'
-    replace='\1md5'
-  notify:
-    Restart PostgreSQL
+    - name: "Set up PostgreSQL user authentication (pg_hba.conf)"
+      copy:
+        src: 'pg_hba.conf'
+        dest: '/etc/postgresql/{{ postgresql_version }}/main/pg_hba.conf'
 
-- name: Start PostgreSQL service and enable on boot
-  service:
-    name=postgresql
-    state=started
-    enabled=yes
-  when: postgresql_initialised is success
-  register: postgresql_started
+    - name: "Start PostgreSQL service"
+      systemd:
+        name: "postgresql"
+        state: "restarted"
+        enabled: yes
+  when: postgresql_version != "legacy"
 
+- name: "Install PostgreSQL server (legacy)"
+  block:
+    - name: "Install PostgreSQL server (legacy version)"
+      yum:
+        name:
+          - "postgresql"
+          - "postgresql-server"
+        state: present
+      register: postgresql_installed
+      when: (ansible_distribution == "Scientific" or ansible_distribution == "CentOS") and ansible_distribution_major_version == "7"
+
+    - name: "Check if PostgreSQL is initialised"
+      stat: path="/var/lib/pgsql/data/postgresql.conf"
+      register: postgresql_conf
+
+    # ansible wants us to use the 'service' module for
+    # this but it doesn't work for 'initdb'
+    - name: "Initialise PostgreSQL database cluster"
+      command:
+        "service postgresql initdb"
+      when: postgresql_conf.stat.exists == False
+      register: postgresql_initialised
+
+    - name: "Update PostgreSQL authentication for postgres user"
+      lineinfile:
+        dest="/var/lib/pgsql/data/pg_hba.conf"
+        line='local\tall\t    postgres\t\t\t      ident'
+        insertafter='^# "local" is for Unix domain socket connections only'
+        backup=yes
+      notify:
+        "Restart PostgreSQL"
+
+    - name: "Update PostgreSQL authentication for all other users"
+      replace:
+        dest="/var/lib/pgsql/data/pg_hba.conf"
+        regexp='^([^\s]+\s+all\s+all\s+.*)ident$'
+        replace='\1md5'
+      notify:
+        "Restart PostgreSQL"
+
+    - name: "Start PostgreSQL service and enable on boot"
+      service:
+        name=postgresql
+        state=started
+        enabled=yes
+      when: postgresql_initialised is success
+      register: postgresql_started
+  when: postgresql_version == "legacy"

--- a/roles/postgresql/tasks/main.yml
+++ b/roles/postgresql/tasks/main.yml
@@ -24,7 +24,7 @@
               - "postgresql-server-dev-{{ postgresql_version }}"
               - "postgresql-contrib"
             state: present
-      - when: ansible_distribution == "Ubuntu"
+      when: ansible_distribution == "Ubuntu"
 
     - name: "Set up PostgreSQL user authentication (pg_hba.conf)"
       copy:


### PR DESCRIPTION
PR which updates the `postgresql` role to work with Ubuntu hosts, and at the same time enable installation of specific versions of PostgreSQL (from version 10 onwards).

A "legacy" version option is also supported which preserves the original functionality; at present this is only known to work for Scientific Linux and CentOS platforms (and won't work with Ubuntu).