### PR TITLE
'galaxy' role: update configuration of limits in job_conf.xml

### DIFF
--- a/inventories/cetus/production.yml
+++ b/inventories/cetus/production.yml
@@ -18,22 +18,27 @@ cetus:
       - id: "jse_drop_serial"
         runner: "jse_drop"
         jse_drop_qsub_options: "-V -j n"
+        total_concurrent_jobs: 12
       - id: "jse_drop_smp_4"
         runner: "jse_drop"
         jse_drop_qsub_options: "-V -j n -pe smp.pe 4"
         jse_drop_slots: "4"
+        total_concurrent_jobs: 12
       - id: "jse_drop_smp_6"
         runner: "jse_drop"
         jse_drop_qsub_options: "-V -j n -pe smp.pe 6"
         jse_drop_slots: "6"
+        total_concurrent_jobs: 8
       - id: "jse_drop_smp_8"
         runner: "jse_drop"
         jse_drop_qsub_options: "-V -j n -pe smp.pe 8"
         jse_drop_slots: "8"
+        total_concurrent_jobs: 4
       - id: "jse_drop_smp_12"
         runner: "jse_drop"
         jse_drop_qsub_options: "-V -j n -pe smp.pe 12"
         jse_drop_slots: "12"
+        total_concurrent_jobs: 2
     galaxy_tool_destinations:
       - id: "bowtie_wrapper"
         destination: "jse_drop_smp_4"

--- a/roles/galaxy/defaults/main.yml
+++ b/roles/galaxy/defaults/main.yml
@@ -159,7 +159,11 @@ galaxy_jse_drop_cleanup_grace_period: "600"
 # - runner (target runner)
 # - jse_drop_qsub_options (optional, JSE-drop 'qsub_options')
 # - jse_drop_slots (optional, JSE-drop 'galaxy_slots')
-# - envs (optional dictionary defining <env...> elements)
+# - envs (optional dictionary defining <env...> elements, see below)
+# - user_concurrent_jobs (optional; sets maximum number of concurrent
+#                         jobs per user for this destination)
+# - total_concurrent_jobs (optional; sets total maximum number of
+#                          concurrent jobs for this destination))
 # 'envs' should be a dictionary with:
 # - id     (ID for env element)
 # - value  (corresponding env value)

--- a/roles/galaxy/templates/job_conf.xml.j2
+++ b/roles/galaxy/templates/job_conf.xml.j2
@@ -53,9 +53,23 @@
     </tools>
 {% endif %}
     <limits>
-        <limit type="registered_user_concurrent_jobs">{{ galaxy_registered_user_concurrent_jobs }}</limit>
-        <limit type="unregistered_user_concurrent_jobs">{{ galaxy_unregistered_user_concurrent_jobs }}</limit>
-        <limit type="job_walltime">24:00:00</limit>
-        <limit type="concurrent_jobs" id="local">{{ galaxy_concurrent_jobs }}</limit>
+{% if galaxy_job_destinations %}
+{% for dest in galaxy_job_destinations %}
+{% if dest.user_concurrent_jobs is defined %}
+      <limit type="destination_user_concurrent_jobs" id="{{ dest.id }}">{{ dest.user_concurrent_jobs }}</limit>
+{% endif %}
+{% if dest.total_concurrent_jobs is defined %}
+      <limit type="destination_total_concurrent_jobs" id="{{ dest.id }}">{{ dest.total_concurrent_jobs }}</limit>
+{% endif %}
+{% endfor %}
+{% endif %}
+{% if galaxy_registered_user_concurrent_jobs is defined %}
+      <limit type="registered_user_concurrent_jobs">{{ galaxy_registered_user_concurrent_jobs }}</limit>
+{% endif %}
+{% if galaxy_unregistered_user_concurrent_jobs is defined %}
+      <limit type="unregistered_user_concurrent_jobs">{{ galaxy_unregistered_user_concurrent_jobs }}</limit>
+{% endif %}
+      <limit type="job_walltime">24:00:00</limit>
+      <limit type="concurrent_jobs" id="local">{{ galaxy_concurrent_jobs }}</limit>
     </limits>
 </job_conf>


### PR DESCRIPTION
Updates the `galaxy` role for compatibility with latest version of `<limits>` section in `job_conf.xml`, and allow more flexibility in assigning maximum numbers of jobs per job destination.

The definition of job destinations has been extended to allow two new optional settings `user_concurrent_jobs` and `total_concurrent_jobs`, which if present will be written to the `job_conf.xml` as e.g.

    <limit type="destination_user_concurrent_jobs" id="jse_drop_serial">4</limit>

and

    <limit type="destination_total_concurrent_jobs" id="jse_drop_smp_pe_12">2</limit>

Also updates the inventory for the production instance of the Cetus Galaxy instance to set per-destination limits for total numbers of concurrent jobs.