### PR TITLE
WIP migrate Palfinder to Ubuntu 20.04 and upgrade to Galaxy 20.09

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -34,11 +34,10 @@ Vagrant.configure(VAGRANT_API_VERSION) do |config|
   end
   # Palfinder VM
   config.vm.define "palfinder" do |palfinder|
-    palfinder.vm.box = "ringo/scientific-linux-6.5"
+    palfinder.vm.box = "ubuntu/focal64"
     palfinder.vm.hostname = "palfinder"
     palfinder.vm.network :private_network, ip: "192.168.60.4"
     palfinder.vm.provision "shell", inline: <<-SHELL
-    service iptables stop
     mkdir -p /mnt/rvmi
     chmod ugo+rwX /mnt/rvmi/
   SHELL

--- a/instances/palfinder/galaxy_config.yml
+++ b/instances/palfinder/galaxy_config.yml
@@ -19,6 +19,10 @@ enable_beta_gdpr: yes
 galaxy_http_port: "8080"
 galaxy_uwsgi_socket: "4001"
 
+# uWSGI and handler configuration
+galaxy_uwsgi_processes: 8
+galaxy_handler_processes: 1
+
 # Users
 galaxy_admin_user: "admin@galaxy.org"
 galaxy_users:
@@ -29,6 +33,11 @@ galaxy_users:
 enable_jse_drop: yes
 galaxy_jse_drop_dir: "{{ galaxy_install_dir }}/palfinder/jse-drop-csf3"
 galaxy_jse_drop_galaxy_id: "{{ galaxy_name }}"
+
+# Concurrent jobs
+galaxy_registered_user_concurrent_jobs: 8
+galaxy_unregistered_user_concurrent_jobs: 0
+galaxy_concurrent_jobs: 8
 
 # Quotas
 enable_quotas: yes

--- a/instances/palfinder/galaxy_config.yml
+++ b/instances/palfinder/galaxy_config.yml
@@ -1,0 +1,83 @@
+---
+# Galaxy configuration for Palfinder
+galaxy_name: "palfinder"
+galaxy_version: "release_20.09"
+
+# Galaxy-specific Python installation
+galaxy_python_version: "3.8.13"
+
+# Account management
+allow_user_creation: yes
+allow_user_deletion: yes
+enable_require_login: yes
+enable_user_activation: yes
+
+# GDPR compliance
+enable_beta_gdpr: yes
+
+# uWSGI sockets and ports
+galaxy_http_port: "8080"
+galaxy_uwsgi_socket: "4001"
+
+# Users
+galaxy_admin_user: "admin@galaxy.org"
+galaxy_users:
+  - email: "{{ galaxy_admin_user }}"
+    password: "{{ galaxy_admin_passwd }}"
+
+# Job configuration
+enable_jse_drop: yes
+galaxy_jse_drop_dir: "{{ galaxy_install_dir }}/jse-drop-csf3"
+galaxy_jse_drop_galaxy_id: "{{ galaxy_name }}"
+
+# Quotas
+enable_quotas: yes
+default_quota_gb: 50
+
+# Automatic dataset deletion
+delete_datasets_after: "30 days"
+
+# Email
+postfix_host_name: "{{ galaxy_server_name }}"
+postfix_relay_host: "[smtp.manchester.ac.uk]"
+galaxy_outgoing_email_addr: "Palfinder Galaxy <galaxy-no-reply@{{ galaxy_server_name  }}>"
+galaxy_incoming_email_addr: "peter.briggs@manchester.ac.uk"
+
+# FTP upload
+enable_ftp_upload: no
+
+# Reporting interface
+enable_reports: yes
+##galaxy_reports_uwsgi_socket: "9001"
+
+# Audit report
+email_audit_report_to: "peter.briggs@manchester.ac.uk"
+
+ # Welcome page etc
+galaxy_welcome_template: "instances/palfinder/templates/palfinder-welcome.html.j2"
+galaxy_terms: "instances/palfinder/files/palfinder-terms.html"
+galaxy_citations: "instances/palfinder/files/palfinder-citations.html"
+
+# User manual
+galaxy_extra_static_content:
+  - src: "instances/palfinder/files/palfinder_galaxy_manual_v1.2.pdf"
+    dest: "/usr/share/nginx/html/palfinder_galaxy_manual_v1.2.pdf"
+    link: "/usr/share/nginx/html/manual"
+galaxy_nginx_extra_locations:
+  - location: "^~ /manual"
+    alias: "/usr/share/nginx/html/manual"
+    add_header: "Content-Type application/pdf"
+
+# Check toolshed for updates
+enable_tool_shed_check: yes
+
+# Message of the day to display on the front page and message
+# to display under masthead
+# -- for ansible <2.6 "errors=..." option is not supported so
+#    an empty placeholder file is required to stop the playbook
+#    failing
+palfinder_motd: "{{ lookup('file', 'instances/{{ galaxy_name }}/files/motd', errors='warn') }}"
+galaxy_message: "{{ lookup('file', 'instances/{{ galaxy_name }}/files/message', errors='warn') }}"
+
+# Tools conf base XML
+galaxy_tool_conf_file: "instances/palfinder/files/palfinder-tool_conf.xml"

