### PR TITLE
'galaxy' role: update JSE-Drop runner for Galaxy 21.05

### DIFF
--- a/roles/galaxy/files/jse_drop_runner.py
+++ b/roles/galaxy/files/jse_drop_runner.py
@@ -408,10 +408,6 @@ class JSEDropJobRunner(AsynchronousJobRunner):
             log.exception("(%s/%s) Job wrapper finish method failed: %s" %
                           (galaxy_id_tag,external_job_id,ex))
             job_state.job_wrapper.fail("Unable to finish job", exception=True)
-        # Clean up the job files
-        cleanup_job = self.app.config.cleanup_job
-        if cleanup_job == "always" or (not stderr and cleanup_job == "onsuccess"):
-            job_state.cleanup()
         # Set the job state
         try:
             job_state.job_wrapper.finish(stdout,stderr,exit_code)

--- a/roles/galaxy/files/jse_drop_runner.py
+++ b/roles/galaxy/files/jse_drop_runner.py
@@ -389,18 +389,10 @@ class JSEDropJobRunner(AsynchronousJobRunner):
                           (external_job_id,tool_stdout_path))
                 with io.open(tool_stdout_path,'rt') as fp:
                     stdout = fp.read()
-                    try:
-                        # Try to clean up non-ascii characters
-                        # (Python 2 only)
-                        stdout = stdout.\
-                                 encode('ascii',errors='ignore').\
-                                 replace('\x00','?')
-                    except TypeError:
-                        pass
             else:
                 log.debug("finish_job %s: couldn't find %s" %
                           (external_job_id,tool_stdout_path))
-                stdout = "Unable to acquire tool output"
+                stdout = "Unable to acquire tool stdout"
             # Stderr
             tool_stderr_path = os.path.join(outputs_directory,"tool_stderr")
             if os.path.exists(tool_stderr_path):
@@ -408,18 +400,10 @@ class JSEDropJobRunner(AsynchronousJobRunner):
                           (external_job_id,tool_stderr_path))
                 with io.open(tool_stderr_path,'rt') as fp:
                     stderr = fp.read()
-                    try:
-                        # Try to clean up non-ascii characters
-                        # (Python 2 only)
-                        stderr = stderr.\
-                                 encode('ascii',errors='ignore').\
-                                 replace('\x00','?')
-                    except TypeError:
-                        pass
             else:
                 log.debug("finish_job %s: couldn't find %s" %
                           (external_job_id,tool_stderr_path))
-                stderr = "Unable to acquire tool output"
+                stderr = "Unable to acquire tool stderr"
         except Exception as ex:
             log.exception("(%s/%s) Job wrapper finish method failed: %s" %
                           (galaxy_id_tag,external_job_id,ex))

--- a/roles/galaxy/files/jse_drop_runner.py
+++ b/roles/galaxy/files/jse_drop_runner.py
@@ -404,12 +404,7 @@ class JSEDropJobRunner(AsynchronousJobRunner):
                 log.debug("finish_job %s: couldn't find %s" %
                           (external_job_id,tool_stderr_path))
                 stderr = "Unable to acquire tool stderr"
-        except Exception as ex:
-            log.exception("(%s/%s) Job wrapper finish method failed: %s" %
-                          (galaxy_id_tag,external_job_id,ex))
-            job_state.job_wrapper.fail("Unable to finish job", exception=True)
-        # Set the job state
-        try:
+            # Set the job state
             job_state.job_wrapper.finish(stdout,stderr,exit_code)
         except Exception as ex:
             log.exception("(%s/%s) Job wrapper finish method failed: %s" %


### PR DESCRIPTION
Updates for compatibility with Galaxy 21.05:

* Remove the Python 2 specific code for handling non-ASCII characters in tool stdout and stderr (Galaxy now only runs under Python 3)
* Remove the explicit invocation of the job wrapper's `cleanup` method, as this seemed to cause a database deadlocking error when invoked (two processes trying to alter the same entries simultaneously) which caused the associated job to be reported as failed. Although not entirely clear to me, it does appear that the `cleanup` operation is invoked implicitly elsewhere so the runner no longer needs to do this
* Tidy up handling of job termination, to try and avoid possible double handling