### PR TITLE
'galaxy' role: update JSE Drop client and job runner for Galaxy 21.05

### DIFF
--- a/roles/galaxy/defaults/main.yml
+++ b/roles/galaxy/defaults/main.yml
@@ -184,7 +184,7 @@ galaxy_jse_drop_dir: "{{ galaxy_dir }}/jse-drop"
 galaxy_jse_drop_virtual_env: "{{ galaxy_root }}/.venv"
 # Grace period after which files from deleted jobs
 # can be removed (seconds)
-galaxy_jse_drop_cleanup_grace_period: "600"
+galaxy_jse_drop_cleanup_grace_period: "300"
 
 # Job destinations
 # Define entries as a dictionary with:

--- a/roles/galaxy/files/jse_drop.py
+++ b/roles/galaxy/files/jse_drop.py
@@ -677,20 +677,10 @@ def jse_drop_cleanup_deleted(drop_dir,interval,timeout=600):
       interval (int): interval (in seconds) from now which
         deleted jobs must be older than in order to be
         cleaned up
-
     """
-    jsedrop = JSEDrop(drop_dir)
-    now = datetime.now()
-    interval = timedelta(seconds=interval)
-    jobs = [j for j in jsedrop.jobs()
-            if (jsedrop.status(j) == JSEDropStatus.DELETED
-                and
-                (now - datetime.fromtimestamp(jsedrop.timestamp(j)))
-                > interval)]
-    for job in jobs:
-        print("%s: cleaning up deleted job '%s'" %
-              (time.strftime("%Y-%m-%d %H:%M:%S"),job))
-        jsedrop.cleanup(job)
+    return jse_drop_cleanup(drop_dir,interval=interval,
+                            status=(JSEDropStatus.DELETED,),
+                            timeout=timeout)
 
 if __name__ == '__main__':
     # Test program

--- a/roles/galaxy/files/jse_drop_runner.py
+++ b/roles/galaxy/files/jse_drop_runner.py
@@ -318,10 +318,8 @@ class JSEDropJobRunner(AsynchronousJobRunner):
                     # Failure
                     job_state.job_wrapper.change_state(model.Job.states.ERROR)
                     self.mark_as_failed(job_state)
-                ##FIXME not sure if clean up of the JSE-drop files
-                ##FIXME should be the responsibility of the runner?
-                # Remove the JSE-drop files
-                self.cleanup(job_name,("always","onsuccess"))
+                # Mark the JSE-drop files for removal
+                self.mark_for_cleanup(job_name,("always","onsuccess"))
                 return None
 
             elif jse_drop_status == JSEDropStatus.RUNNING:
@@ -364,10 +362,8 @@ class JSEDropJobRunner(AsynchronousJobRunner):
                 self.create_log_files(job_state)
                 job_state.job_wrapper.change_state(model.Job.states.ERROR)
                 self.mark_as_failed(job_state)
-                ##FIXME not sure if clean up of the JSE-drop files
-                ##FIXME should be the responsibility of the runner?
-                # Remove the JSE-drop files
-                self.cleanup(job_name,("always",))
+                # Mark the JSE-drop files for removal
+                self.mark_for_cleanup(job_name,("always",))
                 return None
 
             ##FIXME: not clear if it matters to the runner that
@@ -474,11 +470,10 @@ class JSEDropJobRunner(AsynchronousJobRunner):
                 fp.write("Unable to acquire tool stderr")
         return exit_code
 
-    def cleanup(self,job_name,conditions):
-        # Remove the JSEDrop files associated with the job
-        # if Galaxy's "cleanup_job" setting matches one of
-        # the supplied conditions
-        # NB does not clean up the actual job outputs
+    def mark_for_cleanup(self,job_name,conditions):
+        # Mark the JSEDrop files associated with the job for
+        # removal if Galaxy's "cleanup_job" setting matches one
+        # of the specified conditions
         cleanup_job = self.app.config.cleanup_job
         if cleanup_job in conditions:
             log.info("%s: marking JSEDrop files for cleanup" % job_name)

--- a/roles/galaxy/files/jse_drop_runner.py
+++ b/roles/galaxy/files/jse_drop_runner.py
@@ -481,5 +481,5 @@ class JSEDropJobRunner(AsynchronousJobRunner):
         # NB does not clean up the actual job outputs
         cleanup_job = self.app.config.cleanup_job
         if cleanup_job in conditions:
-            log.info("%s: cleanup JSEDrop files" % job_name)
-            JSEDrop(self._get_drop_dir()).cleanup(job_name)
+            log.info("%s: marking JSEDrop files for cleanup" % job_name)
+            JSEDrop(self._get_drop_dir()).mark_for_cleanup(job_name)

--- a/roles/galaxy/files/jse_drop_runner.py
+++ b/roles/galaxy/files/jse_drop_runner.py
@@ -3,6 +3,8 @@ Job runner used to execute Galaxy jobs through JSE-drop.
 
 **This version is compatible with Galaxy 21.05**
 
+(See https://github.com/galaxyproject/galaxy/blob/release_21.05/doc/source/dev/build_a_job_runner.rst)
+
 To configure Galaxy to use JSE-drop:
 
 1. Enable the plugin in job_conf.xml, for example:
@@ -64,6 +66,7 @@ The parameters available for the destinations are:
 """
 
 import logging
