### PR TITLE
Updates to 'export-galaxy-for-cluster' role

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -378,6 +378,13 @@ instance do e.g.:
 This will generate a .tgz archive in the ``assets`` directory, which will
 contain the Galaxy virtualenv to be unpacked and used on the target VM.
 
+.. note::
+
+   If using the JSE-drop job submission mechanism then the
+   ``galaxy_jse_drop_virtual_env`` also needs to be set in the
+   playbooks to point to the unpacked virtual environment to be
+   used.
+
 Migrating Galaxy server to a new VM
 -----------------------------------
 

--- a/roles/export-galaxy-for-cluster/tasks/dependencies.yml
+++ b/roles/export-galaxy-for-cluster/tasks/dependencies.yml
@@ -20,4 +20,6 @@
       - 'sqlite-devel'
       - 'zlib-devel'
       - 'tkinter'
+      - 'libffi'
+      - 'libffi-devel'
     state: 'present'

--- a/roles/export-galaxy-for-cluster/tasks/python.yml
+++ b/roles/export-galaxy-for-cluster/tasks/python.yml
@@ -64,7 +64,5 @@
     cmd: '{{ python_install_dir }}/bin/pip3 install --upgrade pip'
 
 - name: "Python: install Virtualenv"
-  pip:
-    name: 'virtualenv'
-    state: 'present'
-    executable: '{{ python_install_dir }}/bin/pip3'
+  command:
+    cmd: '{{ python_install_dir }}/bin/pip3 install --upgrade virtualenv'


### PR DESCRIPTION
Updates the `export-galaxy-for-cluster` role:

* Adds new dependencies
* Updates how `virtualenv` is installed
* Updates information on using the virtual environment on the cluster system in the `README`