### PR TITLE
'galaxy-install-tools' role: fix defaults

### DIFF
--- a/roles/galaxy-install-tools/defaults/main.yml
+++ b/roles/galaxy-install-tools/defaults/main.yml
@@ -88,17 +88,10 @@ galaxy_tool_data_tables: null
 #         - "seq\thg38\t/mnt/data-sets/hg38/2bit/hg38.analysisSet.2bit"
 #         - "seq\thg19\t/mnt/data-sets/hg19_GRCh37_random_chrM/seq"
 #         - ...
-galaxy_loc_file_data: null
+galaxy_loc_file_data: []
 
 # Galaxy installation location
 galaxy_root: "{{ galaxy_dir }}/{{ galaxy_clone_dir }}"
 
 # Is https enabled
 enable_https: no
-
-# Reference data for tool .loc files
-# Define additional entries for .loc files as a
-# dictionary with:
-# - loc_file (name of the .loc file, relative to tool-data)
-# - data     (data to add)
-galaxy_loc_file_data:

--- a/roles/galaxy-install-tools/defaults/main.yml
+++ b/roles/galaxy-install-tools/defaults/main.yml
@@ -23,7 +23,7 @@ galaxy_utils_dir: "/usr/local"
 #      - tool: ...
 #        owner: ...
 #        section: ... etc
-galaxy_tools: null
+galaxy_tools: []
 
 # Local tools to be installed
 # If defined then should be a list e.g.
@@ -58,27 +58,15 @@ local_galaxy_tools: null
 #      - name: ...
 #        tool_files:
 #          - ... etc
-local_galaxy_tool_references: null
-
-# Data tables
-# If defined then should be a list e.g.
-# galaxy_tool_data_tables:
-#      - description: "Annotation databases for CEAS"
-#        name: "ceas_annotations"
-#        columns: "value, dbkey, name, path"
-#        file_path: "tool-data/ceas.loc"
-#      - description: ...
-#        name: ...
-#        columns: ...
-#        file_path: ...
-galaxy_tool_data_tables: null
+local_galaxy_tool_references: []
 
 # Reference data for tool .loc files
 #
-# Define additional entries for .loc files as a
-# dictionary with:
+# Specify as a list with additional entries for specific .loc
+# files defined as dictionaries of the form:
+#
 # - loc_file (name of the .loc file, relative to tool-data)
-# - data     (data to add)
+# - data     (data to add, as a list)
 #
 # For example:
 #

--- a/roles/galaxy-install-tools/tasks/main.yml
+++ b/roles/galaxy-install-tools/tasks/main.yml
@@ -20,7 +20,7 @@
     - name: "Deactivate Galaxy master API key"
       command:
           "{{ galaxy_utils_dir }}/bin/gxctl.sh restart {{ galaxy_name }} -c {{ galaxy_root }}/config/galaxy.yml -u {{ galaxy_user }} --no-master-api-key"
-  when: galaxy_tools|default(None) != None
+  when: galaxy_tools | length > 0
 
 # Local tools
 - name: "Install local tools"
@@ -33,7 +33,6 @@
       with_items: "{{ local_galaxy_tools }}"
       become: yes
       become_user: "{{ galaxy_user }}"
-      when: local_galaxy_tools|default(None) != None
 
     - name: "Install local tool files"
       copy:
@@ -44,7 +43,6 @@
         - 'tool_files'
       become: yes
       become_user: "{{ galaxy_user }}"
-      when: local_galaxy_tools|default(None) != None
 
     - name: "Build tool_conf XML file for local tools"
       template:
@@ -54,7 +52,7 @@
         - "Restart Galaxy"
   become: yes
   become_user: "{{ galaxy_user }}"
-  when: local_galaxy_tools|default(None) != None
+  when: local_galaxy_tools | length > 0
 
 # Create .loc files from samples
 - name: "Create and populate loc files"
@@ -81,4 +79,4 @@
         - "Restart Galaxy"
   become: yes
   become_user: "{{ galaxy_user }}"
-  when: galaxy_loc_file_data|default(None) != None
+  when: galaxy_loc_file_data | length > 0


### PR DESCRIPTION
Updates the `galaxy-install-tools` role to fix the defaults so they are now set to empty lists.

Also removes a duplicated default declaration, and one that is not used in this role (as well as updating some of the inline documentation in the comments).