### PR TITLE
'galaxy' role: ensure check 'galaxy_installation_tmp_dir' exists

### DIFF
--- a/roles/galaxy/tasks/galaxy.yml
+++ b/roles/galaxy/tasks/galaxy.yml
@@ -302,6 +302,11 @@
     - galaxy_version == "release_20.01"
 
 # Temp dirs for pip and yarn caches
+- name: "Check/create temporary cache directory"
+  file:
+    path: "{{ galaxy_installation_tmp_dir }}"
+    state: directory
+
 - name: "Make temporary pip cache directory"
   tempfile:
     path: "{{ galaxy_installation_tmp_dir }}"


### PR DESCRIPTION
Update the `galaxy` role to ensure that the directory specified by `galaxy_installation_tmp_dir` (used for the `pip` and `yarn` caches when running `common_setup.sh`) actually exists.