### PR TITLE
Update 'virtualenv' export for CSF for Centaurus

### DIFF
--- a/inventories/csf/centaurus.yml
+++ b/inventories/csf/centaurus.yml
@@ -12,5 +12,5 @@ csf:
     galaxy_group: "galaxy"
     galaxy_gid: 400
     # Galaxy and Python versions to target
-    galaxy_version: "20.05"
+    galaxy_version: "20.09"
     python_version: "3.6.11"

--- a/inventories/csf/centaurus.yml
+++ b/inventories/csf/centaurus.yml
@@ -13,4 +13,4 @@ csf:
     galaxy_gid: 400
     # Galaxy and Python versions to target
     galaxy_version: "20.09"
-    python_version: "3.6.11"
+    python_version: "3.8.13"


### PR DESCRIPTION
Updates the inventory file for building a Centaurus Galaxy `virtualenv` for export to the CSF compute cluster, including bumping the Galaxy version to 20.09.