### PR TITLE
'galaxy' role: fix removal of legacy JSE-drop cleanup cron job

### DIFF
--- a/roles/galaxy/tasks/jsedrop.yml
+++ b/roles/galaxy/tasks/jsedrop.yml
@@ -37,7 +37,7 @@
 - name: "Clean up files from JSE-drop directory marked for clean up"
   cron:
     user='{{ galaxy_user }}'
-    name='Clean up JSE-drop jobs marked for clean up'
+    name='Clean up JSE-drop jobs marked for clean up or as deleted'
     minute='*/5'
     job='. {{ galaxy_root }}/.venv/bin/activate && PYTHONPATH={{ galaxy_root }}/lib:$PYTHONPATH python -c "from galaxy.jobs.runners.jse_drop import jse_drop_cleanup ; jse_drop_cleanup(\'{{ galaxy_jse_drop_dir }}\',interval={{ galaxy_jse_drop_cleanup_grace_period }})" 2>&1 1>>{{ galaxy_log_dir}}/jse_drop_cleanup.log'
     state=present


### PR DESCRIPTION
Fixes the name of the legacy JSE-drop cleanup cron job that is removed as part of setting up the JSE-drop runner in the `galaxy` role.