### PR TITLE
'galaxy-utils' role: fix to 'gx_dump_database.py' when setting environment for 'pg_dump'

### DIFF
--- a/roles/galaxy-utils/files/gx_dump_database.py
+++ b/roles/galaxy-utils/files/gx_dump_database.py
@@ -93,7 +93,7 @@ if __name__ == "__main__":
     # Run pg_dump
     try:
         subprocess.run(['pg_dump','-U',user,name],
-                       env={ 'PGPASSWORD': passwd },
+                       env={ **os.environ, 'PGPASSWORD': passwd },
                        stdout=fpout)
     except Exception as ex:
         logging.critical("SQL dump failed: %s" % ex)


### PR DESCRIPTION
Updates the `gx_dump_database.py` utility (in the `galaxy-utils` role) to ensure that the runtime environment set when invoking the `pg_dump` utility via `subprocess` is complete.

Without this fix the script may give the message `could not find a "pg_dump" to execute` (although it appears to successfully dump the database SQL).

The fix is to pass the entire environment to `subprocess` using the fix suggested at https://stackoverflow.com/a/65192626