--- a/instances/palfinder/galaxy_config.yml
+++ b/instances/palfinder/galaxy_config.yml
@@ -43,7 +43,7 @@ enable_quotas: yes
 default_quota_gb: 50
 
 # Automatic dataset deletion
-delete_datasets_after: "30 days"
+delete_datasets_after: "60 days"
 
 # Email
 galaxy_smtp_server: "smtp.manchester.ac.uk"

--- a/instances/palfinder/galaxy_config.yml
+++ b/instances/palfinder/galaxy_config.yml
@@ -10,7 +10,7 @@ galaxy_python_version: "3.8.13"
 allow_user_creation: yes
 allow_user_deletion: yes
 enable_require_login: yes
-enable_user_activation: yes
+# 'enable_user_activation' is set in inventory file
 
 # GDPR compliance
 enable_beta_gdpr: yes
@@ -27,7 +27,7 @@ galaxy_users:
 
 # Job configuration
 enable_jse_drop: yes
-galaxy_jse_drop_dir: "{{ galaxy_install_dir }}/jse-drop-csf3"
+galaxy_jse_drop_dir: "{{ galaxy_install_dir }}/palfinder/jse-drop-csf3"
 galaxy_jse_drop_galaxy_id: "{{ galaxy_name }}"
 
 # Quotas

--- a/instances/palfinder/galaxy_config.yml
+++ b/instances/palfinder/galaxy_config.yml
@@ -7,10 +7,10 @@ galaxy_version: "release_20.09"
 galaxy_python_version: "3.8.13"
 
 # Account management
+# NB 'enable_user_activation' is set in inventory file
 allow_user_creation: yes
 allow_user_deletion: yes
 enable_require_login: yes
-# 'enable_user_activation' is set in inventory file
 
 # GDPR compliance
 enable_beta_gdpr: yes
@@ -30,9 +30,8 @@ galaxy_users:
     password: "{{ galaxy_admin_passwd }}"
 
 # Job configuration
+# NB Drop dir and ID are set in inventory file
 enable_jse_drop: yes
-galaxy_jse_drop_dir: "{{ galaxy_install_dir }}/palfinder/jse-drop-csf3"
-galaxy_jse_drop_galaxy_id: "{{ galaxy_name }}"
 
 # Concurrent jobs
 galaxy_registered_user_concurrent_jobs: 8

--- a/instances/palfinder/galaxy_config.yml
+++ b/instances/palfinder/galaxy_config.yml
@@ -46,8 +46,7 @@ default_quota_gb: 50
 delete_datasets_after: "30 days"
 
 # Email
-postfix_host_name: "{{ galaxy_server_name }}"
-postfix_relay_host: "[smtp.manchester.ac.uk]"
+galaxy_smtp_server: "smtp.manchester.ac.uk"
 galaxy_outgoing_email_addr: "Palfinder Galaxy <galaxy-no-reply@{{ galaxy_server_name  }}>"
 galaxy_incoming_email_addr: "peter.briggs@manchester.ac.uk"
 

--- a/instances/palfinder/sanitize_whitelist.yml
+++ b/instances/palfinder/sanitize_whitelist.yml
@@ -1,0 +1,6 @@
+---
+# Whitelisted tools for rendering HTML correctly
+galaxy_sanitize_whitelist_tools:
+  - "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.71"
+  - "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.72"
+  - "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.72+galaxy1"

--- a/instances/palfinder/sanitize_whitelist.yml
+++ b/instances/palfinder/sanitize_whitelist.yml
@@ -4,3 +4,4 @@ galaxy_sanitize_whitelist_tools:
   - "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.71"
   - "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.72"
   - "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.72+galaxy1"
