### PR TITLE
Galaxy install tools fix for unmanaged local tools

### DIFF
--- a/roles/galaxy-install-tools/defaults/main.yml
+++ b/roles/galaxy-install-tools/defaults/main.yml
@@ -57,8 +57,9 @@ local_galaxy_tools: []
 # If defined then should be a list of dictionaries, each
 # of the form:
 #
-# - name: internal name for the tool
-# - tool_xml_files: paths to XML files (as a list)
+# - name: internal name for the tool (not used)
+# - tool_xml_files: paths to XML files relative to the
+#   'local_tools' directory (as a list)
 # - section: dictionary with 'name' and 'id' of target section
 #
 # For example:
@@ -66,9 +67,9 @@ local_galaxy_tools: []
 # local_galaxy_tool_references:
 #      - name: "cas13_design"
 #        tool_xml_files:
-#          - "tools/cas13_design/RfxCas13d_GuideScoring.xml"
-#          - "tools/cas13_design/guide_specificity_metrics.xml"
-#          - "tools/cas13_design/pdf_report.xml"
+#          - "cas13_design/tools/cas13_design/RfxCas13d_GuideScoring.xml"
+#          - "cas13_design/tools/cas13_design/guide_specificity_metrics.xml"
+#          - "cas13_design/tools/cas13_design/pdf_report.xml"
 #        section:
 #          name: "Cas13 Guide Design"
 #          id: "cas13-guide-design"

--- a/roles/galaxy-install-tools/tasks/main.yml
+++ b/roles/galaxy-install-tools/tasks/main.yml
@@ -57,7 +57,7 @@
 # Create .loc files from samples
 - name: "Create and populate loc files"
   block:
-    - name: "Create loc files from sample versions"
+    - name: "Create initial empty loc files from sample versions"
       copy:
         src='{{ galaxy_root }}/tool-data/{{ item.loc_file }}.sample'
         dest='{{ galaxy_root }}/tool-data/{{ item.loc_file }}'
@@ -66,7 +66,7 @@
         - '{{ galaxy_loc_file_data }}'
 
     # Update the reference data
-    - name: "Update tool data in loc files"
+    - name: "Populate loc files with tool data"
       lineinfile:
         path='{{ galaxy_root }}/tool-data/{{ item.0.loc_file }}'
         state=present

--- a/roles/galaxy-install-tools/templates/local_tool_conf.xml.j2
+++ b/roles/galaxy-install-tools/templates/local_tool_conf.xml.j2
@@ -26,7 +26,7 @@ This file is maintained by Ansible - CHANGES WILL BE OVERWRITTEN
 {%     endif %}
 {%     for tool_file in tool.tool_xml_files %}
 {%       if tool_file.endswith(".xml") %}
-    <tool file="{{ tool.name }}/{{ tool_file | basename }}" />
+    <tool file="{{ tool_file }}" />
 {%       endif %}
 {%     endfor %}
 {%     if "section" in tool %}

--- a/roles/galaxy-install-tools/templates/local_tool_conf.xml.j2
+++ b/roles/galaxy-install-tools/templates/local_tool_conf.xml.j2
@@ -4,6 +4,9 @@ This file is maintained by Ansible - CHANGES WILL BE OVERWRITTEN
 -->
 <toolbox tool_path="../local_tools">
 {% if local_galaxy_tools is not none %}
+<!--
+    Local tools installed by Ansible
+-->
 {%   for tool in local_galaxy_tools %}
 {%     if "section" in tool %}
   <section id="{{ tool.section.id }}" name="{{ tool.section.name }}">
@@ -20,6 +23,9 @@ This file is maintained by Ansible - CHANGES WILL BE OVERWRITTEN
 {%   endfor %}
 {% endif %}
 {% if local_galaxy_tool_references is not none %}
+<!--
+    Additional local tools not installed by Ansible
+-->
 {%   for tool in local_galaxy_tool_references %}
 {%     if "section" in tool %}
   <section id="{{ tool.section.id }}" name="{{ tool.section.name }}">


### PR DESCRIPTION
Fix to `galaxy-install-tools` role when generating the `local_tool_conf.xml` file with "unmanaged" local tools (i.e. local tools that are not installed via the Ansible playbook, originally implemented in PR #240).

Prior to this fix the paths to the tool XML files were incorrectly added to the `local_tool_conf.xml` file, meaning that the tools did not appear within Galaxy.