### PR TITLE
'galaxy' role: add support for environment setup file

### DIFF
--- a/roles/galaxy/defaults/main.yml
+++ b/roles/galaxy/defaults/main.yml
@@ -30,6 +30,9 @@ galaxy_welcome_template: "welcome.html.j2"
 galaxy_terms:
 galaxy_citations:
 
+# Environment setup file
+galaxy_environment_setup_file:
+
 # (S)CSS styles/custom colours
 # Define entries as a dictionary with:
 # - var   (SCSS variable e.g. 'brand-primary')

--- a/roles/galaxy/tasks/galaxy.yml
+++ b/roles/galaxy/tasks/galaxy.yml
@@ -136,6 +136,12 @@
         state: absent
   when: galaxy_conda.stat.exists == False
 
+- name: "Add environment setup file"
+  copy:
+    dest='{{ galaxy_dir }}/environment_setup.sh'
+    src='{{ galaxy_environment_setup_file }}'
+  when: galaxy_environment_setup_file|default(None) != None
+
 - name: Create Galaxy configuration file
   template:
     dest='{{ galaxy_root }}/config/galaxy.yml'

--- a/roles/galaxy/templates/galaxy-config.yml.j2
+++ b/roles/galaxy/templates/galaxy-config.yml.j2
@@ -1680,7 +1680,11 @@ galaxy:
   # prior to running tools.  This can be especially useful for running
   # jobs as the actual user, to remove the need to configure each user's
   # environment individually.
+{% if galaxy_environment_setup_file|default(None) != None %}
+  environment_setup_file: {{ galaxy_dir }}/environment_setup.sh
+{% else %}
   #environment_setup_file: null
+{% endif %}
 
   # Optional file containing job resource data entry fields definition.
   # These fields will be presented to users in the tool forms and allow


### PR DESCRIPTION
Update the `galaxy` role to add support for the Galaxy environment setup file: if specified then this is sourced by Galaxy each time a job is run, and can be used to set environment variables for running jobs.