+  - "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.74+galaxy0"

--- a/instances/palfinder/ssl_certs.yml
+++ b/instances/palfinder/ssl_certs.yml
@@ -2,3 +2,7 @@
 # SSL certificate files
 ssl_certificate: "/etc/letsencrypt/live/{{ galaxy_server_name }}/fullchain.pem"
 ssl_certificate_key: "/etc/letsencrypt/live/{{ galaxy_server_name }}/privkey.pem"
+
+# Certbot & certificate renewal
+certbot_auto_renew_certs: true
+certbot_email_addr: "{{ galaxy_incoming_email_addr }}"

--- a/instances/palfinder/ssl_certs.yml
+++ b/instances/palfinder/ssl_certs.yml
@@ -1,0 +1,4 @@
+---
+# SSL certificate files
+ssl_certificate: "/etc/letsencrypt/live/{{ galaxy_server_name }}/fullchain.pem"
+ssl_certificate_key: "/etc/letsencrypt/live/{{ galaxy_server_name }}/privkey.pem"

--- a/instances/palfinder/templates/palfinder-welcome.html.j2
+++ b/instances/palfinder/templates/palfinder-welcome.html.j2
@@ -37,9 +37,9 @@ g/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 	<li>Run a microsatellite development pipeline using the following
 	  tools within the Galaxy environment:
 	  <ul>
-	    <li>- FastQC</li>
-	    <li>- Trimmomatic</li>
-	    <li>- Pal_finder (also utilises Primer3, Pal_filter and PANDASeq)</li>
+	    <li>FastQC</li>
+	    <li>Trimmomatic</li>
+	    <li>Pal_finder (also utilises Primer3, Pal_filter and PANDASeq)</li>
 	  </ul>
 	</li>
 	<li>Download results files</li>
@@ -49,14 +49,9 @@ g/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 	for detailed instructions and information.</p>
 
       <h2>Data upload</h2>
-      <p>Files can be uploaded directly via your web browser -
-	<b>in principle this should now work for any size of file.</b></p>
-      <p>However an alternative upload method of upload using an FTP server
-	also continues to be available via
-      <a href="ftp://{{ galaxy_server_name }}">ftp://{{ galaxy_server_name }}</a></p>
-      <p>(This requires your registered email address and Galaxy password to
-        log in. Uploaded files will then be available for import via the
-        <em>Upload</em> tool.)</p>
+      <p>Files can be uploaded directly via your web browser using the
+	<em>Upload File</em> option. This should work for any size of
+	file.</p>
 
       <h2>Limitations</h2>
       <p>Accounts have a quota of <b>{{ default_quota_gb }} GB</b>.</p>

--- a/instances/palfinder/tools.yml
+++ b/instances/palfinder/tools.yml
@@ -1,0 +1,12 @@
+---
+# Tools from toolshed
+galaxy_tools:
+  - tool: "fastqc"
+    owner: "devteam"
+    section: ""
+  - tool: "trimmomatic"
+    owner: "pjbriggs"
+    section: ""
+  - tool: "pal_finder"
+    owner: "pjbriggs"
+    section: ""

--- a/inventories/csf/palfinder.yml
+++ b/inventories/csf/palfinder.yml
@@ -12,5 +12,5 @@ csf:
     galaxy_group: "galaxy"
     galaxy_gid: 400
     # Galaxy and Python versions to target
-    galaxy_version: "19.09"
-    python_version: "3.6.11"
+    galaxy_version: "20.09"
+    python_version: "3.8.13"

--- a/inventories/palfinder/production.yml
+++ b/inventories/palfinder/production.yml
@@ -9,6 +9,11 @@ palfinder:
     galaxy_install_dir: "/mnt/rvmi/palfinder/galaxy"
     # Secrets
     palfinder_secrets: palfinder_passwds.yml
+    # Migrating to new VM
+    ##galaxy_force_reinstall_python: yes
+    ##galaxy_force_reinstall_venv: yes
+    ##galaxy_reinstall_conda: yes
+    ##galaxy_new_db_sql: "/mnt/rvmi/palfinder/galaxy/galaxy_palfinder.dump.2023-07-28.sql"
     # Job configuration
     galaxy_jse_drop_dir: "{{ galaxy_install_dir }}/palfinder/jse-drop-csf3"
     galaxy_jse_drop_galaxy_id: "{{ galaxy_name }}"
@@ -24,6 +29,8 @@ palfinder:
     galaxy_tool_destinations:
       - id: "trimmomatic"
         destination: "jse_drop_8_cores"
