### PR TITLE
'galaxy-user' role: allow additional groups for Galaxy user

### DIFF
--- a/roles/galaxy-user/defaults/main.yml
+++ b/roles/galaxy-user/defaults/main.yml
@@ -4,3 +4,11 @@ galaxy_user: "galaxy"
 galaxy_uid: 400
 galaxy_group: "{{ galaxy_user }}"
 galaxy_gid: 400
+
+# Additional groups to create and add Galaxy user to
+# If set then should be a list with each item being
+# a dictionary with keys 'group' and 'gid' e.g.
+# extra_groups:
+#      - group: "ls-bcf"
+#        gid: 337111
+extra_groups:

--- a/roles/galaxy-user/tasks/main.yml
+++ b/roles/galaxy-user/tasks/main.yml
@@ -12,3 +12,19 @@
     uid={{ galaxy_uid }}
     shell="/bin/bash"
     state=present
+
+- name: "Create additional groups"
+  group:
+    name: "{{ item.group }}"
+    gid: "{{ item.gid }}"
+    state: present
+  with_items: "{{ extra_groups }}"
+  when: extra_groups|default(None) != None
+
+- name: "Add Galaxy user to additional groups"
+  user:
+    name: "{{ galaxy_user }}"
+    groups: "{{ item.group }}"
+    append: yes
+  with_items: "{{ extra_groups }}"
+  when: extra_groups|default(None) != None


### PR DESCRIPTION
Update the `galaxy-user` role to allow additional system groups to be specified and added to the Galaxy system user.