### PR TITLE
'galaxy' role: create and use temporary dirs for 'pip' and 'yarn'

### DIFF
--- a/roles/galaxy/defaults/main.yml
+++ b/roles/galaxy/defaults/main.yml
@@ -100,6 +100,9 @@ galaxy_python_version: "3.6.11"
 galaxy_python_dir: '{{ galaxy_dir }}/python/{{ galaxy_python_version }}'
 galaxy_force_reinstall_python: no
 
+# Temporary directory to use during installation
+galaxy_installation_tmp_dir: "/tmp"
+
 # Toolshed check
 enable_tool_shed_check: no
 

--- a/roles/galaxy/tasks/galaxy.yml
+++ b/roles/galaxy/tasks/galaxy.yml
@@ -301,6 +301,21 @@
     - galaxy_python_version.startswith("3.")
     - galaxy_version == "release_20.01"
 
+# Temp dirs for pip and yarn caches
+- name: "Make temporary pip cache directory"
+  tempfile:
+    path: "/tmp"
+    prefix: "pip.cache."
+    state: directory
+  register: pip_cache_dir
+
+- name: "Make temporary yarn cache directory"
+  tempfile:
+    path: "/tmp"
+    prefix: "yarn.cache."
+    state: directory
+  register: yarn_cache_dir
+
 # Setup/update Galaxy
 - name: "Run common_startup.sh to initialise/update Galaxy installation"
   command:
@@ -308,6 +323,8 @@
     ./scripts/common_startup.sh
   environment:
     PATH: '/usr/local/bin:{{ ansible_env.PATH }}'
+    PIP_CACHE_DIR: '{{ pip_cache_dir.path }}'
+    YARN_CACHE_FOLDER: '{{ yarn_cache_dir.path }}'
 
 # Create or update Galaxy database
 - name: "Check if Galaxy database exists"

--- a/roles/galaxy/tasks/galaxy.yml
+++ b/roles/galaxy/tasks/galaxy.yml
@@ -304,14 +304,14 @@
 # Temp dirs for pip and yarn caches
 - name: "Make temporary pip cache directory"
   tempfile:
-    path: "/tmp"
+    path: "{{ galaxy_installation_tmp_dir }}"
     prefix: "pip.cache."
     state: directory
   register: pip_cache_dir
 
 - name: "Make temporary yarn cache directory"
   tempfile:
-    path: "/tmp"
+    path: "{{ galaxy_installation_tmp_dir }}"
     prefix: "yarn.cache."
     state: directory
   register: yarn_cache_dir


### PR DESCRIPTION
Updates the `galaxy` role to create and use temporary directories for `pip` and `yarn` when running `common_startup.sh` to install Galaxy.