### PR TITLE
'galaxy-install-tools': handle missing `.loc.sample` files

### DIFF
--- a/roles/galaxy-install-tools/tasks/main.yml
+++ b/roles/galaxy-install-tools/tasks/main.yml
@@ -57,11 +57,19 @@
 # Create .loc files from samples
 - name: "Create and populate loc files"
   block:
+    - name: "Create any missing sample loc files"
+      copy:
+        content: ""
+        dest: "{{ galaxy_root }}/tool-data/{{ item.loc_file }}.sample"
+        force: false
+      with_items:
+        - '{{ galaxy_loc_file_data }}'
+
     - name: "Create initial empty loc files from sample versions"
       copy:
-        src='{{ galaxy_root }}/tool-data/{{ item.loc_file }}.sample'
-        dest='{{ galaxy_root }}/tool-data/{{ item.loc_file }}'
-        remote_src=True
+        src: '{{ galaxy_root }}/tool-data/{{ item.loc_file }}.sample'
+        dest: '{{ galaxy_root }}/tool-data/{{ item.loc_file }}'
+        remote_src: true
       with_items:
         - '{{ galaxy_loc_file_data }}'
 


### PR DESCRIPTION
Fixes the `galaxy-install-tools` role to handle missing `.loc.sample` files, by creating empty versions of any that are not found.

Without the fix, missing sample files caused the task creating `.loc` files from the samples to fail.