### PR TITLE
Bump Galaxy version to 21.09 for building virtualenvs for cluster

### DIFF
--- a/inventories/csf/centaurus.yml
+++ b/inventories/csf/centaurus.yml
@@ -12,5 +12,5 @@ csf:
     galaxy_group: "galaxy"
     galaxy_gid: 400
     # Galaxy and Python versions to target
-    galaxy_version: "20.09"
+    galaxy_version: "21.09"
     python_version: "3.8.13"

--- a/inventories/csf/palfinder.yml
+++ b/inventories/csf/palfinder.yml
@@ -12,5 +12,5 @@ csf:
     galaxy_group: "galaxy"
     galaxy_gid: 400
     # Galaxy and Python versions to target
-    galaxy_version: "20.09"
+    galaxy_version: "21.09"
     python_version: "3.8.13"


### PR DESCRIPTION
Updates the Galaxy version to 21.09 in the appropriate YAML files under `inventories/csf` for building virtual environments to execute Galaxy jobs on the compute cluster for Palfinder and Centaurus instances.