### PR TITLE
'galaxy' role: enable additional admin users to be specified in config

### DIFF
--- a/roles/galaxy/defaults/main.yml
+++ b/roles/galaxy/defaults/main.yml
@@ -7,8 +7,15 @@ galaxy_version: 'release_20.09'
 galaxy_user: "galaxy"
 galaxy_group: "{{ galaxy_user }}"
 
-# Galaxy admin user
+# Base Galaxy admin user
 galaxy_admin_user: "admin@galaxy.org"
+
+# Additional admin users
+# If defined then should be a list e.g.
+# galaxy_extra_admins:
+#   - "foo@example.org"
+#   - "bar@example.org"
+galaxy_extra_admins: null
 
 # Postgresql database
 galaxy_db: "galaxy_{{ galaxy_name }}"

--- a/roles/galaxy/templates/galaxy-config.yml.j2
+++ b/roles/galaxy/templates/galaxy-config.yml.j2
@@ -1270,7 +1270,11 @@ galaxy:
   # Admin section of the server, and will have access to create users,
   # groups, roles, libraries, and more.  For more information, see:
   # https://galaxyproject.org/admin/
+{% if galaxy_extra_admins is none %}
   admin_users: {{ galaxy_admin_user }}
+{% else %}
+  admin_users: {{ galaxy_admin_user }},{{ galaxy_extra_admins | join(",") }}
+{% endif %}
 
   # Force everyone to log in (disable anonymous access).
   require_login: {{ enable_require_login }}


### PR DESCRIPTION
Updates the `galaxy` role to enable additional accounts to specifed as admin users in the Galaxy YAML config file.

Note that only one "core" admin account can still be defined which will be created if it doesn't already exist; the additional accounts must be created outside the Ansible role.