### PR TITLE
Bump Galaxy version to 21.05 for building virtualenvs for cluster

### DIFF
--- a/inventories/csf/centaurus.yml
+++ b/inventories/csf/centaurus.yml
@@ -12,5 +12,5 @@ csf:
     galaxy_group: "galaxy"
     galaxy_gid: 400
     # Galaxy and Python versions to target
-    galaxy_version: "20.09"
+    galaxy_version: "21.05"
     python_version: "3.8.13"

--- a/inventories/csf/palfinder.yml
+++ b/inventories/csf/palfinder.yml
@@ -12,5 +12,5 @@ csf:
     galaxy_group: "galaxy"
     galaxy_gid: 400
     # Galaxy and Python versions to target
-    galaxy_version: "20.09"
+    galaxy_version: "21.05"
     python_version: "3.8.13"

--- a/roles/export-galaxy-for-cluster/tasks/dependencies.yml
+++ b/roles/export-galaxy-for-cluster/tasks/dependencies.yml
@@ -22,4 +22,6 @@
       - 'tkinter'
       - 'libffi'
       - 'libffi-devel'
+      - 'xz'
+      - 'xz-devel'
     state: 'present'


### PR DESCRIPTION
Updates the Galaxy version to 21.05 in the appropriate YAML files under `inventories/csf` for building virtual environments to execute Galaxy jobs on the compute cluster for Palfinder and Centaurus instances.

Testing on cluster indicates that building Python 3.8 also needs the `xz` and `xv-devel` system libraries in order for the Galaxy upload to function correctly.