### PR TITLE
'galaxy' role: enable forced removal of compiled mako templates

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -413,6 +413,14 @@ Python and the Galaxy virtual environment, by specifiying:
    galaxy_force_reinstall_python: yes
    galaxy_force_reinstall_venv: yes
 
+Finally, it may also be a good idea to refresh the compiled Mako
+templates (especially if upgrading to a new Galaxy release or
+Python version) - this can be done automatically by specifying:
+
+::
+
+   galaxy_remove_mako_templates: yes
+
 Notes on the deployment
 -----------------------
 

--- a/roles/galaxy/defaults/main.yml
+++ b/roles/galaxy/defaults/main.yml
@@ -116,6 +116,11 @@ galaxy_force_reinstall_python: no
 # Temporary directory to use during installation
 galaxy_installation_tmp_dir: "/tmp"
 
+# Remove compiled mako templates?
+# This might be necessary when upgrading to a new
+# Galaxy release and/or Python version
+galaxy_remove_mako_templates: yes
+
 # Toolshed check
 enable_tool_shed_check: no
 

--- a/roles/galaxy/tasks/galaxy.yml
+++ b/roles/galaxy/tasks/galaxy.yml
@@ -291,15 +291,18 @@
   with_items: "{{ galaxy_sanitize_whitelist_tools }}"
   when: galaxy_sanitize_whitelist_tools|default(None) != None
 
-# Remove compiled .mako templates for Python 3 updates
-# See https://docs.galaxyproject.org/en/release_20.01/admin/python.html
-- name: "Remove compiled .mako templates"
+# Remove compiled .mako templates
+- name: "Remove compiled .mako templates from 'database'"
   file:
     path: '{{ galaxy_root }}/database/compiled_templates/'
     state: absent
-  when:
-    - galaxy_python_version.startswith("3.")
-    - galaxy_version == "release_20.01"
+  when: galaxy_remove_mako_templates == True
+
+- name: "Remove compiled .mako templates from 'database/cache'"
+  file:
+    path: '{{ galaxy_root }}/database/cache/compiled_templates/'
+    state: absent
+  when: galaxy_remove_mako_templates == True
 
 # Temp dirs for pip and yarn caches
 - name: "Make temporary pip cache directory"


### PR DESCRIPTION
Updates the `galaxy` role to enable a playbook to force removal of any existing compiled mako templates (which may be necessary when updating the Galaxy and/or Python versions) by setting the new `galaxy_remove_mako_templates` variable to `yes` (default is `no`).