### PR TITLE
'galaxy' role: set the MAILTO and MAILFROM crontab vars

### DIFF
--- a/roles/galaxy/tasks/cronvars.yml
+++ b/roles/galaxy/tasks/cronvars.yml
@@ -1,0 +1,13 @@
+---
+# Ensure MAILTO and MAILFROM are set in crontab
+# for galaxy user
+
+- name: "Set MAILTO and MAILFROM in cron"
+  cronvar:
+    user: "{{ galaxy_user }}"
+    name: "{{ item }}"
+    value: "{{ galaxy_incoming_email_addr }}"
+  with_items:
+    - MAILTO
+    - MAILFROM
+  when: enable_smtp

--- a/roles/galaxy/tasks/main.yml
+++ b/roles/galaxy/tasks/main.yml
@@ -61,3 +61,6 @@
 
 - include: static.yml
   when: galaxy_extra_static_content|default(None) != None
+
+- include: cronvars.yml
+  when: enable_smtp


### PR DESCRIPTION
Updates the `galaxy` role to also set the `MAILTO` and `MAILFROM` variables in the `crontab` file for the `galaxy` user (issue #223).