### PR TITLE
Add audit reporting to the Centaurus production and dev instances

### DIFF
--- a/centaurus-devel.yml
+++ b/centaurus-devel.yml
@@ -96,6 +96,9 @@
   - galaxy-install-tools
   - galaxy-set-default-quota
 
+  # Additional set up
+  - galaxy-audit-report
+
   ## Use this to set environment variables on the remote
   ## when ansible tasks run (e.g. proxy settings)
   #environment: "{{ proxy_env }}"

--- a/centaurus.yml
+++ b/centaurus.yml
@@ -95,6 +95,9 @@
   - galaxy-install-tools
   - galaxy-set-default-quota
 
+  # Additional set up
+  - galaxy-audit-report
+
   ## Use this to set environment variables on the remote
   ## when ansible tasks run (e.g. proxy settings)
   #environment: "{{ proxy_env }}"


### PR DESCRIPTION
Update the playbooks for Centaurus production and dev instances to add the audit reporting cron jobs.