+import shutil
 import string
 import time
 import io
@@ -107,9 +110,10 @@ class JSEDropJobRunner(AsynchronousJobRunner):
         kwargs[ 'runner_param_specs' ].update( runner_param_specs )
         # Initialise the base class
         super( JSEDropJobRunner, self ).__init__( app, nworkers, **kwargs )
-        # Initialise the queues from the base class
-        self._init_monitor_thread()
-        self._init_worker_threads()
+        # Keep a record of completed jobs (to see if job
+        # completion is being double-handled)
+        self._check_double_handling = True
+        self._completed = list()
 
     def _get_job_name(self,galaxy_id_tag,tool_id=None,galaxy_id=None):
         """
@@ -164,6 +168,25 @@ class JSEDropJobRunner(AsynchronousJobRunner):
         except KeyError:
             return None
 
+    def _register_completed_job(self,job_name):
+        """
+        Raises exception if job completion is double handled
+
+        If double handling checking is enabled then the
+        name of the completed job will be checked against
+        the list of previously completed jobs. An
+        exception will be raised if the same job name
+        has already been registered.
+        """
+        if not self._check_double_handling:
+            return
+        if job_name in self._completed:
+            raise Exception("'%s': job already added to list of "
+                            "'completed' jobs in JSE-Drop runner" %
+                            job_name)
+        else:
+            self._completed.append(job_name)
+
     def parse_destination_params(self, params):
         """Parse the JobDestination ``params`` dict and return the runner's native representation of those params.
         """
@@ -194,7 +217,7 @@ class JSEDropJobRunner(AsynchronousJobRunner):
                           "JSE-drop directory defined)" %
                           (galaxy_id_tag,job_name))
             return
-        # Initialise JSE-drop wrapper
+        # Initialise JSE-drop client interface
         jse_drop = JSEDrop(drop_off_dir)
         # ID and name for job
         galaxy_id_tag = job_wrapper.get_id_tag()
@@ -236,7 +259,8 @@ class JSEDropJobRunner(AsynchronousJobRunner):
         script = "\n".join((shell,qsub_header,script))
         # Create the drop file to submit the job
         try:
-            drop_file = jse_drop.run(job_name,script)
+            with jse_drop.get_lock(timeout=60):
+                drop_file = jse_drop.run(job_name,script)
             log.debug("created drop file %s" % drop_file)
             log.info("(%s) submitted as %s" % (galaxy_id_tag,job_name))
         except:
@@ -259,50 +283,8 @@ class JSEDropJobRunner(AsynchronousJobRunner):
         ajs.running = False
         ajs.job_destination = job_destination
         # Add to the queue of jobs to monitor
-        self.monitor_job(ajs)
-        log.info("%s: queued" % job_name)
-
-    def stop_job(self,job_wrapper):
-        # Attempts to remove a job from the JSE-Drop queue
-        # Fetch the job id used by JSE-Drop
-        job_name = job_wrapper.get_job().job_runner_external_id
-        # Fetch the drop dir
-        try:
-            drop_off_dir = self._get_drop_dir()
-            log.debug("stop_job: drop-off dir = %s" % drop_off_dir)
-            jse_drop = JSEDrop(drop_off_dir)
-            # Delete the job
-            jse_drop.kill(job_name)
-            log.debug("JSE-drop: killed job '%s'" % job_name)
-        except Exception as ex:
-            log.error("stop_job: failed with exception: %s", ex)
-
-    def recover(self,job,job_wrapper):
-        # Recovers jobs in the queued/running state when Galaxy started
-        # What is 'job' an instance of???
-        # Could be model.Job?
-        # Fetch the job id used by JSE-Drop
-        job_name = job.get_job_runner_external_id()
-        # Get the job destination
-        job_destination = job_wrapper.job_destination
-        # Fetch the drop dir
-        drop_off_dir = self._get_drop_dir()
-        log.debug("recover: drop-off dir = %s" % drop_off_dir)
-        jse_drop = JSEDrop(drop_off_dir)
-        # Store state information for job
-        ajs = AsynchronousJobState()
-        ajs.job_wrapper = job_wrapper
-        ajs.job_id = job_name
-        ajs.job_destination = job_destination
-        # Sort out the status
-        if job.state == model.Job.states.RUNNING:
-            ajs.old_state = True
-            ajs.running = True
-        elif job.get_state() == model.Job.states.QUEUED:
-            ajs.old_state = True
-            ajs.running = False
-        # Add to the queue of jobs to monitor
         self.monitor_queue.put(ajs)
+        log.info("%s: queued" % job_name)
 
     def check_watched_item(self,job_state):
         # Check for change in job state
@@ -314,28 +296,47 @@ class JSEDropJobRunner(AsynchronousJobRunner):
         with jse_drop.get_lock(timeout=60):
             #log.info("%s: acquired lock" % job_name)
             jse_drop_status = jse_drop.status(job_name)
-            if jse_drop_status == JSEDropStatus.RUNNING and \
-               not job_state.running:
-                # Job has started running
-                log.info("%s: job started running" % job_name)
-                job_state.running = True
-                job_state.job_wrapper.change_state(model.Job.states.RUNNING)
-                return job_state
-            elif jse_drop_status == JSEDropStatus.FINISHED:
+
+            if jse_drop_status == JSEDropStatus.FINISHED:
                 # Job has finished
-                log.info("%s: job has finished" % job_name)
                 job_state.running = False
-                self.mark_as_finished(job_state)
+                log.info("%s: job has finished" % job_name)
+                self._register_completed_job(job_name)
+                # NB JSE-drop finished state only indicates
+                # job completion, not whether it succeeded or
+                # failed - we need to check the exit status
+                # to determine that
+                exit_code = self.create_log_files(job_state)
+                if exit_code == 0:
+                    # Success
+                    job_state.job_wrapper.change_state(model.Job.states.OK)
+                    self.mark_as_finished(job_state)
+                else:
+                    # Failure
+                    job_state.job_wrapper.change_state(model.Job.states.ERROR)
+                    self.mark_as_failed(job_state)
+                ##FIXME not sure if clean up of the JSE-drop files
+                ##FIXME should be the responsibility of the runner?
                 # Remove the JSE-drop files
                 self.cleanup(job_name,("always","onsuccess"))
                 return None
+
+            elif jse_drop_status == JSEDropStatus.RUNNING:
+                if not job_state.running:
+                    # Job has started running
+                    log.info("%s: job started running" % job_name)
+                    job_state.running = True
+                    job_state.job_wrapper.change_state(model.Job.states.RUNNING)
+                return job_state
+
             elif jse_drop_status in (JSEDropStatus.FAILED,
                                      JSEDropStatus.MISSING,
                                      JSEDropStatus.ERROR,):
-                # Job has finished but with an error
+                # Job has finished with an error from JSE-drop
+                job_state.running = False
                 log.info("%s: job has finished with an error" %
                          job_name)
-                job_state.running = False
+                self._register_completed_job(job_name)
                 if jse_drop_status == JSEDropStatus.FAILED:
                     # Get message from qfail file
                     log.warn("%s: failed" % job_name)
@@ -357,66 +358,118 @@ class JSEDropJobRunner(AsynchronousJobRunner):
                              "fail_job (ignored): %s" % (job_name,
                                                          jse_drop_status,
                                                          ex))
+                self.create_log_files(job_state)
+                job_state.job_wrapper.change_state(model.Job.states.ERROR)
+                self.mark_as_failed(job_state)
+                ##FIXME not sure if clean up of the JSE-drop files
+                ##FIXME should be the responsibility of the runner?
                 # Remove the JSE-drop files
                 self.cleanup(job_name,("always",))
                 return None
-            elif jse_drop_status == JSEDropStatus.DELETED:
-                # Job has been deleted
-                # Update state and clean up JSE-drop files
-                log.info("%s: job has been deleted" % job_name)
-                job_state.running = False
-                self.cleanup(job_name,("always","onsuccess"))
-                return None
-        # Other states are ignored
-        return job_state
 
-    def finish_job(self,job_state):
-        # Looks like we need to over-ride the version of this
-        # method in the base class in order to handle setting of
-        # stdout/stderr files and exit code
+            ##FIXME: not clear if it matters to the runner that
+            ##FIXME: the job is being delete?
+            ##elif jse_drop_status == JSEDropStatus.DELETED:
+            ##    # Job has been deleted
+            ##    # Update state and clean up JSE-drop files
+            ##    log.info("%s: job has been deleted" % job_name)
+            ##    job_state.running = False
+            ##    self.cleanup(job_name,("always","onsuccess"))
+            ##    return None
+
+            # Other states are ignored
+            return job_state
+
+    def stop_job(self,job_wrapper):
+        # Invoked by Galaxy to remove a job from the JSE-Drop queue
+        # Also appears to be invoked when a job completes normally?
+        # Fetch the job id used by JSE-Drop
+        job_name = job_wrapper.get_job().job_runner_external_id
+        log.debug("stop_job: job_name = %s" % job_name)
+        # Fetch the drop dir
+        try:
+            jse_drop = JSEDrop(self._get_drop_dir())
+            with jse_drop.get_lock(timeout=60):
+                jse_drop_status = jse_drop.status(job_name)
+                if jse_drop_status in (JSEDropStatus.WAITING,
+                                       JSEDropStatus.RUNNING):
+                    # Delete job which is either pending or running
+                    jse_drop.kill(job_name)
+                    log.debug("JSE-drop: killed job '%s'" % job_name)
+                    ##FIXME this looks like trying to do clean up
+                    ##FIXME prematurely?
+                    ### Clean up JSE-drop files
+                    ##self.cleanup(job_name,("always","onsuccess")
+                else:
+                    log.warning("JSE-drop: job '%s' not in a state that can "
+                                "be stopped" % job_name)
+        except Exception as ex:
+            log.error("stop_job: failed with exception: %s", ex)
+
+    def recover(self,job,job_wrapper):
+        # Recovers jobs in the queued/running state when Galaxy started
+        # Fetch the job id used by JSE-Drop
+        job_name = job.get_job_runner_external_id()
+        # Get the job destination
+        job_destination = job_wrapper.job_destination
+        # Store state information for job
+        ajs = AsynchronousJobState()
+        ajs.job_wrapper = job_wrapper
+        ajs.job_id = job_name
+        ajs.job_destination = job_destination
+        # Sort out the status
+        if job.state == model.Job.states.RUNNING:
+            ajs.old_state = 'R'
+            ajs.running = True
+            self.monitor_queue.put(ajs)
+        elif job.get_state() == model.Job.states.QUEUED:
+            ajs.old_state = 'Q'
+            ajs.running = False
+            self.monitor_queue.put(ajs)
+
+    def create_log_files(self,job_state):
+        # Deal with log files and set exit code
         galaxy_id_tag = job_state.job_wrapper.get_id_tag()
         external_job_id = job_state.job_id
-        # Initialise JSE-drop
-        drop_off_dir = self._get_drop_dir()
-        jse_drop = JSEDrop(drop_off_dir)
         # Get exit_code, stdout and stderr
         job_wrapper = job_state.job_wrapper
+        job = job_state.job_wrapper.get_job()
+        # Exit code
+        exit_code = job_state.read_exit_code()
+        log.info("create_log_files %s: exit code = %s" % (external_job_id,
+                                                          exit_code))
+        exit_code_file = job_state.exit_code_file
+        with open(exit_code_file,'wt') as fp:
+            fp.write("%s" % exit_code)
+        # Stdout
+        tool_stdout_path = os.path.join(job_wrapper.working_directory,
+                                        "outputs",
+                                        "tool_stdout")
+        stdout_file = job_state.output_file
         try:
-            job = job_state.job_wrapper.get_job()
-            # Exit code
-            exit_code = job_state.read_exit_code()
-            log.debug("finish_job %s: exit code = %s" %
-                      (external_job_id,exit_code))
-            # Stdout
-            outputs_directory = os.path.join(job_wrapper.working_directory,
-                                             "outputs")
-            tool_stdout_path = os.path.join(outputs_directory,"tool_stdout")
-            if os.path.exists(tool_stdout_path):
-                log.info("finish_job %s: reading stdout from %s" %
-                          (external_job_id,tool_stdout_path))
-                with io.open(tool_stdout_path,'rt') as fp:
-                    stdout = fp.read()
-            else:
-                log.warn("finish_job %s: couldn't find %s" %
-                         (external_job_id,tool_stdout_path))
-                stdout = "Unable to acquire tool stdout"
-            # Stderr
-            tool_stderr_path = os.path.join(outputs_directory,"tool_stderr")
-            if os.path.exists(tool_stderr_path):
-                log.info("finish_job %s: reading stderr from %s" %
-                         (external_job_id,tool_stderr_path))
-                with io.open(tool_stderr_path,'rt') as fp:
-                    stderr = fp.read()
-            else:
-                log.warn("finish_job %s: couldn't find %s" %
-                         (external_job_id,tool_stderr_path))
-                stderr = "Unable to acquire tool stderr"
-            # Set the job state
-            job_state.job_wrapper.finish(stdout,stderr,exit_code)
+            log.info("create_log_files %s: copying stdout from %s" %
+                     (external_job_id,tool_stdout_path))
+            shutil.copyfile(tool_stdout_path,stdout_file)
         except Exception as ex:
-            log.exception("(%s/%s) Job wrapper finish method failed: %s" %
-                          (galaxy_id_tag,external_job_id,ex))
-            job_state.job_wrapper.fail("Unable to finish job", exception=True)
+            log.error("create_log_files %s: unable to copy stdout: %s" %
+                      (external_job_id,ex))
+            with open(stdout_file,'wt') as fp:
+                fp.write("Unable to acquire tool stdout")
+        # Stderr
+        tool_stderr_path = os.path.join(job_wrapper.working_directory,
+                                        "outputs",
+                                        "tool_stderr")
+        stderr_file = job_state.error_file
+        try:
+            log.info("create_log_files %s: copying stderr from %s" %
+                     (external_job_id,tool_stderr_path))
+            shutil.copyfile(tool_stderr_path,stderr_file)
+        except Exception as ex:
+            log.error("create_log_files %s: unable to copy stderr: %s" %
+                     (external_job_id,ex))
+            with open(stderr_file,'wt') as fp:
+                fp.write("Unable to acquire tool stderr")
+        return exit_code
 
     def cleanup(self,job_name,conditions):
         # Remove the JSEDrop files associated with the job

--- a/roles/galaxy/files/jse_drop_runner.py
+++ b/roles/galaxy/files/jse_drop_runner.py
@@ -113,7 +113,7 @@ class JSEDropJobRunner(AsynchronousJobRunner):
         # Keep a record of completed jobs (to see if job
         # completion is being double-handled)
         self._check_double_handling = True
-        self._completed = list()
+        self._completed = set()
 
     def _get_job_name(self,galaxy_id_tag,tool_id=None,galaxy_id=None):
         """