+    # Cluster needs to use its own virtual env
+    galaxy_jse_drop_virtual_env: "/mnt/rvmi/palfinder/galaxy/shared/csf/galaxy/20.09/venv_py3.8"
     # Postfix/email configuration
     enable_smtp: yes
     # SSL configuration

--- a/inventories/palfinder/production.yml
+++ b/inventories/palfinder/production.yml
@@ -5,9 +5,13 @@ palfinder:
     # Server configuration
     galaxy_server_name: "palfinder.ls.manchester.ac.uk"
     enable_user_activation: yes
+    # Galaxy base installation dir
+    galaxy_install_dir: "/mnt/rvmi/palfinder/galaxy"
     # Secrets
     palfinder_secrets: palfinder_passwds.yml
     # Job configuration
+    galaxy_jse_drop_dir: "{{ galaxy_install_dir }}/palfinder/jse-drop-csf3"
+    galaxy_jse_drop_galaxy_id: "{{ galaxy_name }}"
     enable_local_jse_drop: no
     galaxy_default_runner: "jse_drop_default"
     galaxy_job_destinations:

--- a/inventories/palfinder/production.yml
+++ b/inventories/palfinder/production.yml
@@ -8,9 +8,7 @@ palfinder:
     # Secrets
     palfinder_secrets: palfinder_passwds.yml
     # Job configuration
-    enable_jse_drop: yes
     enable_local_jse_drop: no
-    galaxy_jse_drop_dir: "{{ galaxy_install_dir }}/palfinder/jse-drop-csf3"
     galaxy_default_runner: "jse_drop_default"
     galaxy_job_destinations:
       - id: "jse_drop_default"

--- a/inventories/palfinder/test.yml
+++ b/inventories/palfinder/test.yml
@@ -1,0 +1,39 @@
+palfinder:
+  hosts:
+    10.99.53.203
+  vars:
+    # Server configuration
+    galaxy_server_name: "10.99.53.203"
+    enable_user_activation: yes
+    # Galaxy base installation dir
+    galaxy_install_dir: "/mnt/rvmi/palfinder/galaxy/test"
+    # Secrets
+    palfinder_secrets: palfinder_passwds.yml
+    # Job configuration
+    galaxy_jse_drop_dir: "/mnt/rvmi/palfinder/galaxy/palfinder/jse-drop-csf3"
+    galaxy_jse_drop_galaxy_id: "{{ galaxy_name }}_test"
+    enable_local_jse_drop: no
+    galaxy_default_runner: "jse_drop_default"
+    galaxy_job_destinations:
+      - id: "jse_drop_default"
+        runner: "jse_drop"
+      - id: "jse_drop_8_cores"
+        runner: "jse_drop"
+        jse_drop_qsub_options: "-pe smp.pe 8"
+        jse_drop_slots: "8"
+    galaxy_tool_destinations:
+      - id: "trimmomatic"
+        destination: "jse_drop_8_cores"
+    # Postfix/email configuration
+    enable_smtp: yes
+    # SSL configuration
+    enable_https: no
+    # Demo data
+    demo_data_dir: "{{ galaxy_install_dir }}/demo-data"
+    galaxy_library_datasets:
+      - file: "{{ demo_data_dir }}/miseq_R1.fq"
+        type: "fastqsanger"
+        library: "Example data/Fastqs"
+      - file: "{{ demo_data_dir }}/miseq_R2.fq"
+        type: "fastqsanger"
+        library: "Example data/Fastqs"

--- a/inventories/palfinder/test.yml
+++ b/inventories/palfinder/test.yml
@@ -7,16 +7,24 @@ palfinder:
     enable_user_activation: yes
     # Galaxy base installation dir
     galaxy_install_dir: "/mnt/rvmi/palfinder/galaxy/test"
+    # Use file database from production
+    galaxy_file_path: "/mnt/rvmi/palfinder/galaxy/palfinder/galaxy/database/files"
+    # Migrating to new VM
+    ##galaxy_reinstall_conda: yes
+    ##galaxy_force_reinstall_python: yes
+    ##galaxy_force_reinstall_venv: yes
+    ##galaxy_new_db_sql: "/mnt/rvmi/palfinder/galaxy/galaxy_palfinder.dump.2023-07-28.sql"
     # Secrets
     palfinder_secrets: palfinder_passwds.yml
     # Job configuration
     galaxy_jse_drop_dir: "/mnt/rvmi/palfinder/galaxy/palfinder/jse-drop-csf3"
