### PR TITLE
Add parameter to set interval for clean up job in 'galaxy' role

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -176,6 +176,10 @@ Other configuration settings:
  - ``email_audit_reports_to``: list of space-separated email
    to send weekly audit reports to (default: don't send
    reports to anyone)
+ - ``galaxy_clean_up_cron_interval``: sets the time interval
+   (in days) before files, links and directories are removed
+   from the job working directory (and JSE-Drop directory,
+   if in use) (default: 28 days)
 
 Tools:
 

--- a/roles/galaxy/defaults/main.yml
+++ b/roles/galaxy/defaults/main.yml
@@ -126,6 +126,10 @@ galaxy_tool_conf_file:
 # Should be 'always', 'onsuccess', or 'never'
 galaxy_cleanup_job: "always"
 
+# Number of days before artefacts in job working
+# directory are removed by cron jobs
+galaxy_clean_up_cron_interval: 28
+
 # Allow admins to paste filesystem paths during upload
 galaxy_allow_path_paste: no
 

--- a/roles/galaxy/tasks/cleanup.yml
+++ b/roles/galaxy/tasks/cleanup.yml
@@ -38,10 +38,14 @@
     state: present
   with_items:
     - { name: "{{ galaxy_name }} clean up files from job working directory",
-        job: "find {{ galaxy_job_working_dir }} -mindepth 2 -type f -mtime +28 -exec rm -rf {} \\;",
+        job: "find {{ galaxy_job_working_dir }} -mindepth 2 -type f -mtime +{{ galaxy_clean_up_cron_interval }} -exec rm -rf {} \\;",
+        hour: 00,
+        minute: 10 }
+    - { name: "{{ galaxy_name }} clean up links from job working directory",
+        job: "find {{ galaxy_job_working_dir }} -mindepth 2 -type l -mtime +{{ galaxy_clean_up_cron_interval }} -exec rm -rf {} \\;",
         hour: 00,
         minute: 10 }
     - { name: "{{ galaxy_name }} clean up empty directories from job working directory",
-        job: "find {{ galaxy_job_working_dir }} -mindepth 2 -type d -mtime +28 -empty -exec rmdir {} \\;",
+        job: "find {{ galaxy_job_working_dir }} -mindepth 2 -type d -mtime +{{ galaxy_clean_up_cron_interval }} -empty -exec rmdir {} \\;",
         hour: 00,
         minute: 15 }

--- a/roles/galaxy/tasks/jsedrop.yml
+++ b/roles/galaxy/tasks/jsedrop.yml
@@ -22,7 +22,7 @@
     name='Remove old JSE-drop .qsub files'
     hour=05
     minute=00
-    job='find {{ galaxy_jse_drop_dir }} -name "*.qsub" -type f -mtime +28 -exec rm -f {} \;'
+    job='find {{ galaxy_jse_drop_dir }} -name "*.qsub" -type f -mtime +{{ galaxy_clean_up_cron_interval }} -exec rm -f {} \;'
     state=present
 
 - name: Clean up other files from JSE-drop directory
@@ -31,7 +31,7 @@
     name='Remove all other old JSE-drop files'
     hour=05
     minute=00
-    job='find {{ galaxy_jse_drop_dir }} -name "*" -type f -mtime +28 -exec rm -f {} \;'
+    job='find {{ galaxy_jse_drop_dir }} -name "*" -type f -mtime +{{ galaxy_clean_up_cron_interval }} -exec rm -f {} \;'
     state=present
 
 - name: "Clean up deleted files from JSE-drop directory"


### PR DESCRIPTION
Adds a parameter (`galaxy_clean_up_cron_interval`) to the `galaxy` role, to set the interval (in days) before clean up `cron`  jobs will remove files, links and empty directories from the job working directory and JSE-Drop areas.