### PR TITLE
'galaxy' role: explicitly create shed_tool_conf.xml file

### DIFF
--- a/roles/galaxy/tasks/galaxy.yml
+++ b/roles/galaxy/tasks/galaxy.yml
@@ -176,6 +176,12 @@
     remote_src=yes
   when: galaxy_tool_conf_file|default(None) == None
 
+- name: "Create empty shed_tool_conf.xml"
+  copy:
+    content='<?xml version="1.0"?>\n<toolbox tool_path="../shed_tools">\n</toolbox>\n'
+    dest='{{ galaxy_root }}/config/shed_tool_conf.xml'
+    force=no
+
 - name: "Create empty local_tool_conf.xml"
   copy:
     content='<?xml version="1.0"?>\n<toolbox tool_path="../local_tools">\n</toolbox>\n'


### PR DESCRIPTION
Update to `galaxy` role to explicitly create an empty `shed_tool_conf.xml` file if one doesn't exist, and specify the tool installation directory as `../shed_tools` i.e. parallel directory to the Galaxy source code install directory.