### PR TITLE
'galaxy' role: use '.' instead of 'source' in JSE-drop cleanup cron job

### DIFF
--- a/roles/galaxy/tasks/jsedrop.yml
+++ b/roles/galaxy/tasks/jsedrop.yml
@@ -39,5 +39,5 @@
     user='{{ galaxy_user }}'
     name='Clean up deleted JSE-drop jobs'
     special_time='hourly'
-    job='source {{ galaxy_root }}/.venv/bin/activate && PYTHONPATH={{ galaxy_root }}/lib:$PYTHONPATH python -c "from galaxy.jobs.runners.jse_drop import jse_drop_cleanup_deleted ; jse_drop_cleanup_deleted(\'{{ galaxy_jse_drop_dir }}\',{{ galaxy_jse_drop_cleanup_grace_period }})" 2>&1 1>>{{ galaxy_log_dir}}/jse_drop_cleanup.log'
+    job='. {{ galaxy_root }}/.venv/bin/activate && PYTHONPATH={{ galaxy_root }}/lib:$PYTHONPATH python -c "from galaxy.jobs.runners.jse_drop import jse_drop_cleanup_deleted ; jse_drop_cleanup_deleted(\'{{ galaxy_jse_drop_dir }}\',{{ galaxy_jse_drop_cleanup_grace_period }})" 2>&1 1>>{{ galaxy_log_dir}}/jse_drop_cleanup.log'
     state=present


### PR DESCRIPTION
Updates the `jsedrop.yml` task file in the `galaxy` role to use `.` instead of the `source` command when setting up the cron job for JSE-drop clean-up.

`source` is a `/bin/sh` command which is not necessarily available in `bash`, whereas `.` should always be available.