### PR TITLE
'galaxy' role: add options to force reinstall of Galaxy-specific Python & virtual env

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -398,9 +398,24 @@ targetting the new VM, then the Postgres Galaxy database can be
 initialised with the SQL dump from the old one by specifying the
 path to the ``.sql`` file via the ``galaxy_new_db_sql`` parameter.
 
+.. note::
+
+   The SQL file should be on the remote machine (where Galaxy is
+   installed), not the local one (where the playbooks are being
+   run from).
+
 ``conda`` can also be reinstalled while preserving any existing
 environments that were installed on the old VM, by setting the
 ``galaxy_reinstall_conda`` parameter to ``true``.
+
+If the new VM is a different OS to the old one then it's also
+recommended to force reinstallation of the Galaxy-specific
+Python and the Galaxy virtual environment, by specifiying:
+
+::
+
+   galaxy_force_reinstall_python: yes
+   galaxy_force_reinstall_venv: yes
 
 Notes on the deployment
 -----------------------

--- a/roles/galaxy/defaults/main.yml
+++ b/roles/galaxy/defaults/main.yml
@@ -98,6 +98,7 @@ galaxy_data_manager_data_path: "{{ galaxy_tool_data_path }}"
 # Python for Galaxy
 galaxy_python_version: "3.6.11"
 galaxy_python_dir: '{{ galaxy_dir }}/python/{{ galaxy_python_version }}'
+galaxy_force_reinstall_python: no
 
 # Toolshed check
 enable_tool_shed_check: no

--- a/roles/galaxy/defaults/main.yml
+++ b/roles/galaxy/defaults/main.yml
@@ -103,6 +103,9 @@ galaxy_force_reinstall_python: no
 # Toolshed check
 enable_tool_shed_check: no
 
+# Virtualenv options
+galaxy_force_reinstall_venv: no
+
 # Conda options
 galaxy_reinstall_conda: no
 galaxy_conda_auto_install: yes

--- a/roles/galaxy/tasks/remove_legacy_artefacts.yml
+++ b/roles/galaxy/tasks/remove_legacy_artefacts.yml
@@ -39,3 +39,10 @@
     path: '{{ galaxy_python_dir }}'
     state: absent
   when: galaxy_force_reinstall_python == True
+
+# Remove Galaxy virtualenv
+- name: "Remove Galaxy virtual env"
+  file:
+    path: '{{ galaxy_root }}/.venv'
+    state: absent
+  when: galaxy_force_reinstall_venv == True

--- a/roles/galaxy/tasks/remove_legacy_artefacts.yml
+++ b/roles/galaxy/tasks/remove_legacy_artefacts.yml
@@ -32,3 +32,10 @@
     user="root"
     name="Renew SSL certificate from Lets Encrypt"
     state=absent
+
+# Remove Python
+- name: "Remove Galaxy Python installation"
+  file:
+    path: '{{ galaxy_python_dir }}'
+    state: absent
+  when: galaxy_force_reinstall_python == True


### PR DESCRIPTION
Adds new parameters to the `galaxy` role to force reinstallation of the Galaxy-specific Python (set `galaxy_force_reinstall_python: yes`) and the Galaxy virtual environment (set `galaxy_force_reinstall_venv: yes`).

These options are only really needed when migrating a Galaxy instance to a new VM which has a different OS to the original one; the relevant section of the `README` has been updated to reflect this.