### PR TITLE
Skip post install checks on tools installed from toolshed

### DIFF
--- a/roles/galaxy-install-tools/defaults/main.yml
+++ b/roles/galaxy-install-tools/defaults/main.yml
@@ -25,6 +25,14 @@ galaxy_utils_dir: "/usr/local"
 #        section: ... etc
 galaxy_tools: []
 
+# Extra arguments to append to the 'install_tool.sh' script
+# when installing from the tool shed
+# - Set to "--check-install" to force post-install check on
+#   tool existence after installing (increases installation
+#   time but identifies tools where dependencies can't be
+#   installed or new Galaxy version is needed)
+galaxy_install_tool_extra_args:
+
 # Local tools to be installed
 # If defined then should be a list e.g.
 # local_galaxy_tools:

--- a/roles/galaxy-install-tools/tasks/main.yml
+++ b/roles/galaxy-install-tools/tasks/main.yml
@@ -14,7 +14,7 @@
 
     - name: "Install tools from Galaxy toolshed"
       command:
-        "{{ galaxy_utils_dir }}/bin/install_tool.sh toolshed.g2.bx.psu.edu {{ item.tool }} {{ item.owner }} {{ master_api_key }} {{ galaxy_url }} --section '{{ item.section }}'"
+        "{{ galaxy_utils_dir }}/bin/install_tool.sh toolshed.g2.bx.psu.edu {{ item.tool }} {{ item.owner }} {{ master_api_key }} {{ galaxy_url }} --section '{{ item.section }}' {{ galaxy_install_tool_extra_args }}"
       with_items: "{{ galaxy_tools }}"
 
     - name: "Deactivate Galaxy master API key"

--- a/roles/galaxy-utils/files/install_tool.sh
+++ b/roles/galaxy-utils/files/install_tool.sh
@@ -3,7 +3,7 @@
 # Install tool using nebulizer & Galaxy API
 
 if [ $# -eq 0 ] ; then
-    echo Usage: $0 SHED TOOL OWNER APIKEY \[URL\] \[--section SECTION\]
+    echo Usage: $0 SHED TOOL OWNER APIKEY \[URL\] \[--section SECTION\] \[--check-install\]
     exit
 fi
 
@@ -12,12 +12,16 @@ TOOL=$2
 OWNER=$3
 APIKEY=$4
 SECTION=
+CHECKINSTALL=
 URL=http://localhost:80
 while [ ! -z "$5" ] ; do
     case "$5" in
 	--section)
 	    shift
 	    SECTION=$5
+	    ;;
+	--check-install)
+	    CHECKINSTALL=yes
 	    ;;
 	*)
 	    URL=$5
@@ -58,7 +62,11 @@ if [ $retcode -ne 0 ] ; then
     echo Nonzero return code ignored
 fi
 
-# Check that tool exists
+# Check that tool exists?
+if [ -z "$CHECKINSTALL" ] ; then
+    exit
+fi
+echo Checking that tool is installed
 ntries=0
 while [ $ntries -lt 10 ] ; do
     if [ -n "$(tool_installing)" ] ; then


### PR DESCRIPTION
Updates the `install_tool.sh` script in the `galaxy-utils` role, to disable the post-install checks unless a new `--check-install` option is also specified when invoking the script.

Also updates the `galaxy-install-tools` role to enable this option to be specified, by setting it in the new `galaxy_install_tool_extra_args` parameter.