### PR TITLE
'galaxy-utils' role: improvements for handling local tool and data configuration

### DIFF
--- a/roles/galaxy-install-tools/default/main.yml
+++ b/roles/galaxy-install-tools/default/main.yml
@@ -31,9 +31,14 @@ galaxy_tools: null
 #        tool_files:
 #          - "tools/venn_diagram/cistrome_venn_diagram.xml"
 #          - "tools/venn_diagram/cistrome_venn_diagram.py"
+#        section:
+#          name: "ChIP-seq"
+#          id: "ngs-chip-seq"
 #      - name: ...
-#        tool_file:
+#        tool_files:
 #          - ... etc
+# NB the 'section' is optional; if omitted then the tool
+# will appear in the top-level of the tool panel
 local_galaxy_tools: null
 
 # Data tables

--- a/roles/galaxy-install-tools/handlers/main.yml
+++ b/roles/galaxy-install-tools/handlers/main.yml
@@ -1,0 +1,4 @@
+---
+- name: "Restart Galaxy"
+  command:
+    "{{ galaxy_utils_dir }}/bin/gxctl.sh restart {{ galaxy_name }}"

--- a/roles/galaxy-install-tools/tasks/main.yml
+++ b/roles/galaxy-install-tools/tasks/main.yml
@@ -23,57 +23,62 @@
   when: galaxy_tools|default(None) != None
 
 # Local tools
-- name: "Create directories for local tool files"
-  file:
-    path='{{ galaxy_dir }}/local_tools/{{ item.name }}'
-    state=directory
-    mode='ugo+rX'
-  with_items: "{{ local_galaxy_tools }}"
-  become: yes
-  become_user: "{{ galaxy_user }}"
-  when: local_galaxy_tools|default(None) != None
+- name: "Install local tools"
+  block:
+    - name: "Create directories for local tool files"
+      file:
+        path='{{ galaxy_dir }}/local_tools/{{ item.name }}'
+        state=directory
+        mode='ugo+rX'
+      with_items: "{{ local_galaxy_tools }}"
+      become: yes
+      become_user: "{{ galaxy_user }}"
+      when: local_galaxy_tools|default(None) != None
 
-- name: "Install local tool files"
-  copy:
-    src='{{ item.1 }}'
-    dest='{{ galaxy_dir }}/local_tools/{{ item.0.name }}/{{ item.1 | basename }}'
-  with_subelements:
-    - '{{ local_galaxy_tools }}'
-    - 'tool_files'
-  become: yes
-  become_user: "{{ galaxy_user }}"
-  when: local_galaxy_tools|default(None) != None
+    - name: "Install local tool files"
+      copy:
+        src='{{ item.1 }}'
+        dest='{{ galaxy_dir }}/local_tools/{{ item.0.name }}/{{ item.1 | basename }}'
+      with_subelements:
+        - '{{ local_galaxy_tools }}'
+        - 'tool_files'
+      become: yes
+      become_user: "{{ galaxy_user }}"
+      when: local_galaxy_tools|default(None) != None
 
-- name: "Build tool_conf XML file for local tools"
-  template:
-    dest='{{ galaxy_root }}/config/local_tool_conf.xml'
-    src=local_tool_conf.xml.j2
+    - name: "Build tool_conf XML file for local tools"
+      template:
+        dest='{{ galaxy_root }}/config/local_tool_conf.xml'
+        src=local_tool_conf.xml.j2
+      notify:
+        - "Restart Galaxy"
   become: yes
   become_user: "{{ galaxy_user }}"
   when: local_galaxy_tools|default(None) != None
 
 # Create .loc files from samples
-- name: "Create loc files from sample versions"
-  copy:
-    src='{{ galaxy_root }}/tool-data/{{ item.loc_file }}.sample'
-    dest='{{ galaxy_root }}/tool-data/{{ item.loc_file }}'
-    remote_src=True
-  with_items:
-    - '{{ galaxy_loc_file_data }}'
-  become: yes
-  become_user: "{{ galaxy_user }}"
-  when: galaxy_loc_file_data|default(None) != None
+- name: "Create and populate loc files"
+  block:
+    - name: "Create loc files from sample versions"
+      copy:
+        src='{{ galaxy_root }}/tool-data/{{ item.loc_file }}.sample'
+        dest='{{ galaxy_root }}/tool-data/{{ item.loc_file }}'
+        remote_src=True
+      with_items:
+        - '{{ galaxy_loc_file_data }}'
 
-# Update the reference data
-- name: "Update tool data in loc files"
-  lineinfile:
-    path='{{ galaxy_root }}/tool-data/{{ item.0.loc_file }}'
-    state=present
-    create=no
-    line="{{ item.1 }}"
-  with_subelements:
-    - '{{ galaxy_loc_file_data }}'
-    - 'data'
+    # Update the reference data
+    - name: "Update tool data in loc files"
+      lineinfile:
+        path='{{ galaxy_root }}/tool-data/{{ item.0.loc_file }}'
+        state=present
+        create=no
+        line="{{ item.1 }}"
+      with_subelements:
+        - '{{ galaxy_loc_file_data }}'
+        - 'data'
+      notify:
+        - "Restart Galaxy"
   become: yes
   become_user: "{{ galaxy_user }}"
   when: galaxy_loc_file_data|default(None) != None

--- a/roles/galaxy-install-tools/templates/local_tool_conf.xml.j2
+++ b/roles/galaxy-install-tools/templates/local_tool_conf.xml.j2
@@ -1,12 +1,21 @@
 <?xml version="1.0"?>
+<!--
+This file is maintained by Ansible - CHANGES WILL BE OVERWRITTEN
+-->
 <toolbox tool_path="../local_tools">
 {% if local_galaxy_tools is not none %}
-{% for tool in local_galaxy_tools %}
-{% for tool_file in tool.tool_files %}
-{% if tool_file.endswith(".xml") %}
-  <tool file="{{ tool.name }}/{{ tool_file | basename }}" />
-{% endif %}
-{% endfor %}
-{% endfor %}
+  {% for tool in local_galaxy_tools %}
+     {% if "section" in tool %}
+<section id="{{ tool.section.id }}" name="{{ tool.section.name }}">
+     {% endif %}
+     {% for tool_file in tool.tool_files %}
+        {% if tool_file.endswith(".xml") %}
+<tool file="{{ tool.name }}/{{ tool_file | basename }}" />
+        {% endif %}
+     {% endfor %}
+     {%if "section" in tool %}
+</section>
+     {% endif %}
+  {% endfor %}
 {% endif %}
 </toolbox>


### PR DESCRIPTION
PR which implements improvements to the `galaxy-utils` role:

* Adds a handler to restart Galaxy service after configuration of local tools and data
* Allows local tools to be installed in a specific tool panel section