-    galaxy_jse_drop_galaxy_id: "{{ galaxy_name }}_test"
+    galaxy_jse_drop_galaxy_id: "{{ galaxy_name }}"
     enable_local_jse_drop: no
     galaxy_default_runner: "jse_drop_default"
     galaxy_job_destinations:
       - id: "jse_drop_default"
         runner: "jse_drop"
+        jse_drop_qsub_options: "-l short"
       - id: "jse_drop_8_cores"
         runner: "jse_drop"
         jse_drop_qsub_options: "-pe smp.pe 8"
@@ -24,16 +32,18 @@ palfinder:
     galaxy_tool_destinations:
       - id: "trimmomatic"
         destination: "jse_drop_8_cores"
+    # Cluster needs to use its own virtual env
+    galaxy_jse_drop_virtual_env: "/mnt/rvmi/palfinder/galaxy/shared/csf/galaxy/20.09/venv_py3.8"
     # Postfix/email configuration
     enable_smtp: yes
     # SSL configuration
     enable_https: no
     # Demo data
-    demo_data_dir: "{{ galaxy_install_dir }}/demo-data"
-    galaxy_library_datasets:
-      - file: "{{ demo_data_dir }}/miseq_R1.fq"
-        type: "fastqsanger"
-        library: "Example data/Fastqs"
-      - file: "{{ demo_data_dir }}/miseq_R2.fq"
-        type: "fastqsanger"
-        library: "Example data/Fastqs"
+    ##demo_data_dir: "{{ galaxy_install_dir }}/demo-data"
+    ##galaxy_library_datasets:
+    ##  - file: "{{ demo_data_dir }}/miseq_R1.fq"
+    ##    type: "fastqsanger"
+    ##    library: "Example data/Fastqs"
+    ##  - file: "{{ demo_data_dir }}/miseq_R2.fq"
+    ##    type: "fastqsanger"
+    ##    library: "Example data/Fastqs"

--- a/inventories/palfinder/vagrant.yml
+++ b/inventories/palfinder/vagrant.yml
@@ -10,7 +10,11 @@ palfinder:
     # Server configuration
     galaxy_server_name: 192.168.60.4
     enable_user_activation: no
+    # Galaxy base installation dir
+    galaxy_install_dir: "/mnt/rvmi/palfinder/galaxy"
     # Job configuration
+    galaxy_jse_drop_dir: "{{ galaxy_install_dir }}/palfinder/jse-drop-csf3"
+    galaxy_jse_drop_galaxy_id: "{{ galaxy_name }}_vagrant"
     enable_local_jse_drop: yes
     galaxy_default_runner: "jse_drop_default"
     galaxy_job_destinations:

--- a/inventories/palfinder/vagrant.yml
+++ b/inventories/palfinder/vagrant.yml
@@ -11,9 +11,7 @@ palfinder:
     galaxy_server_name: 192.168.60.4
     enable_user_activation: no
     # Job configuration
-    enable_jse_drop: yes
     enable_local_jse_drop: yes
-    galaxy_jse_drop_dir: "{{ galaxy_install_dir }}/palfinder/jse-drop-csf3"
     galaxy_default_runner: "jse_drop_default"
     galaxy_job_destinations:
       - id: "jse_drop_default"

--- a/palfinder.yml
+++ b/palfinder.yml
@@ -13,6 +13,9 @@
   # System Python and PostgreSQL versions
   - python_version: "3.10.5"
   - postgresql_version: "14"
+  # Postfix settings
+  - postfix_host_name: "palfinder.ls.manchester.ac.uk"
+  - postfix_relay_host: "smtp.manchester.ac.uk"
   # Base installation directory set in inventory file
   vars_files:
   - instances/palfinder/galaxy_config.yml

--- a/palfinder.yml
+++ b/palfinder.yml
@@ -36,9 +36,10 @@
   - role: certbot
     when: enable_https
 
-  # Postfix mail client
-  - role: postfix-null-client
-    when: enable_smtp
+  # Disabled until role is updated
+  ## Postfix mail client
+  #- role: postfix-null-client
+  #  when: enable_smtp
 
   # Local JSEDrop service
   - role: jsedrop

--- a/palfinder.yml
+++ b/palfinder.yml
@@ -37,12 +37,6 @@
   roles:
   # Configure host VM
   - galaxy-user
