### PR TITLE
roles/galaxy-utils: fix 'gx_monitor.py' to handle missing directories

### DIFF
--- a/roles/galaxy-utils/files/gx_monitor.py
+++ b/roles/galaxy-utils/files/gx_monitor.py
@@ -141,6 +141,8 @@ def split_db_connection(database_connection):
     return (name,user,passwd)
 
 def disk_usage(d):
+    if not os.path.exists(d):
+        return "not found"
     usage = shutil.disk_usage(d)
     return "%.1f%% (%s/%s)" % (float(usage.used)/float(usage.total)*100.0,
                                pretty_print_usage(usage.used),


### PR DESCRIPTION
Fix to the `gx_monitor.py` script to handle the case when the specified directories are not found (e.g. the job working directory may not exist if no jobs have been run via the Galaxy instance etc).