### PR TITLE
'galaxy-user' role: explicitly set shell to /bin/bash

### DIFF
--- a/roles/galaxy-user/tasks/main.yml
+++ b/roles/galaxy-user/tasks/main.yml
@@ -10,4 +10,5 @@
     group={{ galaxy_group }}
     home=/home/{{ galaxy_user }}
     uid={{ galaxy_uid }}
+    shell="/bin/bash"
     state=present


### PR DESCRIPTION
PR that updates the `galaxy-user` role to explicitly set the shell to `/bin/bash` (for some platforms `/bin/sh` was used instead).