-  - epel-repo
-    when: ansible_os_family == "RedHat"
-  - nfslock
-    when: ansible_os_family == "RedHat"
-  - selinux
-    when: ansible_os_family == "RedHat"
   - python3
   - nginx
   - postgresql

--- a/palfinder.yml
+++ b/palfinder.yml
@@ -4,7 +4,7 @@
   vars:
   # Galaxy configuration
   - galaxy_name: "palfinder"
-  - galaxy_version: "release_19.09"
+  - galaxy_version: "release_20.09"
   - galaxy_install_dir: "/mnt/rvmi/palfinder/galaxy"
   - enable_require_login: yes
   - enable_quotas: yes

--- a/palfinder.yml
+++ b/palfinder.yml
@@ -13,6 +13,7 @@
   - enable_quotas: yes
   - enable_ftp_upload: no
   - enable_reports: yes
+  - galaxy_tool_conf_file: "instances/palfinder/files/palfinder-tool_conf.xml"
   # System Python and PostgreSQL versions
   - python_version: "3.10.5"
   - postgresql_version: "14"
@@ -41,24 +42,11 @@
   - galaxy_users:
       - email: "{{ galaxy_admin_user }}"
         password: "{{ galaxy_admin_passwd }}"
-  # Tools
-  - galaxy_tool_conf_file: "instances/palfinder/files/palfinder-tool_conf.xml"
-  - galaxy_tools:
-      - tool: "fastqc"
-        owner: "devteam"
-        section: ""
-      - tool: "trimmomatic"
-        owner: "pjbriggs"
-        section: ""
-      - tool: "pal_finder"
-        owner: "pjbriggs"
-        section: ""
   - enable_tool_shed_check: yes
   # Concurrent jobs
   - galaxy_registered_user_concurrent_jobs: 8
   - galaxy_unregistered_user_concurrent_jobs: 0
   - galaxy_concurrent_jobs: 8
-  # Add tools to whitelist for rendering HTML correctly
   # Default quota
   - default_quota_gb: 50
   # Automatic dataset deletion
@@ -88,6 +76,7 @@
 
   vars_files:
   - instances/palfinder/{{ palfinder_secrets }}
+  - instances/centaurus/tools.yml
   - instances/centaurus/sanitize_whitelist.yml
 
   roles:

--- a/palfinder.yml
+++ b/palfinder.yml
@@ -2,6 +2,9 @@
 - hosts: palfinder
 
   vars:
+  # Ubuntu doesn't have Python2 by default
+  # See e.g. https://www.toptechskills.com/ansible-tutorials-courses/how-to-fix-usr-bin-python-not-found-error-tutorial/
+  - ansible_python_interpreter: /usr/bin/python3
   # Galaxy configuration
   - galaxy_name: "palfinder"
   - galaxy_version: "release_20.09"

--- a/palfinder.yml
+++ b/palfinder.yml
@@ -80,31 +80,38 @@
   - instances/centaurus/sanitize_whitelist.yml
 
   roles:
-  # Dependencies
+  # Configure host VM
   - galaxy-user
   - epel-repo
+    when: ansible_os_family == "RedHat"
   - nfslock
-  - git
+    when: ansible_os_family == "RedHat"
   - selinux
+    when: ansible_os_family == "RedHat"
   - python3
   - nginx
   - postgresql
   - supervisord
+  - certbot
+
+  # Postfix mail client
   - role: postfix-null-client
     when: enable_smtp
-  - certbot
+
   # Local JSEDrop service
   - role: jsedrop
     jsedrop_drop_dir: "{{ galaxy_jse_drop_dir }}"
     when: enable_local_jse_drop
+
   # Install and configure Galaxy
-  - galaxy
-  # Install utilities
   - galaxy-utils
+  - galaxy
+
   # Set up users, tools etc
   - galaxy-create-users
   - galaxy-install-tools
   - galaxy-set-default-quota
+
   # Additional set up
   - galaxy-add-library-data
   - galaxy-auto-delete-datasets

--- a/palfinder.yml
+++ b/palfinder.yml
@@ -31,7 +31,10 @@
   - nginx
   - postgresql
   - supervisord
-  - certbot
+
+  # SSL certificates
+  - role: certbot
+    when: enable_https
 
   # Postfix mail client
   - role: postfix-null-client

--- a/palfinder.yml
+++ b/palfinder.yml
@@ -10,8 +10,11 @@
   - enable_quotas: yes
   - enable_ftp_upload: yes
   - enable_reports: yes
