### PR TITLE
'postfix-null-client' role: update config and enable generic maps

### DIFF
--- a/roles/postfix-null-client/defaults/main.yml
+++ b/roles/postfix-null-client/defaults/main.yml
@@ -2,3 +2,4 @@
 # Defaults for Postfix null client setup
 postfix_host_name:
 postfix_relay_host:
+postfix_smtp_generic_maps:

--- a/roles/postfix-null-client/tasks/main.yml
+++ b/roles/postfix-null-client/tasks/main.yml
@@ -36,7 +36,7 @@
   block:
     - name: Copy generic map file
       copy:
-        src='{{ postfix_generic_maps }}'
+        src='{{ postfix_smtp_generic_maps }}'
         dest='/etc/postfix/generic'
 
     - name: Update generic maps

--- a/roles/postfix-null-client/tasks/main.yml
+++ b/roles/postfix-null-client/tasks/main.yml
@@ -39,8 +39,8 @@
         src='{{ postfix_generic_maps }}'
         dest='/etc/postfix/generic'
 
-     - name: Update generic maps
-       command: postmap /etc/postfix/generic
+    - name: Update generic maps
+      command: postmap /etc/postfix/generic
   when: postfix_smtp_generic_maps|default(None) != None
 
 - name: Start Postfix

--- a/roles/postfix-null-client/tasks/main.yml
+++ b/roles/postfix-null-client/tasks/main.yml
@@ -32,6 +32,17 @@
   notify:
   - Reload Postfix
 
+- name: Import generic maps file
+  block:
+    - name: Copy generic map file
+      copy:
+        src='{{ postfix_generic_maps }}'
+        dest='/etc/postfix/generic'
+
+     - name: Update generic maps
+       command: postmap /etc/postfix/generic
+  when: postfix_smtp_generic_maps|default(None) != None
+
 - name: Start Postfix
   service:
     name=postfix

--- a/roles/postfix-null-client/templates/postfix-main.cf.j2
+++ b/roles/postfix-null-client/templates/postfix-main.cf.j2
@@ -9,4 +9,7 @@ inet_interfaces = loopback-only
 inet_interfaces = localhost
 {% endif %}
 mydestination = $myhostname, localhost.localdomain, localhost
+{% if postfix_smtp_generic_maps|default(None) != None %}
+smtp_generic_maps = hash:/etc/postfix/generic_maps
+{% endif %}
 inet_protocols = ipv4

--- a/roles/postfix-null-client/templates/postfix-main.cf.j2
+++ b/roles/postfix-null-client/templates/postfix-main.cf.j2
@@ -1,8 +1,12 @@
 # Configuration file for postfix to send activation emails,
 # password resets etc
+# See http://www.postfix.org/STANDARD_CONFIGURATION_README.html
+# for various use cases
 myhostname= {{ postfix_host_name }}
 relayhost = {{ postfix_relay_host }}
+inet_interfaces = loopback-only
 {% if ipv6_supported.stdout == "no" %}
 inet_interfaces = localhost
 {% endif %}
-mydestination = $myhostname, localhost.$mydomain, localhost
+mydestination = $myhostname, localhost.localdomain, localhost
+inet_protocols = ipv4

--- a/roles/postfix-null-client/templates/postfix-main.cf.j2
+++ b/roles/postfix-null-client/templates/postfix-main.cf.j2
@@ -10,6 +10,6 @@ inet_interfaces = localhost
 {% endif %}
 mydestination = $myhostname, localhost.localdomain, localhost
 {% if postfix_smtp_generic_maps|default(None) != None %}
-smtp_generic_maps = hash:/etc/postfix/generic_maps
+smtp_generic_maps = hash:/etc/postfix/generic
 {% endif %}
 inet_protocols = ipv4


### PR DESCRIPTION
Updates to the `main.cf` generated by the `postfix-null-client`role, and new option to specify a "generic maps" file:

http://www.postfix.org/STANDARD_CONFIGURATION_README.html#fantasy

Specifically, this file should map addresses on the local machine (e.g. `local.user@vm.domain.ac.uk`, which are not recognised by the mail domain) to actual email addresses e.g.

    @vm.domain.ac.uk     peter.briggs@yoyodyne.co.uk
    ...

This will redirect all messages from accounts ending with the local machine name to `peter.briggs@yoyodyne.co.uk`.

The local copy of the generic maps file should be specified with the `postfix_smtp_generic_maps` parameter; this will be copied to the remote server (where the appropriate hashing command will also be run for `postfix`).