### PR TITLE
Update config file templates for Galaxy 22.05

### DIFF
--- a/roles/galaxy/templates/galaxy-config-release_22.05.yml.j2
+++ b/roles/galaxy/templates/galaxy-config-release_22.05.yml.j2
@@ -1,0 +1,2535 @@
+# Template file based on Galaxy 22.05 sample config file
+
+# Galaxy is configured by default to be usable in a single-user development
+# environment.  To tune the application for a multi-user production
+# environment, see the documentation at:
+# 
+#  https://docs.galaxyproject.org/en/master/admin/production.html
+# 
+# Throughout this sample configuration file, except where stated otherwise,
+# uncommented values override the default if left unset, whereas commented
+# values are set to the default value.  Relative paths are relative to the root
+# Galaxy directory.
+# 
+# Examples of many of these options are explained in more detail in the Galaxy
+# Community Hub.
+# 
+#   https://galaxyproject.org/admin/config
+# 
+# Config hackers are encouraged to check there before asking for help.
+# 
+# Configuration for Gravity process manager.
+# ``uwsgi:`` section will be ignored if Galaxy is started via Gravity commands (e.g ``./run.sh``, ``galaxy`` or ``galaxyctl``).
+gravity:
+
+  # Specify Galaxy's root directory.
+  # Gravity will attempt to find the root directory, but you can set the directory explicitly with this option.
+  galaxy_root: {{ galaxy_root }}
+
+  # Set to a directory that should contain log files for the processes controlled by Gravity.
+  # If not specified defaults to ``<state_dir>/log``.
+  log_dir: {{ galaxy_log_dir }}
+
+  # Set to Galaxy's virtualenv directory.
+  # If not specified, Gravity assumes all processes are on PATH.
+  virtualenv: {{ galaxy_root }}/.venv
+
+  # Select the application server.
+  # ``gunicorn`` is the default application server.
+  # ``unicornherder`` is a production-oriented manager for (G)unicorn servers that automates zero-downtime Galaxy server restarts,
+  # similar to uWSGI Zerg Mode used in the past.
+  # Valid options are: gunicorn, unicornherder
+  app_server: gunicorn
+
+  # Override the default instance name.
+  # this is hidden from you when running a single instance.
+  instance_name: {{ galaxy_name }}
+
+  # Configuration for Gunicorn.
+  gunicorn:
+
+    # Enable Galaxy gunicorn server.
+    # enable: true
+
+    # The socket to bind. A string of the form: ``HOST``, ``HOST:PORT``, ``unix:PATH``, ``fd://FD``. An IP is a valid HOST.
+    bind: '127.0.0.1:{{ galaxy_gunicorn_socket }}'
+
+    # Controls the number of Galaxy application processes Gunicorn will spawn.
+    # Increased web performance can be attained by increasing this value.
+    # If Gunicorn is the only application on the server, a good starting value is the number of CPUs * 2 + 1.
+    # 4-12 workers should be able to handle hundreds if not thousands of requests per second.
+    workers: {{ galaxy_gunicorn_workers }}
+
+    # Gunicorn workers silent for more than this many seconds are killed and restarted.
+    # Value is a positive number or 0. Setting it to 0 has the effect of infinite timeouts by disabling timeouts for all workers entirely.
+    # If you disable the ``preload`` option workers need to have finished booting within the timeout.
+    # timeout: 300
+
+    # Extra arguments to pass to Gunicorn command line.
+    # extra_args:
+
+    # Use Gunicorn's --preload option to fork workers after loading the Galaxy Application.
+    # Consumes less memory when multiple processes are configured. Default is ``false`` if using unicornherder, else ``true``.
+    # preload:
+
+    # Extra environment variables and their values to set when running the service. A dictionary where keys are the variable
+    # names.
+    # environment: {}
+
+  # Configuration for Celery Processes.
+  celery:
+
+    # Enable Celery distributed task queue.
+    # enable: true
+
+    # Enable Celery Beat periodic task runner.
+    # enable_beat: true
+
+    # Number of Celery Workers to start.
+    # concurrency: 2
+
+    # Log Level to use for Celery Worker.
+    # Valid options are: DEBUG, INFO, WARNING, ERROR
+    # loglevel: DEBUG
+
+    # Queues to join
+    # queues: celery,galaxy.internal,galaxy.external
+
+    # Pool implementation
+    # Valid options are: prefork, eventlet, gevent, solo, processes, threads
+    # pool: threads
+
+    # Extra arguments to pass to Celery command line.
+    # extra_args:
+
+    # Extra environment variables and their values to set when running the service. A dictionary where keys are the variable
+    # names.
+    # environment: {}
+
+  # Configuration for gx-it-proxy.
+  gx_it_proxy:
+
+    # Set to true to start gx-it-proxy
+    # enable: false
+
+    # Public-facing IP of the proxy
+    # ip: localhost
+
+    # Public-facing port of the proxy
+    # port: 4002
+
+    # Routes file to monitor.
+    # Should be set to the same path as ``interactivetools_map`` in the ``galaxy:`` section.
+    # sessions: database/interactivetools_map.sqlite
+
+    # Include verbose messages in gx-it-proxy
+    # verbose: true
+
+    # Forward all requests to IP.
+    # This is an advanced option that is only needed when proxying to remote interactive tool container that cannot be reached through the local network.
+    # forward_ip:
+
+    # Forward all requests to port.
+    # This is an advanced option that is only needed when proxying to remote interactive tool container that cannot be reached through the local network.
+    # forward_port:
+
+    # Rewrite location blocks with proxy port.
+    # This is an advanced option that is only needed when proxying to remote interactive tool container that cannot be reached through the local network.
+    # reverse_proxy: false
+
+    # Extra environment variables and their values to set when running the service. A dictionary where keys are the variable
+    # names.
+    # environment: {}
+
+  # Configuration for tusd server (https://github.com/tus/tusd).
+  # The ``tusd`` binary must be installed manually and made available on PATH (e.g in galaxy's .venv/bin directory).
+  tusd:
+
+    # Enable tusd server.
+    # If enabled, you also need to set up your proxy as outlined in https://docs.galaxyproject.org/en/latest/admin/nginx.html#receiving-files-via-the-tus-protocol.
+    # enable: false
+
+    # Path to tusd binary
+    # tusd_path: tusd
+
+    # Host to bind the tusd server to
+    # host: localhost
+
+    # Port to bind the tusd server to
+    # port: 1080
+
+    # Directory to store uploads in.
+    # Must match ``tus_upload_store`` setting in ``galaxy:`` section.
+    # upload_dir:
+
+    # Comma-separated string of enabled tusd hooks.
+    # Leave at the default value to require authorization at upload creation time.
+    # This means Galaxy's web process does not need to be running after creating the initial
+    # upload request.
+    # Set to empty string to disable all authorization. This means data can be uploaded (but not processed)
+    # without the Galaxy web process being available.
+    # You can find a list of available hooks at https://github.com/tus/tusd/blob/master/docs/hooks.md#list-of-available-hooks.
+    # hooks_enabled_events: pre-create
+
+    # Extra arguments to pass to tusd command line.
+    # extra_args:
+
+    # Extra environment variables and their values to set when running the service. A dictionary where keys are the variable
+    # names.
+    # environment: {}
+
+  # Configure dynamic handlers in this section.
+  # See https://docs.galaxyproject.org/en/latest/admin/scaling.html#dynamically-defined-handlers for details.
+  # handlers: {}
+
+galaxy:
+
+  # The directory that will be prepended to relative paths in options
+  # specifying other Galaxy config files (e.g. datatypes_config_file).
+  # Defaults to the directory in which galaxy.yml is located.
+  #config_dir: null
+
+  # The directory that will be prepended to relative paths in options
+  # specifying config files controlled by Galaxy (such as
+  # shed_tool_config_file, etc.). Must be writable by the user running
+  # Galaxy.  Defaults to `<config_dir>/` if running Galaxy from source
+  # or `<data_dir>/config` otherwise.
+  #managed_config_dir: null
+
+  # The directory that will be prepended to relative paths in options
+  # specifying Galaxy data/cache directories and files (such as the
+  # default SQLite database, file_path, etc.). Defaults to `database/`
+  # if running Galaxy from source or `<config_dir>/data` otherwise.
+  #data_dir: null
+
+  # Top level cache directory. Any other cache directories
+  # (tool_cache_data_dir, template_cache_path, etc.) should be
+  # subdirectories.
+  # The value of this option will be resolved with respect to
+  # <data_dir>.
+  #cache_dir: cache
+
+  # By default, Galaxy uses a SQLite database at
+  # '<data_dir>/universe.sqlite'.  You may use a SQLAlchemy connection
+  # string to specify an external database instead.
+  # Sample default
+  # 'sqlite:///<data_dir>/universe.sqlite?isolation_level=IMMEDIATE'
+  database_connection: 'postgresql://{{ galaxy_db_user }}:{{ galaxy_db_password }}@localhost:5432/{{ galaxy_db }}'
+
+  # If the server logs errors about not having enough database pool
+  # connections, you will want to increase these values, or consider
+  # running more Galaxy processes.
+  #database_engine_option_pool_size: 5
+
+  # If the server logs errors about not having enough database pool
+  # connections, you will want to increase these values, or consider
+  # running more Galaxy processes.
+  #database_engine_option_max_overflow: 10
+
+  # If using MySQL and the server logs the error "MySQL server has gone
+  # away", you will want to set this to some positive value (7200 should
+  # work).
+  #database_engine_option_pool_recycle: -1
+
+  # If large database query results are causing memory or response time
+  # issues in the Galaxy process, leave the result on the server
+  # instead.  This option is only available for PostgreSQL and is highly
+  # recommended.
+  database_engine_option_server_side_cursors: true
+
+  # Log all database transactions, can be useful for debugging and
+  # performance profiling.  Logging is done via Python's 'logging'
+  # module under the qualname
+  # 'galaxy.model.orm.logging_connection_proxy'
+  #database_query_profiling_proxy: false
+
+  # If auto-creating a postgres database on startup - it can be based on
+  # an existing template database. This will set that. This is probably
+  # only useful for testing but documentation is included here for
+  # completeness.
+  #database_template: null
+
+  # Log number of SQL queries executed and total time spent dispatching
+  # SQL statements for each web request. If statsd is also enabled this
+  # information will be logged there as well. This should be considered
+  # somewhat experimental, we are unsure of the performance costs of
+  # running this in production. This is useful information for
+  # optimizing database interaction performance. Similar information can
+  # be obtained on a per-request basis by enabling the sql_debug
+  # middleware and adding sql_debug=1 to a request string.
+  #database_log_query_counts: false
+
+  # Slow query logging.  Queries slower than the threshold indicated
+  # below will be logged to debug.  A value of '0' is disabled.  For
+  # example, you would set this to .005 to log all queries taking longer
+  # than 5 milliseconds.
+  #slow_query_log_threshold: 0.0
+
+  # Enables a per request sql debugging option. If this is set to true,
+  # append ?sql_debug=1 to web request URLs to enable detailed logging
+  # on the backend of SQL queries generated during that request. This is
+  # useful for debugging slow endpoints during development.
+  #enable_per_request_sql_debugging: false
+
+  # By default, Galaxy will use the same database to track user data and
+  # tool shed install data.  There are many situations in which it is
+  # valuable to separate these - for instance bootstrapping fresh Galaxy
+  # instances with pretested installs.  The following option can be used
+  # to separate the tool shed install database (all other options listed
+  # above but prefixed with ``install_`` are also available).
+  # Defaults to the value of the 'database_connection' option.
+  #install_database_connection: null
+
+  # Setting the following option to true will cause Galaxy to
+  # automatically migrate the database forward after updates. This is
+  # not recommended for production use.
+  #database_auto_migrate: false
+
+  # Wait for database to become available instead of failing
+  # immediately.
+  #database_wait: false
+
+  # Number of attempts before failing if database_wait is enabled.
+  #database_wait_attempts: 60
+
+  # Time to sleep between attempts if database_wait is enabled (in
+  # seconds).
+  #database_wait_sleep: 1.0
+
+  # Time (in seconds) between attempts to remove old rows from the
+  # history_audit database table. Set to 0 to disable pruning.
+  #history_audit_table_prune_interval: 3600
+
+  # Where dataset files are stored. It must be accessible at the same
+  # path on any cluster nodes that will run Galaxy jobs, unless using
+  # Pulsar. The default value has been changed from 'files' to 'objects'
+  # as of 20.05; however, Galaxy will first check if the 'files'
+  # directory exists before using 'objects' as the default.
+  # The value of this option will be resolved with respect to
+  # <data_dir>.
+  file_path: {{ galaxy_file_path }}
+
+  # Where temporary files are stored. It must be accessible at the same
+  # path on any cluster nodes that will run Galaxy jobs, unless using
+  # Pulsar.
+  # The value of this option will be resolved with respect to
+  # <data_dir>.
+  new_file_path: {{ galaxy_new_file_path }}
+
+  # Maximum size of uploadable files, specified in bytes (default:
+  # 100GB). This value is ignored if an external upload server is
+  # configured.
+  #maximum_upload_file_size: 107374182400
+
+  # Tool config files, defines what tools are available in Galaxy. Tools
+  # can be locally developed or installed from Galaxy tool sheds.
+  # (config/tool_conf.xml.sample will be used if left unset and
+  # config/tool_conf.xml does not exist). Can be a single file, a list
+  # of files, or (for backwards compatibility) a comma-separated list of
+  # files.
+  # The value of this option will be resolved with respect to
+  # <config_dir>.
+  tool_config_file: 'config/tool_conf.xml,config/shed_tool_conf.xml,config/local_tool_conf.xml'
+
+  # Tool config file for tools installed from the Galaxy Tool Shed. Must
+  # be writable by Galaxy and generally should not be edited by hand. In
+  # older Galaxy releases, this file was part of the tool_config_file
+  # option. It is still possible to specify this file (and other
+  # shed-enabled tool config files) in tool_config_file, but in the
+  # standard case of a single shed-enabled tool config, this option is
+  # preferable. This file will be created automatically upon tool
+  # installation, whereas Galaxy will fail to start if any files in
+  # tool_config_file cannot be read.
+  # The value of this option will be resolved with respect to
+  # <managed_config_dir>.
+  #shed_tool_config_file: shed_tool_conf.xml
+
+  # This option is deprecated. In previous releases this file was
+  # maintained by tool migration scripts that are no longer part of the
+  # code base. The option remains as a placeholder for deployments where
+  # these scripts were previously run and such a file exists.
+  # The value of this option will be resolved with respect to
+  # <managed_config_dir>.
+  #migrated_tools_config: migrated_tools_conf.xml
+
+  # File that contains the XML section and tool tags from all tool panel
+  # config files integrated into a single file that defines the tool
+  # panel layout.  This file can be changed by the Galaxy administrator
+  # to alter the layout of the tool panel.  If not present, Galaxy will
+  # create it.
+  # The value of this option will be resolved with respect to
+  # <managed_config_dir>.
+  #integrated_tool_panel_config: integrated_tool_panel.xml
+
+  # Default path to the directory containing the tools defined in
+  # tool_conf.xml. Other tool config files must include the tool_path as
+  # an attribute in the <toolbox> tag.
+  #tool_path: tools
+
+  # Various dependency resolver configuration parameters will have
+  # defaults set relative to this path, such as the default conda
+  # prefix, default Galaxy packages path, legacy tool shed dependencies
+  # path, and the dependency cache directory.
+  # Set the string to null to explicitly disable tool dependency
+  # handling. If this option is set to none or an invalid path,
+  # installing tools with dependencies from the Tool Shed or in Conda
+  # will fail.
+  # The value of this option will be resolved with respect to
+  # <data_dir>.
+  tool_dependency_dir: {{ galaxy_tool_dependency_dir }}
+
+  # Specifies the path to the standalone dependency resolvers
+  # configuration file. This configuration can now be specified directly
+  # in the Galaxy configuration, see the description of the
+  # 'dependency_resolvers' option for details.
+  # The value of this option will be resolved with respect to
+  # <config_dir>.
+  #dependency_resolvers_config_file: dependency_resolvers_conf.xml
+
+  # conda_prefix is the location on the filesystem where Conda packages
+  # and environments are installed.
+  # Sample default '<tool_dependency_dir>/_conda'
+  #conda_prefix: null
+
+  # Override the Conda executable to use, it will default to the one on
+  # the PATH (if available) and then to <conda_prefix>/bin/conda
+{% if galaxy_conda_use_mamba %}
+  conda_exec: {{ galaxy_tool_dependency_dir }}/_conda/bin/mamba
+{% else %}
+  #conda_exec: null
+{% endif %}
+
+  # Pass debug flag to conda commands.
+  #conda_debug: false
+
+  # conda channels to enable by default
+  # (https://conda.io/docs/user-guide/tasks/manage-channels.html)
+  #conda_ensure_channels: conda-forge,bioconda,defaults
+
+  # Use locally-built conda packages.
+  #conda_use_local: false
+
+  # Set to true to instruct Galaxy to look for and install missing tool
+  # dependencies before each job runs.
+  conda_auto_install: {{ galaxy_conda_auto_install }}
+
+  # Set to true to instruct Galaxy to install Conda from the web
+  # automatically if it cannot find a local copy and conda_exec is not
+  # configured.
+  #conda_auto_init: true
+
+  # You must set this to true if conda_prefix and job_working_directory
+  # are not on the same volume, or some conda dependencies will fail to
+  # execute at job runtime. Conda will copy packages content instead of
+  # creating hardlinks or symlinks. This will prevent problems with some
+  # specific packages (perl, R), at the cost of extra disk space usage
+  # and extra time spent copying packages.
+  #conda_copy_dependencies: false
+
+  # Path to a file that provides a mapping from abstract packages to
+  # concrete conda packages. See `config/local_conda_mapping.yml.sample`
+  # for examples.
+  # The value of this option will be resolved with respect to
+  # <config_dir>.
+  #local_conda_mapping_file: local_conda_mapping.yml
+
+  # Path to a file that provides a mapping from abstract packages to
+  # locally installed modules. See
+  # `config/environment_modules_mapping.yml.sample` for examples.
+  # The value of this option will be resolved with respect to
+  # <config_dir>.
+  #modules_mapping_files: environment_modules_mapping.yml
+
+  # Certain dependency resolvers (namely Conda) take a considerable
+  # amount of time to build an isolated job environment in the
+  # job_working_directory if the job working directory is on a network
+  # share.  Set this option to true to cache the dependencies in a
+  # folder. This option is beta and should only be used if you
+  # experience long waiting times before a job is actually submitted to
+  # your cluster.
+  # This only affects tools where some requirements can be resolved but
+  # not others, most modern best practice tools can use prebuilt
+  # environments in the Conda directory.
+  use_cached_dependency_manager: {{ galaxy_use_cached_depedency_manager }}
+
+  # By default the tool_dependency_cache_dir is the _cache directory of
+  # the tool dependency directory.
+  # Sample default '<tool_dependency_dir>/_cache'
+  #tool_dependency_cache_dir: null
+
+  # By default, when using a cached dependency manager, the dependencies
+  # are cached when installing new tools and when using tools for the
+  # first time. Set this to false if you prefer dependencies to be
+  # cached only when installing new tools.
+  #precache_dependencies: true
+
+  # File containing the Galaxy Tool Sheds that should be made available
+  # to install from in the admin interface (.sample used if default does
+  # not exist).
+  # The value of this option will be resolved with respect to
+  # <config_dir>.
+  #tool_sheds_config_file: tool_sheds_conf.xml
+
+  # This option controls whether legacy datatypes are loaded from
+  # installed tool shed repositories. We're are in the process of
+  # disabling Tool Shed datatypes. This option with a default of true
+  # will be added in 22.01, we will disable the datatypes on the big
+  # public servers during that release. This option will be switched to
+  # False by default in 22.05 and this broken functionality will be
+  # removed all together during some future release.
+  #load_tool_shed_datatypes: true
+
+  # Monitor the tools and tool directories listed in any tool config
+  # file specified in tool_config_file option.  If changes are found,
+  # tools are automatically reloaded. Watchdog (
+  # https://pypi.org/project/watchdog/ ) must be installed and available
+  # to Galaxy to use this option. Other options include 'auto' which
+  # will attempt to watch tools if the watchdog library is available but
+  # won't fail to load Galaxy if it is not and 'polling' which will use
+  # a less efficient monitoring scheme that may work in wider range of
+  # scenarios than the watchdog default.
+  #watch_tools: 'false'
+
+  # Monitor dynamic job rules. If changes are found, rules are
+  # automatically reloaded. Takes the same values as the 'watch_tools'
+  # option.
+  #watch_job_rules: 'false'
+
+  # Monitor a subset of options in the core configuration file (See
+  # RELOADABLE_CONFIG_OPTIONS in lib/galaxy/config/__init__.py).  If
+  # changes are found, modified options are automatically reloaded.
+  # Takes the same values as the 'watch_tools' option.
+  #watch_core_config: 'false'
+
+  # Monitor the interactive tours directory specified in the
+  # 'tour_config_dir' option. If changes are found, modified tours are
+  # automatically reloaded. Takes the same values as the 'watch_tools'
+  # option.
+  #watch_tours: 'false'
+
+  # Location of files available for a short time as downloads (short
+  # term storage). This directory is exclusively used for serving
+  # dynamically generated downloadable content. Galaxy may uses the
+  # new_file_path parameter as a general temporary directory and that
+  # directory should be monitored by a tool such as tmpwatch in
+  # production environments. short_term_storage_dir on the other hand is
+  # monitored by Galaxy's task framework and should not require such
+  # external tooling.
+  # The value of this option will be resolved with respect to
+  # <cache_dir>.
+  #short_term_storage_dir: short_term_web_storage
+
+  # Default duration before short term web storage files will be cleaned
+  # up by Galaxy tasks (in seconds). The default duration is 1 day.
+  #short_term_storage_default_duration: 86400
+
+  # The maximum duration short term storage files can hosted before they
+  # will be marked for clean up.  The default setting of 0 indicates no
+  # limit here.
+  #short_term_storage_maximum_duration: 0
+
+  # How many seconds between instances of short term storage being
+  # cleaned up in default Celery task configuration.
+  #short_term_storage_cleanup_interval: 3600
+
+  # Configured FileSource plugins.
+  # The value of this option will be resolved with respect to
+  # <config_dir>.
+  #file_sources_config_file: file_sources_conf.yml
+
+  # FileSource plugins described embedded into Galaxy's config.
+  #file_sources: null
+
+  # Enable Galaxy to fetch containers registered with quay.io generated
+  # from tool requirements resolved through Conda. These containers
+  # (when available) have been generated using mulled -
+  # https://github.com/mulled. Container availability will vary by tool,
+  # this option will only be used for job destinations with Docker or
+  # Singularity enabled.
+  #enable_mulled_containers: true
+
+  # Container resolvers configuration. Set up a file describing
+  # container resolvers to use when discovering containers for Galaxy.
+  # If this is set to None, the default container resolvers loaded is
+  # determined by enable_mulled_containers. For available options see
+  # config/container_resolvers_conf.xml.sample.
+  #container_resolvers_config_file: null
+
+  # Rather than specifying a container_resolvers_config_file, the
+  # definition of the resolvers to enable can be embedded into Galaxy's
+  # config with this option. This has no effect if a
+  # container_resolvers_config_file is used. Takes the same options that
+  # can be set in container_resolvers_config_file.
+  #container_resolvers: null
+
+  # involucro is a tool used to build Docker or Singularity containers
+  # for tools from Conda dependencies referenced in tools as
+  # `requirement` s. The following path is the location of involucro on
+  # the Galaxy host. This is ignored if the relevant container resolver
+  # isn't enabled, and will install on demand unless involucro_auto_init
+  # is set to false.
+  # The value of this option will be resolved with respect to
+  # <tool_dependency_dir>.
+  #involucro_path: involucro
+
+  # Install involucro as needed to build Docker or Singularity
+  # containers for tools. Ignored if relevant container resolver is not
+  # used.
+  #involucro_auto_init: true
+
+  # Conda channels to use when building Docker or Singularity containers
+  # using involucro.
+  #mulled_channels: conda-forge,bioconda
+
+  # Enable automatic polling of relative tool sheds to see if any
+  # updates are available for installed repositories.  Ideally only one
+  # Galaxy server process should be able to check for repository
+  # updates.  The setting for hours_between_check should be an integer
+  # between 1 and 24.
+  enable_tool_shed_check: {{ enable_tool_shed_check }}
+
+  # Enable automatic polling of relative tool sheds to see if any
+  # updates are available for installed repositories.  Ideally only one
+  # Galaxy server process should be able to check for repository
+  # updates.  The setting for hours_between_check should be an integer
+  # between 1 and 24.
+  #hours_between_check: 12
+
+  # XML config file that contains data table entries for the
+  # ToolDataTableManager.  This file is manually # maintained by the
+  # Galaxy administrator (.sample used if default does not exist).
+  # The value of this option will be resolved with respect to
+  # <config_dir>.
+  #tool_data_table_config_path: tool_data_table_conf.xml
+
+  # XML config file that contains additional data table entries for the
+  # ToolDataTableManager.  This file is automatically generated based on
+  # the current installed tool shed repositories that contain valid
+  # tool_data_table_conf.xml.sample files.  At the time of installation,
+  # these entries are automatically added to the following file, which
+  # is parsed and applied to the ToolDataTableManager at server start
+  # up.
+  # The value of this option will be resolved with respect to
+  # <managed_config_dir>.
+  #shed_tool_data_table_config: shed_tool_data_table_conf.xml
+
+  # Directory where data used by tools is located.  See the samples in
+  # that directory and the Galaxy Community Hub for help:
+  # https://galaxyproject.org/admin/data-integration
+  tool_data_path: {{ galaxy_tool_data_path }}
+
+  # Directory where Tool Data Table related files will be placed when
+  # installed from a ToolShed. Defaults to the value of the
+  # 'tool_data_path' option.
+  shed_tool_data_path: {{ galaxy_shed_tool_data_path }}
+
+  # Monitor the tool_data and shed_tool_data_path directories. If
+  # changes in tool data table files are found, the tool data tables for
+  # that data manager are automatically reloaded. Watchdog (
+  # https://pypi.org/project/watchdog/ ) must be installed and available
+  # to Galaxy to use this option. Other options include 'auto' which
+  # will attempt to use the watchdog library if it is available but
+  # won't fail to load Galaxy if it is not and 'polling' which will use
+  # a less efficient monitoring scheme that may work in wider range of
+  # scenarios than the watchdog default.
+  #watch_tool_data_dir: 'false'
+
+  # File containing refgenie configuration, e.g.
+  # /path/to/genome_config.yaml. Can be used by refgenie backed tool
+  # data tables.
+  #refgenie_config_file: null
+
+  # File that defines the builds (dbkeys) available at sites used by
+  # display applications and the URL to those sites.
+  # The value of this option will be resolved with respect to
+  # <config_dir>.
+  #build_sites_config_file: build_sites.yml
+
+  # File containing old-style genome builds.
+  # The value of this option will be resolved with respect to
+  # <tool_data_path>.
+  #builds_file_path: shared/ucsc/builds.txt
+
+  # Directory where chrom len files are kept, currently mainly used by
+  # trackster.
+  # The value of this option will be resolved with respect to
+  # <tool_data_path>.
+  #len_file_path: shared/ucsc/chrom
+
+  # Datatypes config file(s), defines what data (file) types are
+  # available in Galaxy (.sample is used if default does not exist).  If
+  # a datatype appears in multiple files, the last definition is used
+  # (though the first sniffer is used so limit sniffer definitions to
+  # one file).
+  # The value of this option will be resolved with respect to
+  # <config_dir>.
+  #datatypes_config_file: datatypes_conf.xml
+
+  # Enable sniffing of compressed datatypes. This can be
+  # configured/overridden on a per-datatype basis in the
+  # datatypes_conf.xml file. With this option set to false the
+  # compressed datatypes will be unpacked before sniffing.
+  #sniff_compressed_dynamic_datatypes_default: true
+
+  # Disable the 'Auto-detect' option for file uploads
+  #datatypes_disable_auto: false
+
+  # Visualizations config directory: where to look for individual
+  # visualization plugins.  The path is relative to the Galaxy root dir.
+  # To use an absolute path begin the path with '/'.  This is a
+  # comma-separated list.
+  #visualization_plugins_directory: config/plugins/visualizations
+
+  # Interactive tour directory: where to store interactive tour
+  # definition files. Galaxy ships with several basic interface tours
+  # enabled, though a different directory with custom tours can be
+  # specified here. The path is relative to the Galaxy root dir.  To use
+  # an absolute path begin the path with '/'.  This is a comma-separated
+  # list.
+  #tour_config_dir: config/plugins/tours
+
+  # Webhooks directory: where to store webhooks - plugins to extend the
+  # Galaxy UI. By default none will be loaded.  Set to
+  # config/plugins/webhooks/demo to load Galaxy's demo webhooks.  To use
+  # an absolute path begin the path with '/'.  This is a comma-separated
+  # list. Add test/functional/webhooks to this list to include the demo
+  # webhooks used to test the webhook framework.
+  #webhooks_dir: config/plugins/webhooks
+
+  # Each job is given a unique empty directory as its current working
+  # directory. This option defines in what parent directory those
+  # directories will be created.
+  # The value of this option will be resolved with respect to
+  # <data_dir>.
+  job_working_directory: {{ galaxy_job_working_dir }}
+
+  # If using a cluster, Galaxy will write job scripts and stdout/stderr
+  # to this directory.
+  # The value of this option will be resolved with respect to
+  # <data_dir>.
+  #cluster_files_directory: pbs
+
+  # Mako templates are compiled as needed and cached for reuse, this
+  # directory is used for the cache
+  # The value of this option will be resolved with respect to
+  # <cache_dir>.
+  #template_cache_path: compiled_templates
+
+  # Set to false to disable various checks Galaxy will do to ensure it
+  # can run job scripts before attempting to execute or submit them.
+  #check_job_script_integrity: true
+
+  # Number of checks to execute if check_job_script_integrity is
+  # enabled.
+  #check_job_script_integrity_count: 35
+
+  # Time to sleep between checks if check_job_script_integrity is
+  # enabled (in seconds).
+  #check_job_script_integrity_sleep: 0.25
+
+  # Set the default shell used by non-containerized jobs Galaxy-wide.
+  # This defaults to bash for all jobs and can be overridden at the
+  # destination level for heterogeneous clusters. conda job resolution
+  # requires bash or zsh so if this is switched to /bin/sh for instance
+  # - conda resolution should be disabled. Containerized jobs always use
+  # /bin/sh - so more maximum portability tool authors should assume
+  # generated commands run in sh.
+  #default_job_shell: /bin/bash
+
+  # Whether to enable the tool document cache. This cache stores
+  # expanded XML strings. Enabling the tool cache results in slightly
+  # faster startup times. The tool cache is backed by a SQLite database,
+  # which cannot be stored on certain network disks. The cache location
+  # is configurable using the ``tool_cache_data_dir`` setting, but can
+  # be disabled completely here.
+  #enable_tool_document_cache: false
+
+  # Tool related caching. Fully expanded tools and metadata will be
+  # stored at this path. Per tool_conf cache locations can be configured
+  # in (``shed_``)tool_conf.xml files using the tool_cache_data_dir
+  # attribute.
+  # The value of this option will be resolved with respect to
+  # <cache_dir>.
+  #tool_cache_data_dir: tool_cache
+
+  # Directory in which the toolbox search index is stored. The value of
+  # this option will be resolved with respect to <data_dir>.
+  #tool_search_index_dir: tool_search_index
+
+  # Set this to true to delay parsing of tool inputs and outputs until
+  # they are needed. This results in faster startup times but uses more
+  # memory when using forked Galaxy processes.
+  #delay_tool_initialization: false
+
+  # Point Galaxy at a repository consisting of a copy of the bio.tools
+  # database (e.g. https://github.com/bio-tools/content/) to resolve
+  # bio.tools data for tool metadata.
+  #biotools_content_directory: null
+
+  # Set this to true to attempt to resolve bio.tools metadata for tools
+  # for tool not resovled via biotools_content_directory.
+  #biotools_use_api: false
+
+  # bio.tools web service request related caching. The type of beaker
+  # cache used.
+  #biotools_service_cache_type: file
+
+  # bio.tools web service request related caching. The data directory to
+  # point beaker cache at.
+  # The value of this option will be resolved with respect to
+  # <cache_dir>.
+  #biotools_service_cache_data_dir: biotools/data
+
+  # bio.tools web service request related caching. The lock directory to
+  # point beaker cache at.
+  # The value of this option will be resolved with respect to
+  # <cache_dir>.
+  #biotools_service_cache_lock_dir: biotools/locks
+
+  # Citation related caching.  Tool citations information maybe fetched
+  # from external sources such as https://doi.org/ by Galaxy - the
+  # following parameters can be used to control the caching used to
+  # store this information.
+  #citation_cache_type: file
+
+  # Citation related caching.  Tool citations information maybe fetched
+  # from external sources such as https://doi.org/ by Galaxy - the
+  # following parameters can be used to control the caching used to
+  # store this information.
+  # The value of this option will be resolved with respect to
+  # <cache_dir>.
+  #citation_cache_data_dir: citations/data
+
+  # Citation related caching.  Tool citations information maybe fetched
+  # from external sources such as https://doi.org/ by Galaxy - the
+  # following parameters can be used to control the caching used to
+  # store this information.
+  # The value of this option will be resolved with respect to
+  # <cache_dir>.
+  #citation_cache_lock_dir: citations/locks
+
+  # Mulled resolution caching. Mulled resolution uses external APIs of
+  # quay.io, these requests are caching using this and the following
+  # parameters
+  #mulled_resolution_cache_type: file
+
+  # Data directory used by beaker for caching mulled resolution
+  # requests.
+  # The value of this option will be resolved with respect to
+  # <cache_dir>.
+  #mulled_resolution_cache_data_dir: mulled/data
+
+  # Lock directory used by beaker for caching mulled resolution
+  # requests.
+  # The value of this option will be resolved with respect to
+  # <cache_dir>.
+  #mulled_resolution_cache_lock_dir: mulled/locks
+
+  # Seconds until the beaker cache is considered old and a new value is
+  # created.
+  #mulled_resolution_cache_expire: 3600
+
+  # Configuration file for the object store If this is set and exists,
+  # it overrides any other objectstore settings.
+  # The value of this option will be resolved with respect to
+  # <config_dir>.
+  #object_store_config_file: object_store_conf.xml
+
+  # What Dataset attribute is used to reference files in an ObjectStore
+  # implementation, this can be 'uuid' or 'id'. The default will depend
+  # on how the object store is configured, starting with 20.05 Galaxy
+  # will try to default to 'uuid' if it can be sure this is a new Galaxy
+  # instance - but the default will be 'id' in many cases. In
+  # particular, if the name of the directory set in <file_path> is
+  # `objects`, the default will be set to 'uuid', otherwise it will be
+  # 'id'.
+  #object_store_store_by: null
+
+  # Galaxy sends mail for various things: subscribing users to the
+  # mailing list if they request it, password resets, reporting dataset
+  # errors, and sending activation emails. To do this, it needs to send
+  # mail through an SMTP server, which you may define here (host:port).
+  # Galaxy will automatically try STARTTLS but will continue upon
+  # failure.
+{% if enable_smtp %}
+  smtp_server: {{ galaxy_smtp_server }}
+{% else %}
+  #smtp_server: null
+{% endif %}
+
+  # If your SMTP server requires a username and password, you can
+  # provide them here (password in cleartext here, but if your server
+  # supports STARTTLS it will be sent over the network encrypted).
+  #smtp_username: null
+
+  # If your SMTP server requires a username and password, you can
+  # provide them here (password in cleartext here, but if your server
+  # supports STARTTLS it will be sent over the network encrypted).
+  #smtp_password: null
+
+  # If your SMTP server requires SSL from the beginning of the
+  # connection
+  #smtp_ssl: false
+
+  # On the user registration form, users may choose to join a mailing
+  # list. This is the address used to subscribe to the list. Uncomment
+  # and leave empty if you want to remove this option from the user
+  # registration form.
+  # Example value 'galaxy-announce-join@lists.galaxyproject.org'
+  #mailing_join_addr: null
+
+  # The subject of the email sent to the mailing list join address. See
+  # the `mailing_join_addr` option for more information.
+  #mailing_join_subject: Join Mailing List
+
+  # The body of the email sent to the mailing list join address. See the
+  # `mailing_join_addr` option for more information.
+  #mailing_join_body: Join Mailing List
+
+  # Datasets in an error state include a link to report the error.
+  # Those reports will be sent to this address.  Error reports are
+  # disabled if no address is set.  Also this email is shown as a
+  # contact to user in case of Galaxy misconfiguration and other events
+  # user may encounter.
+{% if enable_smtp %}
+  error_email_to: {{ galaxy_incoming_email_addr }}
+{% else %}
+  #error_email_to: null
+{% endif %}
+
+  # Email address to use in the 'From' field when sending emails for
+  # account activations, workflow step notifications, password resets,
+  # and tool error reports.  We recommend using a string in the
+  # following format: Galaxy Project <galaxy-no-reply@example.com>. If
+  # not configured, '<galaxy-no-reply@HOSTNAME>' will be used.
+{% if enable_smtp %}
+  email_from: {{ galaxy_outgoing_email_addr }}
+{% else %}
+  #email_from: null
+{% endif %}
+
+  # This text will be inserted at the end of the activation email's
+  # message, before the 'Your Galaxy Team' signature.
+  #custom_activation_email_message: null
+
+  # URL of the support resource for the galaxy instance.  Used in
+  # activation emails.
+  # Example value 'https://galaxyproject.org/'
+  instance_resource_url: {{ galaxy_url }}
+
+  # E-mail domains blocklist is used for filtering out users that are
+  # using disposable email addresses at registration.  If their
+  # address's base domain matches any domain on the list, they are
+  # refused registration. Address subdomains are ignored (both
+  # 'name@spam.com' and 'name@foo.spam.com' will match 'spam.com').
+  # Example value 'email_blocklist.conf'
+  # The value of this option will be resolved with respect to
+  # <config_dir>.
+  #email_domain_blocklist_file: null
+
+  # E-mail domains allowlist is used to specify allowed email address
+  # domains. If the list is non-empty and a user attempts registration
+  # using an email address belonging to a domain that is not on the
+  # list, registration will be denied. Unlike
+  # <email_domain_allowlist_file> which matches the address's base
+  # domain, here email addresses are matched against the full domain
+  # (base + subdomain). This is a more restrictive option than
+  # <email_domain_blocklist_file>, and therefore, in case
+  # <email_domain_allowlist_file> is set and is not empty,
+  # <email_domain_blocklist_file> will be ignored.
+  # Example value 'email_allowlist.conf'
+  # The value of this option will be resolved with respect to
+  # <config_dir>.
+  #email_domain_allowlist_file: null
+
+  # Registration warning message is used to discourage people from
+  # registering multiple accounts.  Applies mostly for the main Galaxy
+  # instance. If no message specified the warning box will not be shown.
+  #registration_warning_message: Please register only one account - we provide this service free of charge and have limited computational resources. Multi-accounts are tracked and will be subjected to account termination and data deletion.
+
+  # User account activation feature global flag.  If set to false, the
+  # rest of the Account activation configuration is ignored and user
+  # activation is disabled (i.e. accounts are active since
+  # registration). The activation is also not working in case the SMTP
+  # server is not defined.
+  user_activation_on: {{ enable_user_activation }}
+
+  # Activation grace period (in hours).  Activation is not forced (login
+  # is not disabled) until grace period has passed.  Users under grace
+  # period can't run jobs. Enter 0 to disable grace period.
+  activation_grace_period: 0
+
+  # Shown in warning box to users that were not activated yet. In use
+  # only if activation_grace_period is set.
+  #inactivity_box_content: Your account has not been activated yet.  Feel free to browse around and see what's available, but you won't be able to upload data or run jobs until you have verified your email address.
+
+  # Password expiration period (in days). Users are required to change
+  # their password every x days. Users will be redirected to the change
+  # password screen when they log in after their password expires. Enter
+  # 0 to disable password expiration.
+  #password_expiration_period: 0
+
+  # Allow users to manage their account data, change passwords or delete
+  # their accounts.
+  #enable_account_interface: true
+
+  # Galaxy Session Timeout This provides a timeout (in minutes) after
+  # which a user will have to log back in. A duration of 0 disables this
+  # feature.
+  #session_duration: 0
+
+  # You can enter tracking code here to track visitor's behavior through
+  # your Google Analytics account.  Example: UA-XXXXXXXX-Y
+  #ga_code: null
+
+  # Please enter the URL for the Plausible server (including https) so
+  # this can be used for tracking with Plausible
+  # (https://plausible.io/).
+  #plausible_server: null
+
+  # Please enter the URL for the Galaxy server so this can be used for
+  # tracking with Plausible (https://plausible.io/).
+  #plausible_domain: null
+
+  # Please enter the URL for the Matomo server (including https) so this
+  # can be used for tracking with Matomo (https://matomo.org/).
+  #matomo_server: null
+
+  # Please enter the site ID for the Matomo server so this can be used
+  # for tracking with Matomo (https://matomo.org/).
+  #matomo_site_id: null
+
+  # Galaxy can display data at various external browsers.  These options
+  # specify which browsers should be available.  URLs and builds
+  # available at these browsers are defined in the specified files.
+  # If use_remote_user is set to true, display application servers will
+  # be denied access to Galaxy and so displaying datasets in these sites
+  # will fail. display_servers contains a list of hostnames which should
+  # be allowed to bypass security to display datasets.  Please be aware
+  # that there are security implications if this is allowed.  More
+  # details (including required changes to the proxy server config) are
+  # available in the Apache proxy documentation on the Galaxy Community
+  # Hub.
+  # The list of servers in this sample config are for the UCSC Main,
+  # Test and Archaea browsers, but the default if left commented is to
+  # not allow any display sites to bypass security (you must uncomment
+  # the line below to allow them).
+  #display_servers: hgw1.cse.ucsc.edu,hgw2.cse.ucsc.edu,hgw3.cse.ucsc.edu,hgw4.cse.ucsc.edu,hgw5.cse.ucsc.edu,hgw6.cse.ucsc.edu,hgw7.cse.ucsc.edu,hgw8.cse.ucsc.edu,lowepub.cse.ucsc.edu
+
+  # Set this to false to disable the old-style display applications that
+  # are hardcoded into datatype classes. This may be desirable due to
+  # using the new-style, XML-defined, display applications that have
+  # been defined for many of the datatypes that have the old-style.
+  # There is also a potential security concern with the old-style
+  # applications, where a malicious party could provide a link that
+  # appears to reference the Galaxy server, but contains a redirect to a
+  # third-party server, tricking a Galaxy user to access said site.
+  #enable_old_display_applications: true
+
+  # This flag enables an AWS cost estimate for every job based on their
+  # runtime matrices. CPU, RAM and runtime usage is mapped against AWS
+  # pricing table. Please note, that those numbers are only estimates.
+  #aws_estimate: false
+
+  # Enable InteractiveTools.
+  #interactivetools_enable: false
+
+  # Set this to false to redirect users of Interactive tools directly to
+  # the Interactive tools proxy. `interactivetools_upstream_proxy`
+  # should only be set to false in development.
+  #interactivetools_upstream_proxy: true
+
+  # Hostname and port of Interactive tools proxy. It is assumed to be
+  # hosted on the same hostname and port as Galaxy by default.
+  #interactivetools_proxy_host: null
+
+  # Base path for interactive tools running at a subpath without a
+  # subdomain. Defaults to "/".
+  #interactivetools_base_path: /
+
+  # Map for interactivetool proxy.
+  # The value of this option will be resolved with respect to
+  # <data_dir>.
+  #interactivetools_map: interactivetools_map.sqlite
+
+  # Prefix to use in the formation of the subdomain or path for
+  # interactive tools
+  #interactivetools_prefix: interactivetool
+
+  # Shorten the uuid portion of the subdomain or path for interactive
+  # tools. Especially useful for avoiding the need for wildcard
+  # certificates by keeping subdomain under 63 chars
+  #interactivetools_shorten_url: false
+
+  # Galaxy Interactive Tools (GxITs) can be stopped from within the
+  # Galaxy interface, killing the GxIT job without completing its
+  # metadata setting post-job steps. In such a case it may be desirable
+  # to set metadata on job outputs internally (in the Galaxy job handler
+  # process). The default is is the value of
+  # `retry_metadata_internally`, which defaults to `true`.
+  #retry_interactivetool_metadata_internally: true
+
+  # Show visualization tab and list in masthead.
+  #visualizations_visible: true
+
+  # Show a message box under the masthead.
+{% if galaxy_message != None and galaxy_message|default("") != "" %}
+  message_box_visible: true
+{% else %}
+  #message_box_visible: false
+{% endif %}
+
+  # Show a message box under the masthead.
+{% if galaxy_message != None and galaxy_message|default("") != "" %}
+  message_box_content: "{{ galaxy_message }}"
+{% else %}
+  #message_box_content: null
+{% endif %}
+
+  # Class of the message box under the masthead. Possible values are:
+  # 'info' (the default), 'warning', 'error', 'done'.
+{% if galaxy_message != None and galaxy_message|default("") != "" %}
+  message_box_class: info
+{% else %}
+  #message_box_class: info
+{% endif %}
+
+  # Append "{brand}" text to the masthead.
+  brand: {{ galaxy_name }}
+
+  # Display the "Galaxy" text in the masthead.
+  #display_galaxy_brand: true
+
+  # Format string used when showing date and time information. The
+  # string may contain: - the directives used by Python time.strftime()
+  # function (see
+  # https://docs.python.org/library/time.html#time.strftime), - $locale
+  # (complete format string for the server locale), - $iso8601 (complete
+  # format string as specified by ISO 8601 international   standard).
+  #pretty_datetime_format: $locale (UTC)
+
+  # Allow import of workflows from the TRS servers configured in the
+  # specified YAML or JSON file. The file should be a list with 'id',
+  # 'label', and 'api_url' for each entry. Optionally, 'link_url' and
+  # 'doc' may be be specified as well for each entry.
+  # If this is null (the default), a simple configuration containing
+  # just Dockstore will be used.
+  # The value of this option will be resolved with respect to
+  # <config_dir>.
+  #trs_servers_config_file: trs_servers_conf.yml
+
+  # Server-wide default selection to use the legacy history during the
+  # transition period, after which this option will disappear.  Users
+  # will remain able to swap back and forth per their preference.
+  #use_legacy_history: false
+
+  # Location of the configuration file containing extra user
+  # preferences.
+  # The value of this option will be resolved with respect to
+  # <config_dir>.
+  #user_preferences_extra_conf_path: user_preferences_extra_conf.yml
+
+  # Default localization for Galaxy UI. Allowed values are listed at the
+  # end of client/src/nls/locale.js. With the default value (auto), the
+  # locale will be automatically adjusted to the user's navigator
+  # language. Users can override this settings in their user preferences
+  # if the localization settings are enabled in
+  # user_preferences_extra_conf.yml
+  #default_locale: auto
+
+  # URL prefix for Galaxy application. If Galaxy should be served under
+  # a prefix set this to the desired prefix value.
+{% if galaxy_proxy_prefix|default(None) != None %}
+  galaxy_url_prefix: {{ galaxy_proxy_prefix }}
+{% else %}
+  #galaxy_url_prefix: /
+{% endif %}
+
+  # URL (with schema http/https) of the Galaxy instance as accessible
+  # within your local network. This URL is used as a default by pulsar
+  # file staging and Interactive Tool containers for communicating back
+  # with Galaxy via the API.
+  # If you plan to run Interactive Tools make sure the docker container
+  # can reach this URL. For more details see
+  # `job_conf.xml.interactivetools`.
+  #galaxy_infrastructure_url: http://localhost:8080
+
+  # If the above URL cannot be determined ahead of time in dynamic
+  # environments but the port which should be used to access Galaxy can
+  # be - this should be set to prevent Galaxy from having to guess.  For
+  # example if Galaxy is sitting behind a proxy with REMOTE_USER enabled
+  # - infrastructure shouldn't talk to Python processes directly and
+  # this should be set to 80 or 443, etc... If unset this file will be
+  # read for a server block defining a port corresponding to the webapp.
+  #galaxy_infrastructure_web_port: 8080
+
+  # The URL of the page to display in Galaxy's middle pane when loaded.
+  # This can be an absolute or relative URL.
+  #welcome_url: /static/welcome.html
+
+  # The URL linked by the "Galaxy/brand" text.
+  #logo_url: /
+
+  # The brand image source.
+  #logo_src: /static/favicon.png
+
+  # The custom brand image source.
+  #logo_src_secondary: null
+
+  # The URL linked by the "Galaxy Help" link in the "Help" menu.
+  #helpsite_url: https://help.galaxyproject.org/
+
+  # The URL linked by the "Community Hub" link in the "Help" menu.
+  #wiki_url: https://galaxyproject.org/
+
+  # The URL linked for quota information in the UI.
+  #quota_url: https://galaxyproject.org/support/account-quotas/
+
+  # The URL linked by the "Support" link in the "Help" menu.
+  #support_url: https://galaxyproject.org/support/
+
+  # The URL linked by the "How to Cite Galaxy" link in the "Help" menu.
+{% if galaxy_citations|default("") != "" %}
+  citation_url: '{{ galaxy_url }}/static/citations.html'
+{% else %}
+  #citation_url: https://galaxyproject.org/citing-galaxy
+{% endif %}
+
+  # The URL linked by the "Galaxy Version" link in the "Help" menu.
+  #release_doc_base_url: https://docs.galaxyproject.org/en/release_
+
+  # The URL linked by the "Videos" link in the "Help" menu.
+  #screencasts_url: https://www.youtube.com/c/galaxyproject
+
+  # The URL linked by the "Terms and Conditions" link in the "Help"
+  # menu, as well as on the user registration and login forms and in the
+  # activation emails.
+{% if galaxy_terms|default("") != "" %}
+  terms_url: '{{ galaxy_url }}/static/terms.html'
+{% else %}
+  #terms_url: null
+{% endif %}
+
+  # Serve static content, which must be enabled if you're not serving it
+  # via a proxy server.  These options should be self explanatory and so
+  # are not documented individually.  You can use these paths (or ones
+  # in the proxy server) to point to your own styles.
+  static_enabled: false
+
+  # Serve static content, which must be enabled if you're not serving it
+  # via a proxy server.  These options should be self explanatory and so
+  # are not documented individually.  You can use these paths (or ones
+  # in the proxy server) to point to your own styles.
+  #static_cache_time: 360
+
+  # Serve static content, which must be enabled if you're not serving it
+  # via a proxy server.  These options should be self explanatory and so
+  # are not documented individually.  You can use these paths (or ones
+  # in the proxy server) to point to your own styles.
+  #static_dir: static/
+
+  # Serve static content, which must be enabled if you're not serving it
+  # via a proxy server.  These options should be self explanatory and so
+  # are not documented individually.  You can use these paths (or ones
+  # in the proxy server) to point to your own styles.
+  #static_images_dir: static/images
+
+  # Serve static content, which must be enabled if you're not serving it
+  # via a proxy server.  These options should be self explanatory and so
+  # are not documented individually.  You can use these paths (or ones
+  # in the proxy server) to point to your own styles.
+  #static_favicon_dir: static/favicon.ico
+
+  # Serve static content, which must be enabled if you're not serving it
+  # via a proxy server.  These options should be self explanatory and so
+  # are not documented individually.  You can use these paths (or ones
+  # in the proxy server) to point to your own styles.
+  #static_scripts_dir: static/scripts/
+
+  # Serve static content, which must be enabled if you're not serving it
+  # via a proxy server.  These options should be self explanatory and so
+  # are not documented individually.  You can use these paths (or ones
+  # in the proxy server) to point to your own styles.
+  #static_style_dir: static/style
+
+  # Serve static content, which must be enabled if you're not serving it
+  # via a proxy server.  These options should be self explanatory and so
+  # are not documented individually.  You can use these paths (or ones
+  # in the proxy server) to point to your own styles.
+  #static_robots_txt: static/robots.txt
+
+  # Incremental Display Options
+  #display_chunk_size: 65536
+
+  # For help on configuring the Advanced proxy features, see:
+  # https://docs.galaxyproject.org/en/master/admin/production.html
+  # Apache can handle file downloads (Galaxy-to-user) via mod_xsendfile.
+  # Set this to true to inform Galaxy that mod_xsendfile is enabled
+  # upstream.
+  #apache_xsendfile: false
+
+  # The same download handling can be done by nginx using
+  # X-Accel-Redirect.  This should be set to the path defined in the
+  # nginx config as an internal redirect with access to Galaxy's data
+  # files (see documentation linked above).
+  #nginx_x_accel_redirect_base: null
+
+  # If using compression in the upstream proxy server, use this option
+  # to disable gzipping of dataset collection and library archives,
+  # since the upstream server will do it faster on the fly. To enable
+  # compression add ``application/zip`` to the proxy's compressable
+  # mimetypes.
+  #upstream_gzip: false
+
+  # If using the mod-zip module in nginx, use this option to assemble
+  # zip archives in nginx. This is preferable over the upstream_gzip
+  # option as Galaxy does not need to serve the archive. Requires
+  # setting up internal nginx locations to all paths that can be
+  # archived. See
+  # https://docs.galaxyproject.org/en/master/admin/nginx.html#creating-archives-with-mod-zip
+  # for details.
+  #upstream_mod_zip: false
+
+  # The following default adds a header to web request responses that
+  # will cause modern web browsers to not allow Galaxy to be embedded in
+  # the frames of web applications hosted at other hosts - this can help
+  # prevent a class of attack called clickjacking
+  # (https://www.owasp.org/index.php/Clickjacking).  If you configure a
+  # proxy in front of Galaxy - please ensure this header remains intact
+  # to protect your users.  Uncomment and leave empty to not set the
+  # `X-Frame-Options` header.
+  #x_frame_options: SAMEORIGIN
+
+  # nginx can also handle file uploads (user-to-Galaxy) via
+  # nginx_upload_module. Configuration for this is complex and explained
+  # in detail in the documentation linked above.  The upload store is a
+  # temporary directory in which files uploaded by the upload module
+  # will be placed.
+  #nginx_upload_store: null
+
+  # This value overrides the action set on the file upload form, e.g.
+  # the web path where the nginx_upload_module has been configured to
+  # intercept upload requests.
+  #nginx_upload_path: null
+
+  # Galaxy can also use nginx_upload_module to receive files staged out
+  # upon job completion by remote job runners (i.e. Pulsar) that
+  # initiate staging operations on the remote end.  See the Galaxy nginx
+  # documentation for the corresponding nginx configuration.
+  #nginx_upload_job_files_store: null
+
+  # Galaxy can also use nginx_upload_module to receive files staged out
+  # upon job completion by remote job runners (i.e. Pulsar) that
+  # initiate staging operations on the remote end.  See the Galaxy nginx
+  # documentation for the corresponding nginx configuration.
+  #nginx_upload_job_files_path: null
+
+  # The upload store is a temporary directory in which files uploaded by
+  # the tus middleware or server will be placed. Defaults to
+  # new_file_path if not set.
+  #tus_upload_store: null
+
+  # Galaxy can upload user files in chunks without using nginx. Enable
+  # the chunk uploader by specifying a chunk size larger than 0. The
+  # chunk size is specified in bytes (default: 10MB).
+  #chunk_upload_size: 10485760
+
+  # Have Galaxy manage dynamic proxy component for routing requests to
+  # other services based on Galaxy's session cookie.  It will attempt to
+  # do this by default though you do need to install node+npm and do an
+  # npm install from `lib/galaxy/web/proxy/js`.  It is generally more
+  # robust to configure this externally, managing it in the same way
+  # Galaxy itself is managed.  If true, Galaxy will only launch the
+  # proxy if it is actually going to be used (e.g. for Jupyter).
+  #dynamic_proxy_manage: true
+
+  # As of 16.04 Galaxy supports multiple proxy types. The original
+  # NodeJS implementation, alongside a new Golang
+  # single-binary-no-dependencies version. Valid values are (node,
+  # golang)
+  #dynamic_proxy: node
+
+  # The NodeJS dynamic proxy can use an SQLite database or a JSON file
+  # for IPC, set that here.
+  # The value of this option will be resolved with respect to
+  # <data_dir>.
+  #dynamic_proxy_session_map: session_map.sqlite
+
+  # Set the port and IP for the dynamic proxy to bind to, this must
+  # match the external configuration if dynamic_proxy_manage is set to
+  # false.
+  #dynamic_proxy_bind_port: 8800
+
+  # Set the port and IP for the dynamic proxy to bind to, this must
+  # match the external configuration if dynamic_proxy_manage is set to
+  # false.
+  #dynamic_proxy_bind_ip: 0.0.0.0
+
+  # Enable verbose debugging of Galaxy-managed dynamic proxy.
+  #dynamic_proxy_debug: false
+
+  # The dynamic proxy is proxied by an external proxy (e.g. apache
+  # frontend to nodejs to wrap connections in SSL).
+  #dynamic_proxy_external_proxy: false
+
+  # Additionally, when the dynamic proxy is proxied by an upstream
+  # server, you'll want to specify a prefixed URL so both Galaxy and the
+  # proxy reside under the same path that your cookies are under. This
+  # will result in a url like https://FQDN/galaxy-prefix/gie_proxy for
+  # proxying
+  #dynamic_proxy_prefix: gie_proxy
+
+  # This attribute governs the minimum length of time between
+  # consecutive HTTP/WS requests through the proxy, before the proxy
+  # considers a container as being inactive and kills it.
+  #dynamic_proxy_golang_noaccess: 60
+
+  # In order to kill containers, the golang proxy has to check at some
+  # interval for possibly dead containers. This is exposed as a
+  # configurable parameter, but the default value is probably fine.
+  #dynamic_proxy_golang_clean_interval: 10
+
+  # The golang proxy needs to know how to talk to your docker daemon.
+  # Currently TLS is not supported, that will come in an update.
+  #dynamic_proxy_golang_docker_address: unix:///var/run/docker.sock
+
+  # The golang proxy uses a RESTful HTTP API for communication with
+  # Galaxy instead of a JSON or SQLite file for IPC. If you do not
+  # specify this, it will be set randomly for you. You should set this
+  # if you are managing the proxy manually.
+  #dynamic_proxy_golang_api_key: null
+
+  # If true, Galaxy will attempt to configure a simple root logger if a
+  # "loggers" section does not appear in this configuration file.
+  #auto_configure_logging: true
+
+  # Log destination, defaults to special value "stdout" that logs to
+  # standard output. If set to anything else, then it will be
+  # interpreted as a path that will be used as the log file, and logging
+  # to stdout will be disabled.
+  #log_destination: stdout
+
+  # Size of log file at which size it will be rotated as per the
+  # documentation in
+  # https://docs.python.org/library/logging.handlers.html#logging.handlers.RotatingFileHandler
+  # If log_rotate_count is not also set, no log rotation will be
+  # performed. A value of 0 (the default) means no rotation. Size can be
+  # a number of bytes or a human-friendly representation like "100 MB"
+  # or "1G".
+  #log_rotate_size: '0'
+
+  # Number of log file backups to keep, per the documentation in
+  # https://docs.python.org/library/logging.handlers.html#logging.handlers.RotatingFileHandler
+  # Any additional rotated log files will automatically be pruned. If
+  # log_rotate_size is not also set, no log rotation will be performed.
+  # A value of 0 (the default) means no rotation.
+  #log_rotate_count: 0
+
+  # Verbosity of console log messages. Acceptable values can be found
+  # here: https://docs.python.org/library/logging.html#logging-levels A
+  # custom debug level of "TRACE" is available for even more verbosity.
+  #log_level: DEBUG
+
+  # Controls where and how the server logs messages. If set, overrides
+  # all settings in the log_* configuration options. Configuration is
+  # described in the documentation at:
+  # https://docs.galaxyproject.org/en/master/admin/config_logging.html
+  #logging: null
+
+  # Print database operations to the server log (warning, quite
+  # verbose!).
+  #database_engine_option_echo: false
+
+  # Print database pool operations to the server log (warning, quite
+  # verbose!).
+  #database_engine_option_echo_pool: false
+
+  # Turn on logging of application events and some user events to the
+  # database.
+  #log_events: false
+
+  # Turn on logging of user actions to the database.  Actions currently
+  # logged are grid views, tool searches, and use of "recently" used
+  # tools menu.  The log_events and log_actions functionality will
+  # eventually be merged.
+  #log_actions: false
+
+  # Fluentd configuration.  Various events can be logged to the fluentd
+  # instance configured below by enabling fluent_log.
+  #fluent_log: false
+
+  # Fluentd configuration.  Various events can be logged to the fluentd
+  # instance configured below by enabling fluent_log.
+  #fluent_host: localhost
+
+  # Fluentd configuration.  Various events can be logged to the fluentd
+  # instance configured below by enabling fluent_log.
+  #fluent_port: 24224
+
+  # Sanitize all HTML tool output.  By default, all tool output served
+  # as 'text/html' will be sanitized thoroughly.  This can be disabled
+  # if you have special tools that require unaltered output.  WARNING:
+  # disabling this does make the Galaxy instance susceptible to XSS
+  # attacks initiated by your users.
+  #sanitize_all_html: true
+
+  # Datasets created by tools listed in this file are trusted and will
+  # not have their HTML sanitized on display.  This can be manually
+  # edited or manipulated through the Admin control panel -- see "Manage
+  # Allowlist"
+  # The value of this option will be resolved with respect to
+  # <mutable_config_dir>.
+  sanitize_allowlist_file: sanitize_allowlist.txt
+
+  # By default Galaxy will serve non-HTML tool output that may
+  # potentially contain browser executable JavaScript content as plain
+  # text.  This will for instance cause SVG datasets to not render
+  # properly and so may be disabled by setting this option to true.
+  #serve_xss_vulnerable_mimetypes: false
+
+  # Return a Access-Control-Allow-Origin response header that matches
+  # the Origin header of the request if that Origin hostname matches one
+  # of the strings or regular expressions listed here. This is a
+  # comma-separated list of hostname strings or regular expressions
+  # beginning and ending with /. E.g.
+  # mysite.com,google.com,usegalaxy.org,/^[\w\.]*example\.com/ See:
+  # https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS
+  #allowed_origin_hostnames: null
+
+  # Set to true to use Jupyter nbconvert to build HTML from Jupyter
+  # notebooks in Galaxy histories.  This process may allow users to
+  # execute arbitrary code or serve arbitrary HTML.  If enabled, Jupyter
+  # must be available and on Galaxy's PATH, to do this run `pip install
+  # jinja2 pygments jupyter` in Galaxy's virtualenv.
+  #trust_jupyter_notebook_conversion: false
+
+  # Debug enables access to various config options useful for
+  # development and debugging: use_lint, use_profile, and
+  # use_printdebug.  It also causes the files used by PBS/SGE
+  # (submission script, output, and error) to remain on disk after the
+  # job is complete.
+  #debug: false
+
+  # Check for WSGI compliance.
+  #use_lint: false
+
+  # Run the Python profiler on each request.
+  #use_profile: false
+
+  # Intercept print statements and show them on the returned page.
+  #use_printdebug: true
+
+  # When stopping Galaxy cleanly, how much time to give various
+  # monitoring/polling threads to finish before giving up on joining
+  # them. Set to 0 to disable this and terminate without waiting. Among
+  # others, these threads include the job handler workers, which are
+  # responsible for preparing/submitting and collecting/finishing jobs,
+  # and which can cause job errors if not shut down cleanly. If using
+  # supervisord, consider also increasing the value of `stopwaitsecs`.
+  # See the Galaxy Admin Documentation for more.
+  #monitor_thread_join_timeout: 30
+
+  # Write thread status periodically to 'heartbeat.log',  (careful, uses
+  # disk space rapidly!).  Useful to determine why your processes may be
+  # consuming a lot of CPU.
+  #use_heartbeat: false
+
+  # Control the period (in seconds) between dumps. Use -1 to disable.
+  # Regardless of this setting, if use_heartbeat is enabled, you can
+  # send a Galaxy process SIGUSR1 (`kill -USR1`) to force a dump.
+  #heartbeat_interval: 20
+
+  # Heartbeat log filename. Can accept the template variables
+  # {server_name} and {pid}
+  #heartbeat_log: heartbeat_{server_name}.log
+
+  # Log to Sentry Sentry is an open source logging and error aggregation
+  # platform.  Setting sentry_dsn will enable the Sentry middleware and
+  # errors will be sent to the indicated sentry instance.  This
+  # connection string is available in your sentry instance under
+  # <project_name> -> Settings -> API Keys.
+  #sentry_dsn: null
+
+  # Determines the minimum log level that will be sent as an event to
+  # Sentry. Possible values are DEBUG, INFO, WARNING, ERROR or CRITICAL.
+  #sentry_event_level: ERROR
+
+  # Log to statsd Statsd is an external statistics aggregator
+  # (https://github.com/etsy/statsd) Enabling the following options will
+  # cause galaxy to log request timing and other statistics to the
+  # configured statsd instance.  The statsd_prefix is useful if you are
+  # running multiple Galaxy instances and want to segment statistics
+  # between them within the same aggregator.
+  #statsd_host: null
+
+  # Log to statsd Statsd is an external statistics aggregator
+  # (https://github.com/etsy/statsd) Enabling the following options will
+  # cause galaxy to log request timing and other statistics to the
+  # configured statsd instance.  The statsd_prefix is useful if you are
+  # running multiple Galaxy instances and want to segment statistics
+  # between them within the same aggregator.
+  #statsd_port: 8125
+
+  # Log to statsd Statsd is an external statistics aggregator
+  # (https://github.com/etsy/statsd) Enabling the following options will
+  # cause galaxy to log request timing and other statistics to the
+  # configured statsd instance.  The statsd_prefix is useful if you are
+  # running multiple Galaxy instances and want to segment statistics
+  # between them within the same aggregator.
+  #statsd_prefix: galaxy
+
+  # If you are using telegraf to collect these metrics and then sending
+  # them to InfluxDB, Galaxy can provide more nicely tagged metrics.
+  # Instead of sending prefix + dot-separated-path, Galaxy will send
+  # prefix with a tag path set to the page url
+  #statsd_influxdb: false
+
+  # Mock out statsd client calls - only used by testing infrastructure
+  # really. Do not set this in production environments.
+  #statsd_mock_calls: false
+
+  # Add an option to the library upload form which allows administrators
+  # to upload a directory of files.
+  #library_import_dir: null
+
+  # Add an option to the library upload form which allows authorized
+  # non-administrators to upload a directory of files.  The configured
+  # directory must contain sub-directories named the same as the
+  # non-admin user's Galaxy login ( email ).  The non-admin user is
+  # restricted to uploading files or sub-directories of files contained
+  # in their directory.
+  #user_library_import_dir: null
+
+  # If user_library_import_dir is set, this option will auto create a
+  # library import directory for every user (based on their email) upon
+  # login.
+  #user_library_import_dir_auto_creation: false
+
+  # For security reasons, users may not import any files that actually
+  # lie outside of their `user_library_import_dir` (e.g. using symbolic
+  # links). A list of directories can be allowed by setting the
+  # following option (the list is comma-separated). Be aware that *any*
+  # user with library import permissions can import from anywhere in
+  # these directories (assuming they are able to create symlinks to
+  # them).
+  #user_library_import_symlink_allowlist: null
+
+  # In conjunction or alternatively, Galaxy can restrict user library
+  # imports to those files that the user can read (by checking basic
+  # unix permissions). For this to work, the username has to match the
+  # username on the filesystem.
+  #user_library_import_check_permissions: false
+
+  # Allow admins to paste filesystem paths during upload. For libraries
+  # this adds an option to the admin library upload tool allowing admins
+  # to paste filesystem paths to files and directories in a box, and
+  # these paths will be added to a library.  For history uploads, this
+  # allows pasting in paths as URIs. (i.e. prefixed with file://). Set
+  # to true to enable.  Please note the security implication that this
+  # will give Galaxy Admins access to anything your Galaxy user has
+  # access to.
+  allow_path_paste: {{ galaxy_allow_path_paste }}
+
+  # Users may choose to download multiple files from a library in an
+  # archive.  By default, Galaxy allows users to select from a few
+  # different archive formats if testing shows that Galaxy is able to
+  # create files using these formats. Specific formats can be disabled
+  # with this option, separate more than one format with commas.
+  # Available formats are currently 'zip', 'gz', and 'bz2'.
+  #disable_library_comptypes: null
+
+  # In tool search, a query match against a tool's name text will
+  # receive this score multiplier.
+  #tool_name_boost: 20.0
+
+  # If a search query matches a tool name exactly, the score will be
+  # multiplied by this factor.
+  #tool_name_exact_multiplier: 10.0
+
+  # In tool search, a query match against a tool's ID text will receive
+  # this score multiplier. The query must be an exact match against ID
+  # in order to be counted as a match.
+  #tool_id_boost: 20.0
+
+  # In tool search, a query match against a tool's section text will
+  # receive this score multiplier.
+  #tool_section_boost: 3.0
+
+  # In tool search, a query match against a tool's description text will
+  # receive this score multiplier.
+  #tool_description_boost: 8.0
+
+  # In tool search, a query match against a tool's label text will
+  # receive this score multiplier.
+  #tool_label_boost: 1.0
+
+  # A stub is parsed from the GUID as "owner/repo/tool_id". In tool
+  # search, a query match against a tool's stub text will receive this
+  # score multiplier.
+  #tool_stub_boost: 2.0
+
+  # In tool search, a query match against a tool's help text will
+  # receive this score multiplier.
+  #tool_help_boost: 1.0
+
+  # The lower this parameter, the greater the diminishing reward for
+  # term frequency in the help text. A higher K1 increases the level of
+  # reward for additional occurences of a term. The default value will
+  # provide a slight increase in score for the first, second and third
+  # occurrence and little reward thereafter.
+  #tool_help_bm25f_k1: 0.5
+
+  # Limits the number of results in toolbox search. Use to set the
+  # maximum number of tool search results to display.
+  #tool_search_limit: 20
+
+  # Disabling this will prevent partial matches on tool names.
+  # Enable/disable Ngram-search for tools. It makes tool search results
+  # tolerant for spelling mistakes in the query, and will also match
+  # query substrings e.g. "genome" will match "genomics" or
+  # "metagenome".
+  #tool_enable_ngram_search: true
+
+  # Set minimum character length of ngrams
+  #tool_ngram_minsize: 3
+
+  # Set maximum character length of ngrams
+  #tool_ngram_maxsize: 4
+
+  # Ngram matched scores will be multiplied by this factor. Should
+  # always be below 1, because an ngram match is a partial match of a
+  # search term.
+  #tool_ngram_factor: 0.2
+
+  # Set tool test data directory. The test framework sets this value to
+  # 'test-data,https://github.com/galaxyproject/galaxy-test-data.git'
+  # which will cause Galaxy to clone down extra test data on the fly for
+  # certain tools distributed with Galaxy but this is likely not
+  # appropriate for production systems. Instead one can simply clone
+  # that repository directly and specify a path here instead of a Git
+  # HTTP repository.
+  #tool_test_data_directories: test-data
+
+  # Galaxy encodes various internal values when these values will be
+  # output in some format (for example, in a URL or cookie).  You should
+  # set a key to be used by the algorithm that encodes and decodes these
+  # values. It can be any string with a length between 5 and 56 bytes.
+  # One simple way to generate a value for this is with the shell
+  # command:   python -c 'from __future__ import print_function; import
+  # time; print(time.time())' | md5sum | cut -f 1 -d ' '
+  id_secret: {{ galaxy_id_secret }}
+
+  # User authentication can be delegated to an upstream proxy server
+  # (usually Apache).  The upstream proxy should set a REMOTE_USER
+  # header in the request. Enabling remote user disables regular logins.
+  # For more information, see:
+  # https://docs.galaxyproject.org/en/master/admin/special_topics/apache.html
+  #use_remote_user: false
+
+  # If use_remote_user is enabled and your external authentication
+  # method just returns bare usernames, set a default mail domain to be
+  # appended to usernames, to become your Galaxy usernames (email
+  # addresses).
+  #remote_user_maildomain: null
+
+  # If use_remote_user is enabled, the header that the upstream proxy
+  # provides the remote username in defaults to HTTP_REMOTE_USER (the
+  # ``HTTP_`` is prepended by WSGI).  This option allows you to change
+  # the header.  Note, you still need to prepend ``HTTP_`` to the header
+  # in this option, but your proxy server should *not* include ``HTTP_``
+  # at the beginning of the header name.
+  #remote_user_header: HTTP_REMOTE_USER
+
+  # If use_remote_user is enabled, anyone who can log in to the Galaxy
+  # host may impersonate any other user by simply sending the
+  # appropriate header.  Thus a secret shared between the upstream proxy
+  # server, and Galaxy is required. If anyone other than the Galaxy user
+  # is using the server, then apache/nginx should pass a value in the
+  # header 'GX_SECRET' that is identical to the one below.
+  #remote_user_secret: USING THE DEFAULT IS NOT SECURE!
+
+  # If use_remote_user is enabled, you can set this to a URL that will
+  # log your users out.
+  #remote_user_logout_href: null
+
+  # If your proxy and/or authentication source does not normalize e-mail
+  # addresses or user names being passed to Galaxy - set this option to
+  # true to force these to lower case.
+  #normalize_remote_user_email: false
+
+  # If an e-mail address is specified here, it will hijack remote user
+  # mechanics (``use_remote_user``) and have the webapp inject a single
+  # fixed user. This has the effect of turning Galaxy into a single user
+  # application with no login or external proxy required. Such
+  # applications should not be exposed to the world.
+  #single_user: null
+
+  # Administrative users - set this to a comma-separated list of valid
+  # Galaxy users (email addresses).  These users will have access to the
+  # Admin section of the server, and will have access to create users,
+  # groups, roles, libraries, and more.  For more information, see:
+  # https://galaxyproject.org/admin/
+{% if galaxy_extra_admins is none %}
+  admin_users: {{ galaxy_admin_user }}
+{% else %}
+  admin_users: {{ galaxy_admin_user }},{{ galaxy_extra_admins | join(",") }}
+{% endif %}
+
+  # Force everyone to log in (disable anonymous access).
+  require_login: {{ enable_require_login }}
+
+  # Show the site's welcome page (see welcome_url) alongside the login
+  # page (even if require_login is true).
+  show_welcome_with_login: true
+
+  # Controls the order of the login page to prefer Custos-based login
+  # and registration.
+  #prefer_custos_login: false
+
+  # Allow unregistered users to create new accounts (otherwise, they
+  # will have to be created by an admin).
+  allow_user_creation: {{ allow_user_creation }}
+
+  # Allow administrators to delete accounts.
+  allow_user_deletion: {{ allow_user_deletion }}
+
+  # Allow administrators to log in as other users (useful for
+  # debugging).
+  allow_user_impersonation: {{ allow_user_impersonation }}
+
+  # When using LDAP for authentication, allow administrators to
+  # pre-populate users using an additional form on 'Create new user'
+  #show_user_prepopulate_form: false
+
+  # If 'always-on', add another button to tool form data inputs that
+  # allow uploading data from the tool form in fewer clicks (at the
+  # expense of making the form more complicated). This applies to
+  # workflows as well.
+  # Avoiding making this a boolean because we may add options such as
+  # 'in-single-form-view' or 'in-simplified-workflow-views'.
+  # https://github.com/galaxyproject/galaxy/pull/9809/files#r461889109
+  #upload_from_form_button: always-off
+
+  # Allow users to remove their datasets from disk immediately
+  # (otherwise, datasets will be removed after a time period specified
+  # by an administrator in the cleanup scripts run via cron)
+  allow_user_dataset_purge: true
+
+  # By default, users' data will be public, but setting this to true
+  # will cause it to be private.  Does not affect existing users and
+  # data, only ones created after this option is set.  Users may still
+  # change their default back to public.
+  #new_user_dataset_access_role_default_private: false
+
+  # Expose user list.  Setting this to true will expose the user list to
+  # authenticated users.  This makes sharing datasets in smaller galaxy
+  # instances much easier as they can type a name/email and have the
+  # correct user show up. This makes less sense on large public Galaxy
+  # instances where that data shouldn't be exposed.  For semi-public
+  # Galaxies, it may make sense to expose just the username and not
+  # email, or vice versa.
+  # If enable_beta_gdpr is set to true, then this option will be
+  # overridden and set to false.
+  expose_user_name: {{ expose_user_name }}
+
+  # Expose user list.  Setting this to true will expose the user list to
+  # authenticated users.  This makes sharing datasets in smaller galaxy
+  # instances much easier as they can type a name/email and have the
+  # correct user show up. This makes less sense on large public Galaxy
+  # instances where that data shouldn't be exposed.  For semi-public
+  # Galaxies, it may make sense to expose just the username and not
+  # email, or vice versa.
+  # If enable_beta_gdpr is set to true, then this option will be
+  # overridden and set to false.
+  #expose_user_email: false
+
+  # List of allowed local network addresses for "Upload from URL"
+  # dialog. By default, Galaxy will deny access to the local network
+  # address space, to prevent users making requests to services which
+  # the administrator did not intend to expose. Previously, you could
+  # request any network service that Galaxy might have had access to,
+  # even if the user could not normally access it. It should be a
+  # comma-separated list of IP addresses or IP address/mask, e.g.
+  # 10.10.10.10,10.0.1.0/24,fd00::/8
+  #fetch_url_allowlist: null
+
+  # Enables GDPR Compliance mode. This makes several changes to the way
+  # Galaxy logs and exposes data externally such as removing emails and
+  # usernames from logs and bug reports. It also causes the delete user
+  # admin action to permanently redact their username and password, but
+  # not to delete data associated with the account as this is not
+  # currently easily implementable.
+  # You are responsible for removing personal data from backups.
+  # This forces expose_user_email and expose_user_name to be false, and
+  # forces user_deletion to be true to support the right to erasure.
+  # Please read the GDPR section under the special topics area of the
+  # admin documentation.
+  enable_beta_gdpr: {{ enable_beta_gdpr }}
+
+  # Enable beta workflow modules that should not yet be considered part
+  # of Galaxy's stable API. (The module state definitions may change and
+  # workflows built using these modules may not function in the future.)
+  #enable_beta_workflow_modules: false
+
+  # Comma-separated list of the EDAM panel views to load - choose from
+  # merged, operations, topics. Set to empty string to disable EDAM all
+  # together. Set default_panel_view to 'ontology:edam_topics' to
+  # override default tool panel to use an EDAM view.
+  #edam_panel_views: operations,topics
+
+  # Sets the path to EDAM ontology file - if the path doesn't exist PyPI
+  # package data will be loaded.
+  # The value of this option will be resolved with respect to
+  # <data_dir>.
+  #edam_toolbox_ontology_path: EDAM.tsv
+
+  # Directory to check out for toolbox tool panel views. The path is
+  # relative to the Galaxy root dir.  To use an absolute path begin the
+  # path with '/'.  This is a comma-separated list.
+  #panel_views_dir: config/plugins/activities
+
+  # Definitions of static toolbox panel views embedded directly in the
+  # config instead of reading YAML from directory with panel_views_dir.
+  #panel_views: null
+
+  # Default tool panel view for the current Galaxy configuration. This
+  # should refer to an id of a panel view defined using the panel_views
+  # or panel_views_dir configuration options or an EDAM panel view. The
+  # default panel view is simply called `default` and refers to the tool
+  # panel state defined by the integrated tool panel.
+  #default_panel_view: default
+
+  # Default format for the export of workflows. Possible values are 'ga'
+  # or 'format2'.
+  #default_workflow_export_format: ga
+
+  # If multiple job handlers are enabled, allow Galaxy to schedule
+  # workflow invocations in multiple handlers simultaneously. This is
+  # discouraged because it results in a less predictable order of
+  # workflow datasets within in histories.
+  #parallelize_workflow_scheduling_within_histories: false
+
+  # This is the maximum amount of time a workflow invocation may stay in
+  # an active scheduling state in seconds. Set to -1 to disable this
+  # maximum and allow any workflow invocation to schedule indefinitely.
+  # The default corresponds to 1 month.
+  #maximum_workflow_invocation_duration: 2678400
+
+  # Specify a maximum number of jobs that any given workflow scheduling
+  # iteration can create. Set this to a positive integer to prevent
+  # large collection jobs in a workflow from preventing other jobs from
+  # executing. This may also mitigate memory issues associated with
+  # scheduling workflows at the expense of increased total DB traffic
+  # because model objects are expunged from the SQL alchemy session
+  # between workflow invocation scheduling iterations. Set to -1 to
+  # disable any such maximum.
+  #maximum_workflow_jobs_per_scheduling_iteration: 1000
+
+  # Maximum number of datasets to create before flushing created
+  # datasets to database. This affects tools that create many output
+  # datasets. Higher values will lead to fewer database flushes and
+  # faster execution, but require more memory. Set to -1 to disable
+  # creating datasets in batches.
+  #flush_per_n_datasets: 1000
+
+  # Set this to a positive integer value to limit the number of datasets
+  # that can be discovered by a single job. This prevents accidentally
+  # creating large numbers of datasets when running tools that create a
+  # potentially unlimited number of output datasets, such as tools that
+  # split a file into a collection of datasets for each line in an input
+  # dataset.
+  #max_discovered_files: 10000
+
+  # Force serial scheduling of workflows within the context of a
+  # particular history
+  #history_local_serial_workflow_scheduling: false
+
+  # Enables and disables OpenID Connect (OIDC) support.
+  #enable_oidc: false
+
+  # Sets the path to OIDC configuration file.
+  # The value of this option will be resolved with respect to
+  # <config_dir>.
+  #oidc_config_file: oidc_config.xml
+
+  # Sets the path to OIDC backends configuration file.
+  # The value of this option will be resolved with respect to
+  # <config_dir>.
+  #oidc_backends_config_file: oidc_backends_config.xml
+
+  # XML config file that allows the use of different authentication
+  # providers (e.g. LDAP) instead or in addition to local authentication
+  # (.sample is used if default does not exist).
+  # The value of this option will be resolved with respect to
+  # <config_dir>.
+  #auth_config_file: auth_conf.xml
+
+  # Optional list of email addresses of API users who can make calls on
+  # behalf of other users.
+  #api_allow_run_as: null
+
+  # API key that allows performing some admin actions without actually
+  # having a real admin user in the database and config. Only set this
+  # if you need to bootstrap Galaxy, in particular to create a real
+  # admin user account via API. You should probably not set this on a
+  # production server.
+  #master_api_key: changethis
+
+  # Enable tool tags (associating tools with tags).  This has its own
+  # option since its implementation has a few performance implications
+  # on startup for large servers.
+  #enable_tool_tags: false
+
+  # Enable a feature when running workflows.  When enabled, default
+  # datasets are selected for "Set at Runtime" inputs from the history
+  # such that the same input will not be selected twice, unless there
+  # are more inputs than compatible datasets in the history. When false,
+  # the most recently added compatible item in the history will be used
+  # for each "Set at Runtime" input, independent of others in the
+  # workflow.
+  #enable_unique_workflow_defaults: false
+
+  # If set to 'off' by default, always use the traditional workflow form
+  # that renders all steps in the GUI and serializes the tool state of
+  # all steps during invocation. Set to 'prefer' to default to a
+  # simplified workflow UI that only renders the inputs if possible (the
+  # workflow must have no disconnected runtime inputs and not
+  # replacement parameters within tool steps). In the future 'force' may
+  # be added an option for Galaskio-style servers that should only
+  # render simplified workflows.
+  #simplified_workflow_run_ui: prefer
+
+  # When the simplified workflow run form is rendered, should the
+  # invocation outputs be sent to the 'current' history or a 'new'
+  # history. If the user should be presented and option between these -
+  # set this to 'prefer_current' or 'prefer_new' to display a runtime
+  # setting with the corresponding default. The default is to provide
+  # the user this option and default it to the current history (the
+  # traditional behavior of Galaxy for years) - this corresponds to the
+  # setting 'prefer_current'.
+  #simplified_workflow_run_ui_target_history: prefer_current
+
+  # When the simplified workflow run form is rendered, should the
+  # invocation use job caching. This isn't a boolean so an option for
+  # 'show-selection' can be added later.
+  #simplified_workflow_run_ui_job_cache: 'off'
+
+  # The URL to the myExperiment instance being used (omit scheme but
+  # include port).
+  #myexperiment_target_url: www.myexperiment.org:80
+
+  # Enable Galaxy's "Upload via FTP" interface.  You'll need to install
+  # and configure an FTP server (we've used ProFTPd since it can use
+  # Galaxy's database for authentication) and set the following two
+  # options. This will be provided to users in the help text as 'log in
+  # to the FTP server at '. Thus, it should be the hostname of your FTP
+  # server.
+  #ftp_upload_site: null
+
+  # This should point to a directory containing subdirectories matching
+  # users' identifier (defaults to e-mail), where Galaxy will look for
+  # files.
+  #ftp_upload_dir: null
+
+  # User attribute to use as subdirectory in calculating default
+  # ftp_upload_dir pattern. By default this will be email so a user's
+  # FTP upload directory will be ${ftp_upload_dir}/${user.email}. Can
+  # set this to other attributes such as id or username though.
+  #ftp_upload_dir_identifier: email
+
+  # Python string template used to determine an FTP upload directory for
+  # a particular user.
+  # Defaults to '${ftp_upload_dir}/${ftp_upload_dir_identifier}'.
+  #ftp_upload_dir_template: null
+
+  # Set to false to prevent Galaxy from deleting uploaded FTP files as
+  # it imports them.
+  #ftp_upload_purge: true
+
+  # Enable enforcement of quotas.  Quotas can be set from the Admin
+  # interface.
+  enable_quotas: true
+
+  # This option allows users to see the full path of datasets via the
+  # "View Details" option in the history. This option also exposes the
+  # command line to non-administrative users. Administrators can always
+  # see dataset paths.
+  #expose_dataset_path: false
+
+  # This option allows users to view the tool wrapper source code. This
+  # is safe to enable if you have not hardcoded any secrets in any of
+  # the tool wrappers installed on this Galaxy server. If you have only
+  # installed tool wrappers from  public tool sheds and tools shipped
+  # with Galaxy there you can enable this option.
+  #enable_tool_source_display: false
+
+  # XML config file that contains the job metric collection
+  # configuration.
+  # The value of this option will be resolved with respect to
+  # <config_dir>.
+  #job_metrics_config_file: job_metrics_conf.xml
+
+  # This option allows users to see the job metrics (except for
+  # environment variables).
+  #expose_potentially_sensitive_job_metrics: false
+
+  # Enable the API for sample tracking
+  #enable_legacy_sample_tracking_api: false
+
+  # Allow non-admin users to view available Data Manager options.
+  #enable_data_manager_user_view: false
+
+  # File where Data Managers are configured (.sample used if default
+  # does not exist).
+  # The value of this option will be resolved with respect to
+  # <config_dir>.
+  #data_manager_config_file: data_manager_conf.xml
+
+  # File where Tool Shed based Data Managers are configured. This file
+  # will be created automatically upon data manager installation.
+  # The value of this option will be resolved with respect to
+  # <managed_config_dir>.
+  #shed_data_manager_config_file: shed_data_manager_conf.xml
+
+  # Directory to store Data Manager based tool-data. Defaults to the
+  # value of the <tool_data_path> option.
+  galaxy_data_manager_data_path: {{ galaxy_data_manager_data_path }}
+
+  # To increase performance of job execution and the web interface, you
+  # can separate Galaxy into multiple processes.  There are more than
+  # one way to do this, and they are explained in detail in the
+  # documentation:
+  # https://docs.galaxyproject.org/en/master/admin/scaling.html
+  # By default, Galaxy manages and executes jobs from within a single
+  # process and notifies itself of new jobs via in-memory queues.  Jobs
+  # are run locally on the system on which Galaxy is started.  Advanced
+  # job running capabilities can be configured through the job
+  # configuration file.
+  # The value of this option will be resolved with respect to
+  # <config_dir>.
+  #job_config_file: job_conf.xml
+
+  # Description of job running configuration, can be embedded into
+  # Galaxy configuration or loaded from an additional file with the
+  # job_config_file option.
+  #job_config: null
+
+  # Rather than specifying a dependency_resolvers_config_file, the
+  # definition of the resolvers to enable can be embedded into Galaxy's
+  # config with this option. This has no effect if a
+  # dependency_resolvers_config_file is used.
+  # The syntax, available resolvers, and documentation of their options
+  # is explained in detail in the documentation:
+  # https://docs.galaxyproject.org/en/master/admin/dependency_resolvers.html
+  #dependency_resolvers: null
+
+  # Alternative representation of various dependency resolution
+  # parameters. Takes the dictified version of a DependencyManager
+  # object - so this is ideal for automating the configuration of
+  # dependency resolution from one application that uses a
+  # DependencyManager to another.
+  #dependency_resolution: null
+
+  # When jobs fail due to job runner problems, Galaxy can be configured
+  # to retry these or reroute the jobs to new destinations. Very fine
+  # control of this is available with resubmit declarations in
+  # job_conf.xml. For simple deployments of Galaxy though, the following
+  # attribute can define resubmission conditions for all job
+  # destinations. If any job destination defines even one resubmission
+  # condition explicitly in job_conf.xml - the condition described by
+  # this option will not apply to that destination. For instance, the
+  # condition: 'attempt < 3 and unknown_error and (time_running < 300 or
+  # time_since_queued < 300)' would retry up to two times jobs that
+  # didn't fail due to detected memory or walltime limits but did fail
+  # quickly (either while queueing or running). The commented out
+  # default below results in no default job resubmission condition,
+  # failing jobs are just failed outright.
+  #default_job_resubmission_condition: null
+
+  # This option is deprecated, use the `mem-self` handler assignment
+  # option in the job configuration instead.
+  #track_jobs_in_database: true
+
+  # This enables splitting of jobs into tasks, if specified by the
+  # particular tool config. This is a new feature and not recommended
+  # for production servers yet.
+  #use_tasked_jobs: false
+
+  # This enables splitting of jobs into tasks, if specified by the
+  # particular tool config. This is a new feature and not recommended
+  # for production servers yet.
+  #local_task_queue_workers: 2
+
+  # Each Galaxy job handler process runs one thread responsible for
+  # discovering jobs and dispatching them to runners. This thread
+  # operates in a loop and sleeps for the given number of seconds at the
+  # end of each iteration. This can be decreased if extremely high job
+  # throughput is necessary, but doing so can increase CPU usage of
+  # handler processes. Float values are allowed.
+  #job_handler_monitor_sleep: 1.0
+
+  # Each Galaxy job handler process runs one thread per job runner
+  # plugin responsible for checking the state of queued and running
+  # jobs.  This thread operates in a loop and sleeps for the given
+  # number of seconds at the end of each iteration. This can be
+  # decreased if extremely high job throughput is necessary, but doing
+  # so can increase CPU usage of handler processes. Float values are
+  # allowed.
+  #job_runner_monitor_sleep: 1.0
+
+  # Each Galaxy workflow handler process runs one thread responsible for
+  # checking the state of active workflow invocations.  This thread
+  # operates in a loop and sleeps for the given number of seconds at the
+  # end of each iteration. This can be decreased if extremely high job
+  # throughput is necessary, but doing so can increase CPU usage of
+  # handler processes. Float values are allowed.
+  #workflow_monitor_sleep: 1.0
+
+  # Determines how metadata will be set. Valid values are `directory`,
+  # `extended`, `directory_celery` and `extended_celery`. In extended
+  # mode jobs will decide if a tool run failed, the object stores
+  # configuration is serialized and made available to the job and is
+  # used for writing output datasets to the object store as part of the
+  # job and dynamic output discovery (e.g. discovered datasets
+  # <discover_datasets>, unpopulated collections, etc) happens as part
+  # of the job. In `directory_celery` and `extended_celery` metadata
+  # will be set within a celery task.
+  #metadata_strategy: directory
+
+  # Although it is fairly reliable, setting metadata can occasionally
+  # fail.  In these instances, you can choose to retry setting it
+  # internally or leave it in a failed state (since retrying internally
+  # may cause the Galaxy process to be unresponsive).  If this option is
+  # set to false, the user will be given the option to retry externally,
+  # or set metadata manually (when possible).
+  #retry_metadata_internally: true
+
+  # Very large metadata values can cause Galaxy crashes.  This will
+  # allow limiting the maximum metadata key size (in bytes used in
+  # memory, not the end result database value size) Galaxy will attempt
+  # to save with a dataset.  Use 0 to disable this feature.  The default
+  # is 5MB, but as low as 1MB seems to be a reasonable size.
+  #max_metadata_value_size: 5242880
+
+  # This option will override tool output paths to write outputs to the
+  # job working directory (instead of to the file_path) and the job
+  # manager will move the outputs to their proper place in the dataset
+  # directory on the Galaxy server after the job completes. This is
+  # necessary (for example) if jobs run on a cluster and datasets can
+  # not be created by the user running the jobs (e.g. if the filesystem
+  # is mounted read-only or the jobs are run by a different user than
+  # the galaxy user).
+  #outputs_to_working_directory: false
+
+  # If your network filesystem's caching prevents the Galaxy server from
+  # seeing the job's stdout and stderr files when it completes, you can
+  # retry reading these files.  The job runner will retry the number of
+  # times specified below, waiting 1 second between tries.  For NFS, you
+  # may want to try the -noac mount option (Linux) or -actimeo=0
+  # (Solaris).
+  #retry_job_output_collection: 0
+
+  # Determines which process will evaluate the tool command line. If set
+  # to "local" the tool command line, configuration files and other
+  # dynamic values will be templated in the job handler process. If set
+  # to ``remote`` the tool command line will be built as part of the
+  # submitted job. Note that ``remote`` is a beta setting that will be
+  # useful for materializing deferred datasets as part of the submitted
+  # job. Note also that you have to set ``metadata_strategy`` to
+  # ``extended`` if you set this option to ``remote``.
+  #tool_evaluation_strategy: local
+
+  # In the past Galaxy would preserve its Python environment when
+  # running jobs ( and still does for internal tools packaged with
+  # Galaxy). This behavior exposes Galaxy internals to tools and could
+  # result in problems when activating Python environments for tools
+  # (such as with Conda packaging). The default legacy_only will
+  # restrict this behavior to tools identified by the Galaxy team as
+  # requiring this environment. Set this to "always" to restore the
+  # previous behavior (and potentially break Conda dependency resolution
+  # for many tools). Set this to legacy_and_local to preserve the
+  # environment for legacy tools and locally managed tools (this might
+  # be useful for instance if you are installing software into Galaxy's
+  # virtualenv for tool development).
+  preserve_python_environment: {{ galaxy_preserve_python_env }}
+
+  # Clean up various bits of jobs left on the filesystem after
+  # completion.  These bits include the job working directory, external
+  # metadata temporary files, and DRM stdout and stderr files (if using
+  # a DRM).  Possible values are: always, onsuccess, never
+  cleanup_job: {{ galaxy_cleanup_job }}
+
+  # When running DRMAA jobs as the Galaxy user
+  # (https://docs.galaxyproject.org/en/master/admin/cluster.html#submitting-jobs-as-the-real-user)
+  # this script is used to run the job script Galaxy generates for a
+  # tool execution.
+  # Example value 'sudo -E scripts/drmaa_external_runner.py
+  # --assign_all_groups'
+  #drmaa_external_runjob_script: null
+
+  # When running DRMAA jobs as the Galaxy user
+  # (https://docs.galaxyproject.org/en/master/admin/cluster.html#submitting-jobs-as-the-real-user)
+  # this script is used to kill such jobs by Galaxy (e.g. if the user
+  # cancels the job).
+  # Example value 'sudo -E scripts/drmaa_external_killer.py'
+  #drmaa_external_killjob_script: null
+
+  # When running DRMAA jobs as the Galaxy user
+  # (https://docs.galaxyproject.org/en/master/admin/cluster.html#submitting-jobs-as-the-real-user)
+  # this script is used transfer permissions back and forth between the
+  # Galaxy user and the user that is running the job.
+  # Example value 'sudo -E scripts/external_chown_script.py'
+  #external_chown_script: null
+
+  # When running DRMAA jobs as the Galaxy user
+  # (https://docs.galaxyproject.org/en/master/admin/cluster.html#submitting-jobs-as-the-real-user)
+  # Galaxy can extract the user name from the email address (actually
+  # the local-part before the @) or the username which are both stored
+  # in the Galaxy data base. The latter option is particularly useful
+  # for installations that get the authentication from LDAP. Also,
+  # Galaxy can accept the name of a common system user (eg.
+  # galaxy_worker) who can run every job being submitted. This user
+  # should not be the same user running the galaxy system. Possible
+  # values are user_email (default), username or <common_system_user>
+  #real_system_username: user_email
+
+  # File to source to set up the environment when running jobs.  By
+  # default, the environment in which the Galaxy server starts is used
+  # when running jobs locally, and the environment set up per the DRM's
+  # submission method and policy is used when running jobs on a cluster
+  # (try testing with `qsub` on the command line).
+  # environment_setup_file can be set to the path of a file on the
+  # cluster that should be sourced by the user to set up the environment
+  # prior to running tools.  This can be especially useful for running
+  # jobs as the actual user, to remove the need to configure each user's
+  # environment individually.
+{% if galaxy_environment_setup_file|default(None) != None %}
+  environment_setup_file: {{ galaxy_dir }}/environment_setup.sh
+{% else %}
+  #environment_setup_file: null
+{% endif %}
+
+  # Enable export of Galaxy Markdown documents (pages and workflow
+  # reports) to PDF. Requires manual installation and setup of
+  # weasyprint (latest version available for Python 2.7 is 0.42).
+  #enable_beta_markdown_export: false
+
+  # CSS file to apply to all Markdown exports to PDF - currently used by
+  # WeasyPrint during rendering an HTML export of the document to PDF.
+  # The value of this option will be resolved with respect to
+  # <config_dir>.
+  #markdown_export_css: markdown_export.css
+
+  # CSS file to apply to "Galaxy Page" exports to PDF. Generally prefer
+  # markdown_export_css, but this is here for deployments that would
+  # like to tailor different kinds of exports.
+  # The value of this option will be resolved with respect to
+  # <config_dir>.
+  #markdown_export_css_pages: markdown_export_pages.css
+
+  # CSS file to apply to invocation report exports to PDF. Generally
+  # prefer markdown_export_css, but this is here for deployments that
+  # would like to tailor different kinds of exports.
+  # The value of this option will be resolved with respect to
+  # <config_dir>.
+  #markdown_export_css_invocation_reports: markdown_export_invocation_reports.css
+
+  # Prologue Markdown/HTML to apply to markdown exports to PDF. Allowing
+  # branded headers.
+  #markdown_export_prologue: ''
+
+  # Prologue Markdown/HTML to apply to markdown exports to PDF. Allowing
+  # branded footers.
+  #markdown_export_epilogue: ''
+
+  # Alternative to markdown_export_prologue that applies just to page
+  # exports.
+  #markdown_export_prologue_pages: ''
+
+  # Alternative to markdown_export_prologue that applies just to
+  # invocation report exports.
+  #markdown_export_prologue_invocation_reports: ''
+
+  # Alternative to markdown_export_epilogue that applies just to page
+  # exports.
+  #markdown_export_epilogue_pages: ''
+
+  # Alternative to markdown_export_epilogue that applies just to
+  # invocation report exports.
+  #markdown_export_epilogue_invocation_reports: ''
+
+  # Optional file containing job resource data entry fields definition.
+  # These fields will be presented to users in the tool forms and allow
+  # them to overwrite default job resources such as number of
+  # processors, memory and walltime.
+  # The value of this option will be resolved with respect to
+  # <config_dir>.
+  #job_resource_params_file: job_resource_params_conf.xml
+
+  # Similar to the above parameter, workflows can describe parameters
+  # used to influence scheduling of jobs within the workflow. This
+  # requires both a description of the fields available (which defaults
+  # to the definitions in job_resource_params_file if not set).
+  # The value of this option will be resolved with respect to
+  # <config_dir>.
+  #workflow_resource_params_file: workflow_resource_params_conf.xml
+
+  # This parameter describes how to map users and workflows to a set of
+  # workflow resource parameter to present (typically input IDs from
+  # workflow_resource_params_file). If this this is a function reference
+  # it will be passed various inputs (workflow model object and user)
+  # and it should produce a list of input IDs. If it is a path it is
+  # expected to be an XML or YAML file describing how to map group names
+  # to parameter descriptions (additional types of mappings via these
+  # files could be implemented but haven't yet - for instance using
+  # workflow tags to do the mapping).
+  # Sample default path
+  # 'config/workflow_resource_mapper_conf.yml.sample'
+  #workflow_resource_params_mapper: null
+
+  # Optional configuration file similar to `job_config_file` to specify
+  # which Galaxy processes should schedule workflows.
+  # The value of this option will be resolved with respect to
+  # <config_dir>.
+  #workflow_schedulers_config_file: workflow_schedulers_conf.xml
+
+  # If using job concurrency limits (configured in job_config_file),
+  # several extra database queries must be performed to determine the
+  # number of jobs a user has dispatched to a given destination.  By
+  # default, these queries will happen for every job that is waiting to
+  # run, but if cache_user_job_count is set to true, it will only happen
+  # once per iteration of the handler queue. Although better for
+  # performance due to reduced queries, the trade-off is a greater
+  # possibility that jobs will be dispatched past the configured limits
+  # if running many handlers.
+  #cache_user_job_count: false
+
+  # Define toolbox filters
+  # (https://galaxyproject.org/user-defined-toolbox-filters/) that
+  # admins may use to restrict the tools to display.
+  #tool_filters: null
+
+  # Define toolbox filters
+  # (https://galaxyproject.org/user-defined-toolbox-filters/) that
+  # admins may use to restrict the tool labels to display.
+  #tool_label_filters: null
+
+  # Define toolbox filters
+  # (https://galaxyproject.org/user-defined-toolbox-filters/) that
+  # admins may use to restrict the tool sections to display.
+  #tool_section_filters: null
+
+  # Define toolbox filters
+  # (https://galaxyproject.org/user-defined-toolbox-filters/) that users
+  # may use to restrict the tools to display.
+  #user_tool_filters: examples:restrict_upload_to_admins, examples:restrict_encode
+
+  # Define toolbox filters
+  # (https://galaxyproject.org/user-defined-toolbox-filters/) that users
+  # may use to restrict the tool sections to display.
+  #user_tool_section_filters: examples:restrict_text
+
+  # Define toolbox filters
+  # (https://galaxyproject.org/user-defined-toolbox-filters/) that users
+  # may use to restrict the tool labels to display.
+  #user_tool_label_filters: examples:restrict_upload_to_admins, examples:restrict_encode
+
+  # The base module(s) that are searched for modules for toolbox
+  # filtering (https://galaxyproject.org/user-defined-toolbox-filters/)
+  # functions.
+  #toolbox_filter_base_modules: galaxy.tools.filters,galaxy.tools.toolbox.filters,galaxy.tool_util.toolbox.filters
+
+  # Galaxy uses AMQP internally for communicating between processes.
+  # For example, when reloading the toolbox or locking job execution,
+  # the process that handled that particular request will tell all
+  # others to also reload, lock jobs, etc. For connection examples, see
+  # https://docs.celeryq.dev/projects/kombu/en/stable/userguide/connections.ht
+ml
+  # Without specifying anything here, galaxy will first attempt to use
+  # your specified database_connection above.  If that's not specified
+  # either, Galaxy will automatically create and use a separate sqlite
+  # database located in your <galaxy>/database folder (indicated in the
+  # commented out line below).
+  #amqp_internal_connection: sqlalchemy+sqlite:///./database/control.sqlite?isolation_level=IMMEDIATE
+
+  # Offload long-running tasks to a Celery task queue. Activate this
+  # only if you have setup a Celery worker for Galaxy. For details, see
+  # https://docs.galaxyproject.org/en/master/admin/production.html
+  #enable_celery_tasks: false
+
+  # Celery broker (if unset falls back to amqp_internal_connection).
+  #celery_broker: null
+
+  # Allow disabling pbkdf2 hashing of passwords for legacy situations.
+  # This should normally be left enabled unless there is a specific
+  # reason to disable it.
+  #use_pbkdf2: true
+
+  # Tell Galaxy that multiple domains sharing the same root are
+  # associated to this instance and wants to share the same session
+  # cookie. This allow a user to stay logged in when passing from one
+  # subdomain to the other. This root domain will be written in the
+  # unique session cookie shared by all subdomains.
+  #cookie_domain: null
+
+  # Due to performance considerations (select2 fields are pretty
+  # 'expensive' in terms of memory usage) Galaxy uses the regular select
+  # fields for non-dataset selectors in the workflow run form. use 0 in
+  # order to always use select2 fields, use -1 (default) in order to
+  # always use the regular select fields, use any other positive number
+  # as threshold (above threshold: regular select fields will be used)
+  #select_type_workflow_threshold: -1
+
+  # Allow the display of tool recommendations in workflow editor and
+  # after tool execution. If it is enabled and set to true, please
+  # enable 'tool_recommendation_model_path' as well
+  #enable_tool_recommendations: false
+
+  # Set remote path of the trained model (HDF5 file) for tool
+  # recommendation.
+  #tool_recommendation_model_path: https://github.com/galaxyproject/galaxy-test-data/raw/master/tool_recommendation_model.hdf5
+
+  # Set the number of predictions/recommendations to be made by the
+  # model
+  #topk_recommendations: 10
+
+  # Set path to the additional tool preferences from Galaxy admins. It
+  # has two blocks. One for listing deprecated tools which will be
+  # removed from the recommendations and another is for adding
+  # additional tools to be recommended along side those from the deep
+  # learning model.
+  # The value of this option will be resolved with respect to
+  # <config_dir>.
+  #admin_tool_recommendations_path: tool_recommendations_overwrite.yml
+
+  # Overwrite or append to the tool recommendations by the deep learning
+  # model. When set to true, all the recommendations by the deep
+  # learning model are overwritten by the recommendations set by an
+  # admin in a config file 'tool_recommendations_overwrite.yml'. When
+  # set to false, the recommended tools by admins and predicted by the
+  # deep learning model are shown.
+  #overwrite_model_recommendations: false
+
+  # Path to error reports configuration file.
+  # The value of this option will be resolved with respect to
+  # <config_dir>.
+  #error_report_file: error_report.yml
+
+  # Path to dynamic tool destinations configuration file.
+  # The value of this option will be resolved with respect to
+  # <config_dir>.
+  #tool_destinations_config_file: tool_destinations.yml
+
+  # Location of New User Welcome data, a single directory containing the
+  # images and JSON of Topics/Subtopics/Slides as export. This location
+  # is relative to galaxy/static
+  #welcome_directory: plugins/welcome_page/new_user/static/topics/
+
+  # Vault config file.
+  # The value of this option will be resolved with respect to
+  # <config_dir>.
+  #vault_config_file: vault_conf.yml
+
+  # Display built-in converters in the tool panel.
+  #display_builtin_converters: true
+

