### PR TITLE
Switch to using Miniforge to install 'conda'

### DIFF
--- a/roles/galaxy/tasks/galaxy.yml
+++ b/roles/galaxy/tasks/galaxy.yml
@@ -175,19 +175,6 @@
         "{{ galaxy_tool_dependency_dir }}/_conda/bin/conda update -y --all"
   when: galaxy_conda.stat.exists == True and galaxy_reinstall_conda == True
 
-- name: "Use mamba to resolve conda dependencies"
-  block:
-    - name: "Check if mamba is already installed"
-      stat:
-        path: '{{ galaxy_tool_dependency_dir }}/_conda/bin/mamba'
-      register: mamba
-
-    - name: "Install mamba into conda base environment"
-      shell:
-        "{{ galaxy_tool_dependency_dir }}/_conda/bin/conda install -y mamba -n base -c conda-forge"
-      when: mamba.stat.exists == False
-  when: galaxy_conda_use_mamba == True
-
 - name: "Add environment setup file"
   copy:
     dest='{{ galaxy_dir }}/environment_setup.sh'

--- a/roles/galaxy/tasks/galaxy.yml
+++ b/roles/galaxy/tasks/galaxy.yml
@@ -141,22 +141,22 @@
         state: absent
   when: galaxy_conda.stat.exists == True and galaxy_reinstall_conda == True
 
-- name: "Install conda"
+- name: "Install conda via Miniforge3"
   block:
-    # See https://docs.conda.io/en/latest/miniconda.html#linux-installers
-    - name: "Fetch Miniconda installer"
+    # See https://github.com/conda-forge/miniforge
+    - name: "Fetch Miniforge installer"
       get_url:
-        url: 'https://repo.anaconda.com/miniconda/Miniconda3-py37_4.12.0-Linux-x86_64.sh'
-        dest: '{{ galaxy_tool_dependency_dir }}/miniconda.sh'
+        url: "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-x86_64.sh"
+        dest: "{{ galaxy_tool_dependency_dir }}/Miniforge3.sh"
         force: true
 
-    - name: "Install conda using Miniconda"
+    - name: "Install Miniforge conda"
       command:
-        "bash {{ galaxy_tool_dependency_dir }}/miniconda.sh -b -p {{ galaxy_tool_dependency_dir }}/_conda"
+        "bash {{ galaxy_tool_dependency_dir }}/Miniforge3.sh -b -p {{ galaxy_tool_dependency_dir }}/_conda"
 
-    - name: "Remove Miniconda installer"
+    - name: "Remove Miniforge installer"
       file:
-        path: '{{ galaxy_tool_dependency_dir }}/miniconda.sh'
+        path: '{{ galaxy_tool_dependency_dir }}/Miniforge3.sh'
         state: absent
   when: galaxy_conda.stat.exists == False or galaxy_reinstall_conda == True
 

--- a/roles/galaxy/templates/galaxy-config-release_22.05.yml.j2
+++ b/roles/galaxy/templates/galaxy-config-release_22.05.yml.j2
@@ -404,7 +404,7 @@ galaxy:
 
   # conda channels to enable by default
   # (https://conda.io/docs/user-guide/tasks/manage-channels.html)
-  #conda_ensure_channels: conda-forge,bioconda,defaults
+  conda_ensure_channels: conda-forge,bioconda
 
   # Use locally-built conda packages.
   #conda_use_local: false


### PR DESCRIPTION
Updates the `galaxy` role to (re)install `conda` using Miniforge3 (https://github.com/conda-forge/miniforge) instead of Miniconda.

Also updates the Galaxy configuration template to explicitly remove the `defaults` channel when installing conda depenedencies.

Closes #278.