### PR TITLE
'galaxy-audit-report': fix bug with potentially undefined variable

### DIFF
--- a/roles/galaxy-audit-report/tasks/main.yml
+++ b/roles/galaxy-audit-report/tasks/main.yml
@@ -11,4 +11,3 @@
   when:
     - enable_smtp
     - email_audit_report_to is defined and email_audit_report_to != None
-    - galaxy_yml.stat.exists == True


### PR DESCRIPTION
Fixes bug in the `galaxy-audit-report` role by removing the reference to `galaxy_yaml` (which is defined in a different role and so may not be available).