@@ -177,15 +177,18 @@ class JSEDropJobRunner(AsynchronousJobRunner):
         the list of previously completed jobs. An
         exception will be raised if the same job name
         has already been registered.
+
+        NB this mechanism is only intended for debugging
+        purposes.
         """
         if not self._check_double_handling:
             return
         if job_name in self._completed:
-            raise Exception("'%s': job already added to list of "
-                            "'completed' jobs in JSE-Drop runner" %
+            raise Exception("'%s': job already registered as a "
+                            "completed job in JSE-Drop runner" %
                             job_name)
         else:
-            self._completed.append(job_name)
+            self._completed.add(job_name)
 
     def parse_destination_params(self, params):
         """Parse the JobDestination ``params`` dict and return the runner's native representation of those params.

--- a/roles/galaxy/files/jse_drop_runner.py
+++ b/roles/galaxy/files/jse_drop_runner.py
@@ -402,7 +402,7 @@ class JSEDropJobRunner(AsynchronousJobRunner):
                     ##FIXME this looks like trying to do clean up
                     ##FIXME prematurely?
                     ### Clean up JSE-drop files
-                    ##self.cleanup(job_name,("always","onsuccess")
+                    ##self.cleanup(job_name,("always","onsuccess"))
                 else:
                     log.warning("JSE-drop: job '%s' not in a state that can "
                                 "be stopped" % job_name)

