### PR TITLE
Trap and ignore exceptions in JSE-Drop client clean up

### DIFF
--- a/roles/galaxy/files/jse_drop.py
+++ b/roles/galaxy/files/jse_drop.py
@@ -666,7 +666,12 @@ def jse_drop_cleanup(drop_dir,interval=None,timeout=600,
             for job in jobs:
                 print("%s: cleaning up job '%s'" %
                       (time.strftime("%Y-%m-%d %H:%M:%S"),job))
-                jsedrop.cleanup(job)
+                try:
+                    jsedrop.cleanup(job)
+                except Exception as ex:
+                    print("%s: error attempting clean up for '%s': "
+                          "%s (ignored)" %
+                          (time.strftime("%Y-%m-%d %H:%M:%S"),job,ex))
 
 def jse_drop_cleanup_deleted(drop_dir,interval,timeout=600):
     """


### PR DESCRIPTION
Fixes the `jse_drop_cleanup` function in the JSE-Drop Python client (`jse_drop.py` in the `galaxy` role) to trap and ignore any exceptions. The fix is needed as a "blunt tool" to address possible collisions when two Galaxy instances try to do clean up on the same drop-off directory at the same time.