### PR TITLE
'galaxy-utils': enable option for faster tool installation

### DIFF
--- a/roles/galaxy-install-tools/defaults/main.yml
+++ b/roles/galaxy-install-tools/defaults/main.yml
@@ -31,6 +31,9 @@ galaxy_tools: []
 #   tool existence after installing (increases installation
 #   time but identifies tools where dependencies can't be
 #   installed or new Galaxy version is needed)
+# - Set to "--no-wait" to force tool installation not to wait
+#   for installations to complete (fastest option if tools
+#   are already installed, not recommended otherwise)
 galaxy_install_tool_extra_args:
 
 # Local tools to be installed

--- a/roles/galaxy-utils/files/install_tool.sh
+++ b/roles/galaxy-utils/files/install_tool.sh
@@ -3,7 +3,7 @@
 # Install tool using nebulizer & Galaxy API
 
 if [ $# -eq 0 ] ; then
-    echo Usage: $0 SHED TOOL OWNER APIKEY \[URL\] \[--section SECTION\] \[--check-install\]
+    echo Usage: $0 SHED TOOL OWNER APIKEY \[URL\] \[--section SECTION\] \[--check-install\] \[--no-wait\]
     exit
 fi
 
@@ -13,6 +13,7 @@ OWNER=$3
 APIKEY=$4
 SECTION=
 CHECKINSTALL=
+NOWAIT=
 URL=http://localhost:80
 while [ ! -z "$5" ] ; do
     case "$5" in
@@ -22,6 +23,10 @@ while [ ! -z "$5" ] ; do
 	    ;;
 	--check-install)
 	    CHECKINSTALL=yes
+	    ;;
+	--no-wait)
+	    shift
+	    NOWAIT="--no-wait"
 	    ;;
 	*)
 	    URL=$5
@@ -52,9 +57,9 @@ fi
 
 # Install the tool
 if [ -z "$SECTION" ] ; then
-    $NEBULIZER -k $APIKEY install_tool -y $URL $SHED $OWNER $TOOL
+    $NEBULIZER -k $APIKEY install_tool -y $NOWAIT $URL $SHED $OWNER $TOOL
 else
-    $NEBULIZER -k $APIKEY install_tool -y --tool-panel-section "$SECTION" $URL $SHED $OWNER $TOOL
+    $NEBULIZER -k $APIKEY install_tool -y $NOWAIT --tool-panel-section "$SECTION" $URL $SHED $OWNER $TOOL
 fi
 retcode=$?
 echo Tool installation returned $retcode


### PR DESCRIPTION
Updates the `install_tool.sh` script in `galaxy-utils` to expose `nebulizer`'s `--no-wait` option when installing tools from the toolshed. This option forces `nebulizer install_tool` to return immediately (rather than waiting for Galaxy to finish the tool installation).

When this option is specified in the `galaxy_install_tool_extra_args` variable when running the `galaxy-install-tools` utility, then the tool installation invocations should proceed much more rapidly - this can enable faster completion of the tasks, but may cause problems if Galaxy is restarted before the installations have completed on the server (for this reason it is really only recommended when running the playbooks on Galaxy servers where the tools are already installed).