--- a/roles/galaxy/templates/galaxy-config-release_22.05.yml.j2
+++ b/roles/galaxy/templates/galaxy-config-release_22.05.yml.j2
@@ -2443,8 +2443,7 @@ galaxy:
   # For example, when reloading the toolbox or locking job execution,
   # the process that handled that particular request will tell all
   # others to also reload, lock jobs, etc. For connection examples, see
-  # https://docs.celeryq.dev/projects/kombu/en/stable/userguide/connections.ht
-ml
+  # https://docs.celeryq.dev/projects/kombu/en/stable/userguide/connections.html
   # Without specifying anything here, galaxy will first attempt to use
   # your specified database_connection above.  If that's not specified
   # either, Galaxy will automatically create and use a separate sqlite

--- a/roles/galaxy/templates/galaxy-config-release_22.05.yml.j2
+++ b/roles/galaxy/templates/galaxy-config-release_22.05.yml.j2
@@ -329,7 +329,7 @@ galaxy:
   # files.
   # The value of this option will be resolved with respect to
   # <config_dir>.
-  tool_config_file: 'config/tool_conf.xml,config/shed_tool_conf.xml,config/local_tool_conf.xml'
+  tool_config_file: 'tool_conf.xml,shed_tool_conf.xml,local_tool_conf.xml'
 
   # Tool config file for tools installed from the Galaxy Tool Shed. Must
   # be writable by Galaxy and generally should not be edited by hand. In


### PR DESCRIPTION
Updates to the templates used for deploying Galaxy 22.05:

* `galaxy` role: update `galaxy-config-release_22.05.yml.j2`