### PR TITLE
'galaxy' role: enable reinstallation of existing conda

### DIFF
--- a/roles/galaxy/defaults/main.yml
+++ b/roles/galaxy/defaults/main.yml
@@ -100,6 +100,7 @@ galaxy_python_dir: '{{ galaxy_dir }}/python/{{ galaxy_python_version }}'
 enable_tool_shed_check: no
 
 # Conda options
+galaxy_reinstall_conda: no
 galaxy_conda_auto_install: yes
 
 # Dependency caching options

--- a/roles/galaxy/tasks/galaxy.yml
+++ b/roles/galaxy/tasks/galaxy.yml
@@ -117,6 +117,22 @@
     path: "{{ galaxy_tool_dependency_dir }}/_conda/bin/conda"
   register: galaxy_conda
 
+- name: "Prepare for reinstallation of conda"
+  block:
+    - name: "Move existing conda environments directory"
+      shell:
+        test -d {{ galaxy_tool_dependency_dir }}/_conda/envs && test ! -d {{ galaxy_tool_dependency_dir }}/conda_envs.bak && mv {{ galaxy_tool_dependency_dir }}/_conda/envs {{ galaxy_tool_dependency_dir }}/conda_envs.bak
+
+    - name: "Move existing conda packages directory"
+      shell:
+        test -d {{ galaxy_tool_dependency_dir }}/_conda/pkgs && test ! -d {{ galaxy_tool_dependency_dir }}/conda_pkgs.bak && mv {{ galaxy_tool_dependency_dir }}/_conda/pkgs {{ galaxy_tool_dependency_dir }}/conda_pkgs.bak
+
+    - name: "Remove existing conda installation"
+      file:
+        path: '{{ galaxy_tool_dependency_dir }}/_conda'
+        state: absent
+  when: galaxy_conda.stat.exists == True and galaxy_reinstall_conda == True
+
 - name: "Install conda"
   block:
     # See https://docs.conda.io/en/latest/miniconda.html#linux-installers
@@ -134,7 +150,22 @@
       file:
         path: '{{ galaxy_tool_dependency_dir }}/miniconda.sh'
         state: absent
-  when: galaxy_conda.stat.exists == False
+  when: galaxy_conda.stat.exists == False or galaxy_reinstall_conda == True
+
+- name: "Reinstate old conda environments and packages"
+  block:
+    - name: "Reinstate old conda environments"
+      shell:
+        test -d {{ galaxy_tool_dependency_dir }}/conda_envs.bak && rmdir {{ galaxy_tool_dependency_dir }}/_conda/envs && mv {{ galaxy_tool_dependency_dir }}/conda_envs.bak {{ galaxy_tool_dependency_dir }}/_conda/envs
+
+    - name: "Reinstate old conda packages"
+      shell:
+        test -d {{ galaxy_tool_dependency_dir }}/conda_pkgs.bak && rm -rf {{ galaxy_tool_dependency_dir }}/_conda/pkgs && mv {{ galaxy_tool_dependency_dir }}/conda_pkgs.bak {{ galaxy_tool_dependency_dir }}/_conda/pkgs
+
+    - name: "Update the reinstated packages"
+      shell:
+        {{ galaxy_tool_dependency_dir }}/_conda/bin/conda update -y --all
+  when: galaxy_conda.stat.exists == True and galaxy_reinstall_conda == True
 
 - name: "Add environment setup file"
   copy:


### PR DESCRIPTION
Update `galaxy` role to enable an existing `conda` installation to be removed and reinstalled, while preserving previously installed environments.