--- a/roles/galaxy/tasks/jsedrop.yml
+++ b/roles/galaxy/tasks/jsedrop.yml
@@ -34,10 +34,10 @@
     job='find {{ galaxy_jse_drop_dir }} -name "*" -type f -mtime +{{ galaxy_clean_up_cron_interval }} -exec rm -f {} \;'
     state=present
 
-- name: "Clean up deleted files from JSE-drop directory"
+- name: "Clean up files from JSE-drop directory marked for clean up"
   cron:
     user='{{ galaxy_user }}'
-    name='Clean up deleted JSE-drop jobs'
-    special_time='hourly'
-    job='. {{ galaxy_root }}/.venv/bin/activate && PYTHONPATH={{ galaxy_root }}/lib:$PYTHONPATH python -c "from galaxy.jobs.runners.jse_drop import jse_drop_cleanup_deleted ; jse_drop_cleanup_deleted(\'{{ galaxy_jse_drop_dir }}\',{{ galaxy_jse_drop_cleanup_grace_period }})" 2>&1 1>>{{ galaxy_log_dir}}/jse_drop_cleanup.log'
+    name='Clean up JSE-drop jobs marked for clean up'
+    minute='*/5'
+    job='. {{ galaxy_root }}/.venv/bin/activate && PYTHONPATH={{ galaxy_root }}/lib:$PYTHONPATH python -c "from galaxy.jobs.runners.jse_drop import jse_drop_cleanup ; jse_drop_cleanup(\'{{ galaxy_jse_drop_dir }}\',interval={{ galaxy_jse_drop_cleanup_grace_period }})" 2>&1 1>>{{ galaxy_log_dir}}/jse_drop_cleanup.log'
     state=present

