### PR TITLE
Drop supervisord installation from Centaurus and Pal_finder configurations

### DIFF
--- a/centaurus-devel.yml
+++ b/centaurus-devel.yml
@@ -72,7 +72,6 @@
   - python3
   - nginx
   - postgresql
-  - supervisord
 
   # SSL certificates
   - role: certbot

--- a/centaurus.yml
+++ b/centaurus.yml
@@ -71,7 +71,6 @@
   - python3
   - nginx
   - postgresql
-  - supervisord
 
   # SSL certificates
   - role: certbot

--- a/palfinder.yml
+++ b/palfinder.yml
@@ -30,7 +30,6 @@
   - python3
   - nginx
   - postgresql
-  - supervisord
 
   # SSL certificates
   - role: certbot


### PR DESCRIPTION
Removes invocations of the `supervisord` role from the playbooks for the Centaurus, Centaurus-dev and Pal_finder Galaxy instances.