### PR TITLE
'galaxy' role: update pinned 'pydantic' version for Galaxy 21.05

### DIFF
--- a/roles/galaxy/tasks/galaxy.yml
+++ b/roles/galaxy/tasks/galaxy.yml
@@ -99,7 +99,7 @@
       when: venv_python_version.stdout != external_python_version.stdout
   when: galaxy_venv.stat.exists
 
-- name: "Remove futures from pinned-requirements.txt"
+- name: "Remove futures from pinned-requirements.txt (release_20.09)"
   lineinfile:
     path: '{{ galaxy_root }}/lib/galaxy/dependencies/pipfiles/default/pinned-requirements.txt'
     state: absent

--- a/roles/galaxy/tasks/galaxy.yml
+++ b/roles/galaxy/tasks/galaxy.yml
@@ -106,6 +106,14 @@
     line: "futures==3.1.1"
   when: galaxy_version == "release_20.09"
 
+- name: "Change pydantic version to 1.10 in pinned-requirements.txt (release_21.05)"
+  lineinfile:
+    path: '{{ galaxy_root }}/lib/galaxy/dependencies/pinned-requirements.txt'
+    search_string: "pydantic==1.7.3;"
+    state: present
+    line: 'pydantic==1.10; python_version >= "3.6" and python_version < "4.0"'
+  when: galaxy_version == "release_21.05"
+
 - name: "Make virtualenv in Galaxy root"
   command:
     chdir: '{{ galaxy_root }}'


### PR DESCRIPTION
Updates the `galaxy` role to modify the default `pinned-requirements.txt` file to change the required version of the `pydantic` package to 1.10 (rather than original 1.7.3), when Galaxy version is `release_21.05`.

This update appears to fix a bug with the installed Galaxy continually producing errors of the form `RunTimeError: cannot release un-acquired lock in logging module`.

(As previously `pydantic==1.7.3` worked without problems this is possibly due to a recent update somewhere in the dependency tree of the `pydantic` package. Note that the suggestion of setting `py-call-osafterfork = false` in the `uwsgi` section of the Galaxy config - which also seems to appear in the context of the above error message - didn't do anything in this case.)