### PR TITLE
'galaxy' role: allow SMTP server to be explicitly specified for Galaxy

### DIFF
--- a/roles/galaxy/defaults/main.yml
+++ b/roles/galaxy/defaults/main.yml
@@ -248,6 +248,7 @@ galaxy_ftp_password: "{{ galaxy_ftp_user }}"
 
 # Outgoing mail notification settings
 enable_smtp: no
+galaxy_smtp_server: "localhost:25"
 galaxy_outgoing_email_addr: "Galaxy {{ galaxy_name }} <galaxy-no-reply@{{ galaxy_server_name  }}>"
 galaxy_incoming_email_addr: "None"
 

--- a/roles/galaxy/templates/galaxy-config.yml.j2
+++ b/roles/galaxy/templates/galaxy-config.yml.j2
@@ -513,7 +513,7 @@ galaxy:
   # Galaxy will automatically try STARTTLS but will continue upon
   # failure.
 {% if enable_smtp %}
-  smtp_server: localhost:25
+  smtp_server: {{ galaxy_smtp_server }}
 {% endif %}
 
   # If your SMTP server requires a username and password, you can


### PR DESCRIPTION
Updates the `galaxy` role to allow the SMTP server to be specified via a new `galaxy_smtp_server' parameter.