+  # System Python and PostgreSQL versions
+  - python_version: "3.10.5"
+  - postgresql_version: "14"
   # Galaxy-specific Python installation
-  - galaxy_python_version: "3.6.11"
+  - galaxy_python_version: "3.8.13"
   # GDPR compliance
   - enable_beta_gdpr: yes
   # Welcome page etc

--- a/palfinder.yml
+++ b/palfinder.yml
@@ -22,17 +22,13 @@
   - galaxy_registered_user_concurrent_jobs: 8
   - galaxy_unregistered_user_concurrent_jobs: 0
   - galaxy_concurrent_jobs: 8
-  # SSL configuration
-  # Enable/disable in inventory file (enable_https)
-  # If enabled then will use the settings below
-  - ssl_certificate: "/etc/letsencrypt/live/{{ galaxy_server_name }}/fullchain.pem"
-  - ssl_certificate_key: "/etc/letsencrypt/live/{{ galaxy_server_name }}/privkey.pem"
 
   vars_files:
   - instances/palfinder/galaxy_config.yml
   - instances/palfinder/{{ palfinder_secrets }}
   - instances/palfinder/tools.yml
   - instances/palfinder/sanitize_whitelist.yml
+  - instances/palfinder/ssl_certs.yml
 
   roles:
   # Configure host VM

--- a/palfinder.yml
+++ b/palfinder.yml
@@ -59,10 +59,6 @@
   - galaxy_unregistered_user_concurrent_jobs: 0
   - galaxy_concurrent_jobs: 8
   # Add tools to whitelist for rendering HTML correctly
-  - galaxy_sanitize_whitelist_tools:
-      - "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.71"
-      - "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.72"
-      - "toolshed.g2.bx.psu.edu/repos/devteam/fastqc/fastqc/0.72+galaxy1"
   # Default quota
   - default_quota_gb: 50
   # Automatic dataset deletion
@@ -92,6 +88,7 @@
 
   vars_files:
   - instances/palfinder/{{ palfinder_secrets }}
+  - instances/centaurus/sanitize_whitelist.yml
 
   roles:
   # Dependencies

--- a/palfinder.yml
+++ b/palfinder.yml
@@ -15,13 +15,6 @@
   - postgresql_version: "14"
   # Base installation directory
   - galaxy_install_dir: "/mnt/rvmi/palfinder/galaxy"
-  # uWSGI and handler configuration
-  - galaxy_uwsgi_processes: 8
-  - galaxy_handler_processes: 1
-  # Concurrent jobs
-  - galaxy_registered_user_concurrent_jobs: 8
-  - galaxy_unregistered_user_concurrent_jobs: 0
-  - galaxy_concurrent_jobs: 8
 
   vars_files:
   - instances/palfinder/galaxy_config.yml

--- a/palfinder.yml
+++ b/palfinder.yml
@@ -103,7 +103,6 @@
   - python3
   - nginx
   - postgresql
-  - proftpd
   - supervisord
   - role: postfix-null-client
     when: enable_smtp

--- a/palfinder.yml
+++ b/palfinder.yml
@@ -5,79 +5,34 @@
   # Ubuntu doesn't have Python2 by default
   # See e.g. https://www.toptechskills.com/ansible-tutorials-courses/how-to-fix-usr-bin-python-not-found-error-tutorial/
   - ansible_python_interpreter: /usr/bin/python3
-  # Galaxy configuration
-  - galaxy_name: "palfinder"
-  - galaxy_version: "release_20.09"
-  - galaxy_install_dir: "/mnt/rvmi/palfinder/galaxy"
-  - enable_require_login: yes
-  - enable_quotas: yes
-  - enable_ftp_upload: no
-  - enable_reports: yes
-  - galaxy_tool_conf_file: "instances/palfinder/files/palfinder-tool_conf.xml"
+  # Galaxy user and group on system
+  - galaxy_user: "galaxy"
+  - galaxy_uid: 400
+  - galaxy_group: "galaxy"
+  - galaxy_gid: 400
   # System Python and PostgreSQL versions
   - python_version: "3.10.5"
   - postgresql_version: "14"
