### PR TITLE
'galaxy' role: add support for mamba to resolve conda dependencies

### DIFF
--- a/roles/galaxy/defaults/main.yml
+++ b/roles/galaxy/defaults/main.yml
@@ -102,6 +102,7 @@ enable_tool_shed_check: no
 # Conda options
 galaxy_reinstall_conda: no
 galaxy_conda_auto_install: yes
+galaxy_conda_use_mamba: no
 
 # Dependency caching options
 galaxy_use_cached_depedency_manager: no

--- a/roles/galaxy/tasks/galaxy.yml
+++ b/roles/galaxy/tasks/galaxy.yml
@@ -167,6 +167,19 @@
         "{{ galaxy_tool_dependency_dir }}/_conda/bin/conda update -y --all"
   when: galaxy_conda.stat.exists == True and galaxy_reinstall_conda == True
 
+- name: "Use mamba to resolve conda dependencies"
+  block:
+    - name: "Check if mamba is already installed"
+      stat:
+        path: '{{ galaxy_tool_dependency_dir }}/_conda/bin/mamba'
+      register: mamba
+
+    - name: "Install mamba into conda base environment"
+      shell:
+        "{{ galaxy_tool_dependency_dir }}/_conda/bin/conda install -y mamba -n base -c conda-forge"
+      when: mamba.stat.exists == False
+  when: galaxy_conda_use_mamba == True
+
 - name: "Add environment setup file"
   copy:
     dest='{{ galaxy_dir }}/environment_setup.sh'

--- a/roles/galaxy/templates/galaxy-config.yml.j2
+++ b/roles/galaxy/templates/galaxy-config.yml.j2
@@ -233,7 +233,11 @@ galaxy:
 
   # Override the Conda executable to use, it will default to the one on
   # the PATH (if available) and then to <conda_prefix>/bin/conda
+{% if galaxy_conda_use_mamba %}
+  conda_exec: {{ galaxy_tool_dependency_dir }}/_conda/bin/mamba
+{% else %}
   #conda_exec: null
+{% endif %}
 
   # Pass debug flag to conda commands.
   #conda_debug: false


### PR DESCRIPTION
Update to the `galaxy` role which adds an option to use `mamba` instead of `conda` when resolving tool dependencies. The option is turned on by specifying `galaxy_conda_use_mamba = yes` in the playbooks (by default `mamba` is not used).

More information on `mamba` as a drop-in replacement for `conda` can be found at https://mamba.readthedocs.io/en/latest/index.html.