### PR TITLE
'galaxy' role: fix import of SQL for migrated database

### DIFF
--- a/roles/galaxy/tasks/galaxy.yml
+++ b/roles/galaxy/tasks/galaxy.yml
@@ -339,12 +339,20 @@
         path: "{{ galaxy_install_dir }}/tmp"
         state: "directory"
 
-    - name: "Copy default template Galaxy database SQL file"
-      copy:
-        src: 'galaxy_database-v153.sql'
-        dest: '{{ galaxy_install_dir }}/tmp/galaxy_database.sql'
-        remote_src: no
-        force: yes
+    - name: "Bootstrap Galaxy database from template SQL"
+      block:
+        - name: "Copy default template Galaxy database SQL file"
+          copy:
+            src: 'galaxy_database-v153.sql'
+            dest: '{{ galaxy_install_dir }}/tmp/galaxy_database.sql'
+            remote_src: no
+            force: yes
+
+        - name: "Update Galaxy database user in template DB SQL"
+          replace:
+            path: '{{ galaxy_install_dir }}/tmp/galaxy_database.sql'
+            regexp: "__GALAXY_DB_USER__"
+            replace: "{{ galaxy_db_user }}"
       when: galaxy_new_db_sql|default(None) == None
 
     - name: "Copy user Galaxy database SQL file"
@@ -355,13 +363,7 @@
         force: yes
       when: galaxy_new_db_sql|default(None) != None
 
-    - name: "Update Galaxy database user in DB SQL"
-      replace:
-        path: '{{ galaxy_install_dir }}/tmp/galaxy_database.sql'
-        regexp: "__GALAXY_DB_USER__"
-        replace: "{{ galaxy_db_user }}"
-
-    - name: "Import empty Galaxy database from template SQL"
+    - name: "Import existing Galaxy database from SQL file"
       shell:
         "PGPASSWORD={{ galaxy_db_password }} psql -U {{ galaxy_db_user }} {{ galaxy_db}} < {{ galaxy_install_dir }}/tmp/galaxy_database.sql"
 


### PR DESCRIPTION
Fixes the importing of the SQL for migrated databases in the `galaxy` role, so that the database user is not rewritten (now this is only done if the database is being bootstrapped from the default SQL template).