-  # Galaxy-specific Python installation
-  - galaxy_python_version: "3.8.13"
-  # GDPR compliance
-  - enable_beta_gdpr: yes
-  # Welcome page etc
-  - galaxy_welcome_template: "instances/palfinder/templates/palfinder-welcome.html.j2"
-  - galaxy_terms: "instances/palfinder/files/palfinder-terms.html"
-  - galaxy_citations: "instances/palfinder/files/palfinder-citations.html"
-  # User manual
-  - galaxy_extra_static_content:
-      - src: "instances/palfinder/files/palfinder_galaxy_manual_v1.2.pdf"
-        dest: "/usr/share/nginx/html/palfinder_galaxy_manual_v1.2.pdf"
-        link: "/usr/share/nginx/html/manual"
-  - galaxy_nginx_extra_locations:
-      - location: "^~ /manual"
-        alias: "/usr/share/nginx/html/manual"
-        add_header: "Content-Type application/pdf"
+  # Base installation directory
+  - galaxy_install_dir: "/mnt/rvmi/palfinder/galaxy"
   # uWSGI and handler configuration
   - galaxy_uwsgi_processes: 8
   - galaxy_handler_processes: 1
-  # Users
-  - galaxy_admin_user: "admin@galaxy.org"
-  - galaxy_users:
-      - email: "{{ galaxy_admin_user }}"
-        password: "{{ galaxy_admin_passwd }}"
-  - enable_tool_shed_check: yes
   # Concurrent jobs
   - galaxy_registered_user_concurrent_jobs: 8
   - galaxy_unregistered_user_concurrent_jobs: 0
   - galaxy_concurrent_jobs: 8
-  # Default quota
-  - default_quota_gb: 50
-  # Automatic dataset deletion
-  - delete_datasets_after: "30 days"
-  # Audit report
-  - email_audit_report_to: "peter.briggs@manchester.ac.uk"
-  # Postfix/email configuration
-  # Enable/disable in inventory file (enable_smtp)
-  # If enabled then will use the settings below
-  - postfix_host_name: "{{ galaxy_server_name }}"
-  - postfix_relay_host: "[smtp.manchester.ac.uk]"
-  - galaxy_outgoing_email_addr: "Palfinder Galaxy <galaxy-no-reply@{{ galaxy_server_name  }}>"
-  - galaxy_incoming_email_addr: "peter.briggs@manchester.ac.uk"
   # SSL configuration
   # Enable/disable in inventory file (enable_https)
   # If enabled then will use the settings below
   - ssl_certificate: "/etc/letsencrypt/live/{{ galaxy_server_name }}/fullchain.pem"
   - ssl_certificate_key: "/etc/letsencrypt/live/{{ galaxy_server_name }}/privkey.pem"
-  # Palfinder-specific settings
-  # Message of the day to display on the front page and message
-  # to display under masthead
-  # -- for ansible <2.6 "errors=..." option is not supported so
-  #    an empty placeholder file is required to stop the playbook
-  #    failing
-  - palfinder_motd: "{{ lookup('file', 'instances/palfinder/files/motd', errors='warn') }}"
-  - galaxy_message: "{{ lookup('file', 'instances/palfinder/files/message', errors='warn') }}"
 
   vars_files:
+  - instances/palfinder/galaxy_config.yml
   - instances/palfinder/{{ palfinder_secrets }}
-  - instances/centaurus/tools.yml
-  - instances/centaurus/sanitize_whitelist.yml
+  - instances/palfinder/tools.yml
+  - instances/palfinder/sanitize_whitelist.yml
 
   roles:
   # Configure host VM

--- a/palfinder.yml
+++ b/palfinder.yml
@@ -8,7 +8,7 @@
   - galaxy_install_dir: "/mnt/rvmi/palfinder/galaxy"
   - enable_require_login: yes
   - enable_quotas: yes
-  - enable_ftp_upload: yes
+  - enable_ftp_upload: no
   - enable_reports: yes
   # System Python and PostgreSQL versions
   - python_version: "3.10.5"

--- a/palfinder.yml
+++ b/palfinder.yml
@@ -13,9 +13,7 @@
   # System Python and PostgreSQL versions
   - python_version: "3.10.5"
   - postgresql_version: "14"
-  # Base installation directory
-  - galaxy_install_dir: "/mnt/rvmi/palfinder/galaxy"
-
+  # Base installation directory set in inventory file
   vars_files:
   - instances/palfinder/galaxy_config.yml
   - instances/palfinder/{{ palfinder_secrets }}


### PR DESCRIPTION
WIP pull request to migrate the Palfinder service from unsupported Scientific Linux 6 to Ubuntu 20.04.

The migration will also upgrade to Galaxy version 20.09 (currently Palfinder is on 19.09).