### PR TITLE
Extend JSE-Drop runner timeout intervals

### DIFF
--- a/roles/galaxy/files/jse_drop.py
+++ b/roles/galaxy/files/jse_drop.py
@@ -664,6 +664,8 @@ def jse_drop_cleanup(drop_dir,interval=None,timeout=600,
     with jsedrop.get_lock(timeout=timeout):
         now = datetime.now()
         interval = timedelta(seconds=interval)
+        print("%s: jse_drop_cleanup: acquired lock" %
+              time.strftime("%Y-%m-%d %H:%M:%S"))
         for s in status:
             jobs = [j for j in jsedrop.jobs()
                     if ((s == "all" or jsedrop.status(j) == s)
@@ -680,6 +682,8 @@ def jse_drop_cleanup(drop_dir,interval=None,timeout=600,
                     print("%s: error attempting clean up for '%s': "
                           "%s (ignored)" %
                           (time.strftime("%Y-%m-%d %H:%M:%S"),job,ex))
+        print("%s: jse_drop_cleanup: releasing lock" %
+              time.strftime("%Y-%m-%d %H:%M:%S"))
 
 def jse_drop_cleanup_deleted(drop_dir,interval,timeout=600):
     """

--- a/roles/galaxy/files/jse_drop.py
+++ b/roles/galaxy/files/jse_drop.py
@@ -194,8 +194,8 @@ class JSEDrop(object):
             # Remove leading and trailing spaces and '//'
             return job_id.strip().strip('/')
         except Exception as ex:
-            raise Exception("Failed to extract job id for '%s' from "
-                            "'%s': %s" % (name,job_id,ex))
+            raise JSEDropException("Failed to extract job id for '%s' from "
+                                   "'%s': %s" % (name,job_id,ex))
 
     def get_job_number(self,name):
         """
@@ -617,7 +617,10 @@ class FileLock:
                     break
         if not self.has_lock:
             # Failed to get lock
-            raise BlockingIOError
+            err_msg = "failed to acquire lock for JSEDrop"
+            if timeout is not None:
+                err_msg += " (timeout after %ss)" % timeout
+            raise JSEDropException(err_msg)
 
     def release(self):
         # Release a previously acquired lock

--- a/roles/galaxy/files/jse_drop.py
+++ b/roles/galaxy/files/jse_drop.py
@@ -703,6 +703,7 @@ if __name__ == '__main__':
     """
     Provide a basic CLI for JSE Drop
     """
+    import sys
     from argparse import ArgumentParser
     from fnmatch import fnmatch
     status_descriptions = {
@@ -727,42 +728,46 @@ if __name__ == '__main__':
                    "seconds; by default jobs marked 'cleanup' are "
                    "removed (use -s to select other job statuses)")
     args = p.parse_args()
-    jse = JSEDrop(args.drop_dir)
-    with jse.get_lock(timeout=60):
-        jobs = sorted(jse.jobs(),key=lambda j: jse.timestamp(j))
-        if args.job_name is not None:
-            jobs = [j for j in jobs if fnmatch(j,args.job_name)]
-        status = None
-        if args.status is not None:
-            for s in status_descriptions:
-                if fnmatch(status_descriptions[s],args.status):
-                    status = s
-                    break
-        if args.clean_interval is not None:
-            if not status:
-                status = JSEDropStatus.CLEANUP
-        if status:
-            jobs = [j for j in jobs if jse.status(j) == status]
-        if args.clean_interval is not None:
-            # Clean up selected jobs
-            now = datetime.now()
-            interval = timedelta(seconds=int(args.clean_interval))
-            jobs = [j for j in jobs
-                    if now - datetime.fromtimestamp(jse.timestamp(j))
-                    > interval]
-            for job in jobs:
-                print("Cleaning up job '%s'" % job)
-                jse.cleanup(job)
-        else:
-            # Print list of jobs
-            for job in jobs:
-                status = jse.status(job)
-                try:
-                    status = status_descriptions[status]
-                except KeyError:
-                    pass
-                ts = jse.timestamp(job)
-                ds = datetime.fromtimestamp(ts)
-                print("%s\t%s\t%s" % (job,
-                                      status,
-                                      ds.strftime("%m/%d/%Y %H:%M:%S")))
+    try:
+        jse = JSEDrop(args.drop_dir)
+        with jse.get_lock(timeout=60):
+            jobs = sorted(jse.jobs(),key=lambda j: jse.timestamp(j))
+            if args.job_name is not None:
+                jobs = [j for j in jobs if fnmatch(j,args.job_name)]
+            status = None
+            if args.status is not None:
+                for s in status_descriptions:
+                    if fnmatch(status_descriptions[s],args.status):
+                        status = s
+                        break
+            if args.clean_interval is not None:
+                if not status:
+                    status = JSEDropStatus.CLEANUP
+            if status:
+                jobs = [j for j in jobs if jse.status(j) == status]
+            if args.clean_interval is not None:
+                # Clean up selected jobs
+                now = datetime.now()
+                interval = timedelta(seconds=int(args.clean_interval))
+                jobs = [j for j in jobs
+                        if now - datetime.fromtimestamp(jse.timestamp(j))
+                        > interval]
+                for job in jobs:
+                    print("Cleaning up job '%s'" % job)
+                    jse.cleanup(job)
+            else:
+                # Print list of jobs
+                for job in jobs:
+                    status = jse.status(job)
+                    try:
+                        status = status_descriptions[status]
+                    except KeyError:
+                        pass
+                    ts = jse.timestamp(job)
+                    ds = datetime.fromtimestamp(ts)
+                    print("%s\t%s\t%s" % (job,
+                                          status,
+                                          ds.strftime("%m/%d/%Y %H:%M:%S")))
+    except Exception as ex:
+        print("Failed: %s" % ex)
+        sys.exit(1)

--- a/roles/galaxy/files/jse_drop.py
+++ b/roles/galaxy/files/jse_drop.py
@@ -630,6 +630,11 @@ class FileLock:
         # Check if instance holds the lock
         return (self._lockfd is not None)
 
+class JSEDropException(Exception):
+    """
+    Custom exception class for JSE-Drop
+    """
+
 def jse_drop_cleanup(drop_dir,interval=None,timeout=600,
                      status=None):
     """

--- a/roles/galaxy/files/jse_drop_runner.py
+++ b/roles/galaxy/files/jse_drop_runner.py
@@ -270,12 +270,12 @@ class JSEDropJobRunner(AsynchronousJobRunner):
                 drop_file = jse_drop.run(job_name,script)
             log.debug("created drop file %s" % drop_file)
             log.info("(%s) submitted as %s" % (galaxy_id_tag,job_name))
-        except:
+        except Exception as ex:
             # Some problem writing the qsub file
-            job_wrapper.fail("failure preparing job script",
-                             exception=True )
-            log.exception("(%s/%s) failure writing job script" %
-                          (galaxy_id_tag,job_name))
+            job_wrapper.fail("failure preparing job script: %s" % ex,
+                             exception=True)
+            log.exception("(%s/%s) failure writing job script: %s" %
+                          (galaxy_id_tag,job_name,ex))
             return
         # External job id (i.e. id used by JSE-Drop as a handle to
         # identify the job) is the same as the job name here

--- a/roles/galaxy/files/jse_drop_runner.py
+++ b/roles/galaxy/files/jse_drop_runner.py
@@ -88,7 +88,7 @@ log = logging.getLogger( __name__ )
 
 __all__ = [ 'JSEDropJobRunner' ]
 
-JSEDROP_LOCK_TIMEOUT = 60
+JSEDROP_LOCK_TIMEOUT = 300
 
 class JSEDropJobRunner(AsynchronousJobRunner):
     """

--- a/roles/galaxy/files/jse_drop_runner.py
+++ b/roles/galaxy/files/jse_drop_runner.py
@@ -88,6 +88,8 @@ log = logging.getLogger( __name__ )
 
 __all__ = [ 'JSEDropJobRunner' ]
 
+JSEDROP_LOCK_TIMEOUT = 60
+
 class JSEDropJobRunner(AsynchronousJobRunner):
     """
     Job runner dropping job files into shared dir for execution by JSE
@@ -264,7 +266,7 @@ class JSEDropJobRunner(AsynchronousJobRunner):
         script = "\n".join((shell,qsub_header,script))
         # Create the drop file to submit the job
         try:
-            with jse_drop.get_lock(timeout=60):
+            with jse_drop.get_lock(timeout=JSEDROP_LOCK_TIMEOUT):
                 drop_file = jse_drop.run(job_name,script)
             log.debug("created drop file %s" % drop_file)
             log.info("(%s) submitted as %s" % (galaxy_id_tag,job_name))
@@ -292,7 +294,7 @@ class JSEDropJobRunner(AsynchronousJobRunner):
         job_name = job_state.job_id
         drop_off_dir = self._get_drop_dir()
         jse_drop = JSEDrop(drop_off_dir)
-        with jse_drop.get_lock(timeout=60):
+        with jse_drop.get_lock(timeout=JSEDROP_LOCK_TIMEOUT):
             #log.info("%s: acquired lock" % job_name)
             jse_drop_status = jse_drop.status(job_name)
 
@@ -398,7 +400,7 @@ class JSEDropJobRunner(AsynchronousJobRunner):
         # Fetch the drop dir
         try:
             jse_drop = JSEDrop(self._get_drop_dir())
-            with jse_drop.get_lock(timeout=60):
+            with jse_drop.get_lock(timeout=JSEDROP_LOCK_TIMEOUT):
                 jse_drop_status = jse_drop.status(job_name)
                 if jse_drop_status in (JSEDropStatus.WAITING,
                                        JSEDropStatus.RUNNING):

--- a/roles/galaxy/files/jse_drop_runner.py
+++ b/roles/galaxy/files/jse_drop_runner.py
@@ -267,7 +267,11 @@ class JSEDropJobRunner(AsynchronousJobRunner):
         # Create the drop file to submit the job
         try:
             with jse_drop.get_lock(timeout=JSEDROP_LOCK_TIMEOUT):
+                log.info("(%s/%s) acquired JSE-Drop lock" %
+                         (galaxy_id_tag,job_name))
                 drop_file = jse_drop.run(job_name,script)
+                log.info("(%s/%s) releasing JSE-Drop lock" %
+                         (galaxy_id_tag,job_name))
             log.debug("created drop file %s" % drop_file)
             log.info("(%s) submitted as %s" % (galaxy_id_tag,job_name))
         except Exception as ex:


### PR DESCRIPTION
Updates the JSE-Drop job runner in the `galaxy` role to parameterise the lock acquisition timeout interval, and increase the length of this interval (to reduce number of timeouts when several processes are competing for the lock).