### PR TITLE
Fix JSE Drop runner job recovery

### DIFF
--- a/roles/galaxy/files/jse_drop_runner.py
+++ b/roles/galaxy/files/jse_drop_runner.py
@@ -235,7 +235,9 @@ class JSEDropJobRunner(AsynchronousJobRunner):
         # Set up job state instance
         ajs = AsynchronousJobState(
             files_dir=job_wrapper.working_directory,
-            job_wrapper=job_wrapper)
+            job_wrapper=job_wrapper,
+            job_id=job_name,
+            job_destination=job_destination)
         # Sort out the slots (see e.g. condor.py for example)
         if galaxy_slots:
             galaxy_slots_statement = 'GALAXY_SLOTS="%s"; export GALAXY_SLOTS_CONFIGURED="1"' % galaxy_slots
@@ -279,12 +281,6 @@ class JSEDropJobRunner(AsynchronousJobRunner):
         # Store runner information for tracking if Galaxy restarts
         job_wrapper.set_job_destination(job_destination,
                                         external_job_id)
-        # Store state information for job
-        ajs.job_wrapper = job_wrapper
-        ajs.job_id = job_name
-        ajs.old_state = True
-        ajs.running = False
-        ajs.job_destination = job_destination
         # Add to the queue of jobs to monitor
         self.monitor_queue.put(ajs)
         log.info("%s: queued" % job_name)

--- a/roles/galaxy/files/jse_drop_runner.py
+++ b/roles/galaxy/files/jse_drop_runner.py
@@ -419,19 +419,19 @@ class JSEDropJobRunner(AsynchronousJobRunner):
         # Recovers jobs in the queued/running state when Galaxy started
         # Fetch the job id used by JSE-Drop
         job_name = job.get_job_runner_external_id()
-        # Get the job destination
-        job_destination = job_wrapper.job_destination
-        # Store state information for job
-        ajs = AsynchronousJobState()
+        log.debug("recover: attempting to recover job '%s'" % job_name)
+        ajs = AsynchronousJobState(
+            files_dir=job_wrapper.working_directory,
+            job_wrapper=job_wrapper)
+        ajs.job_id = str(job_name)
+        ajs.job_destination = job_wrapper.job_destination
+        job_wrapper.command_line = job.command_line
         ajs.job_wrapper = job_wrapper
-        ajs.job_id = job_name
-        ajs.job_destination = job_destination
-        # Sort out the status
         if job.state == model.Job.states.RUNNING:
             ajs.old_state = 'R'
             ajs.running = True
             self.monitor_queue.put(ajs)
-        elif job.get_state() == model.Job.states.QUEUED:
+        elif job.state == model.Job.states.QUEUED:
             ajs.old_state = 'Q'
             ajs.running = False
             self.monitor_queue.put(ajs)


### PR DESCRIPTION
Fixes the `recover` method of the `JSEDropJobRunner` class in `jse_drop_runner.py` (the `galaxy` role), to correctly set the properties of the `AsynchronousJobState` instance that is created when recovering job state e.g. when restarting Galaxy while queued or running jobs are present. Without this fix the job state was not fully recovered, resulting in the job being marked as "failed" on completion.