### PR TITLE
Centaurus: update Python versions and configure SMTP server

### DIFF
--- a/centaurus.yml
+++ b/centaurus.yml
@@ -2,13 +2,16 @@
 - hosts: centaurus
 
   vars:
+  # Ubuntu doesn't have Python2 by default
+  # See e.g. https://www.toptechskills.com/ansible-tutorials-courses/how-to-fix-usr-bin-python-not-found-error-tutorial/
+  - ansible_python_interpreter: /usr/bin/python3
   # Galaxy user and group on system
   - galaxy_user: "centaurus-galaxy"
   - galaxy_uid: 22223
   - galaxy_group: "galaxy"
   - galaxy_gid: 400
   # System Python and PostgreSQL versions
-  - python_version: "3.6.11"
+  - python_version: "3.10.5"
   - postgresql_version: "14"
   # Base installation directory
   - galaxy_install_dir: "/mnt/rvmi/centaurus/galaxy"

--- a/instances/centaurus/devel.yml
+++ b/instances/centaurus/devel.yml
@@ -11,7 +11,7 @@ galaxy_job_working_dir: "/mnt/bmh01-rvmi/bcf-galaxy/centaurus/devel/job_working_
 galaxy_data_manager_data_path: "/mnt/bmh01-rvmi/bcf-galaxy/centaurus/devel/tool-data"
 
 # Galaxy-specific Python installation
-galaxy_python_version: "3.6.11"
+galaxy_python_version: "3.8.13"
 
 # Account management
 allow_user_creation: no

--- a/instances/centaurus/devel.yml
+++ b/instances/centaurus/devel.yml
@@ -41,7 +41,9 @@ galaxy_new_file_path: "{{ galaxy_install_dir }}/tmp"
 enable_quotas: yes
 
 # Email
-galaxy_outgoing_email_addr: "Centaurus Galaxy <galaxy-no-reply@{{ galaxy_server_name  }}>"
+postfix_host_name: "{{ galaxy_server_name }}"
+postfix_relay_host: "[smtp.manchester.ac.uk]"
+galaxy_outgoing_email_addr: "Centaurus-dev Galaxy <galaxy-no-reply@{{ galaxy_server_name  }}>"
 galaxy_incoming_email_addr: "{{ galaxy_admin_user }}"
 
 # FTP upload

--- a/instances/centaurus/production.yml
+++ b/instances/centaurus/production.yml
@@ -41,6 +41,8 @@ galaxy_new_file_path: "{{ galaxy_install_dir }}/tmp"
 enable_quotas: yes
 
 # Email
+postfix_host_name: "{{ galaxy_server_name }}"
+postfix_relay_host: "[smtp.manchester.ac.uk]"
 galaxy_outgoing_email_addr: "Centaurus Galaxy <galaxy-no-reply@{{ galaxy_server_name  }}>"
 galaxy_incoming_email_addr: "{{ galaxy_admin_user }}"
 

--- a/instances/centaurus/production.yml
+++ b/instances/centaurus/production.yml
@@ -11,7 +11,7 @@ galaxy_job_working_dir: "/mnt/bmh01-rvmi/bcf-galaxy/centaurus/production/job_wor
 galaxy_data_manager_data_path: "/mnt/bmh01-rvmi/bcf-galaxy/centaurus/production/tool-data"
 
 # Galaxy-specific Python installation
-galaxy_python_version: "3.6.11"
+galaxy_python_version: "3.8.13"
 
 # Account management
 allow_user_creation: no


### PR DESCRIPTION
PR which implements updates for deploying the Centaurus 'production' and 'devel' instances:

* Python version for system set to 3.10.5
* Python version for Galaxy set to 3.8.13 (highest version that appears to enable Galaxy 20.09 to be installed)
* SMTP configuration details added