--- a/roles/galaxy/tasks/remove_legacy_artefacts.yml
+++ b/roles/galaxy/tasks/remove_legacy_artefacts.yml
@@ -24,6 +24,8 @@
     - 'Clean up empty directories from job working directory'
     - 'Delete old datasets'
     - 'Email audit report'
+    - 'Clean up deleted files from JSE-drop directory'
+    - 'Remove JSE-drop jobs marked for clean up or as deleted'
 
 # NB using certbot SSL certificate renewal is performed automatically
 # so this task simply removes any existing legacy cronjob


### PR DESCRIPTION
Updates the JSE Drop client and job runner code for compatibility with Galaxy 21.05.

Updates to the client code in `jse_drop.py` include:

* Implementation of a new 'CLEANUP` state which enables jobs to be marked for cleanup by external code (e.g. the job runner) via the `JSEDrop.mark_for_cleanup()` method
* Implementation of a new function `jse_drop_cleanup`, which can be used to remove job files automatically; by default it will remove the associated files for deleted jobs and jobs marked for cleanup
* Reimplementation of the `jse_drop_cleanup_deleted` function to wrap `jse_drop_cleanup`
* Reimplementation of `__main__` to provide a simple CLI when running e.g. `python3 jse_drop.py`

Updates to the job runner in `jse_drop_runner.py` include:

* Extensive refactoring to match the Galaxy "how to build a job runner" documentation at https://github.com/galaxyproject/galaxy/blob/release_21.05/doc/source/dev/build_a_job_runner.rst (including removal of redundant methods)
* Using the `mark_for_cleanup` method to mark job files for removal (rather than removing them directly within the runner), so the file deletion can be handled elsewhere

Additionally the `galaxy` role has some related updates:

* Replace the cron job which removed deleted jobs with one which removes both deleted jobs and jobs marked for clean up, as an external "garbage collection" process for JSE Drop
* Reduce the default grace time before deleted and cleanup jobs are processed to 300s (i.e. 5 minutes)