### PR TITLE
'galaxy' role: remove uWSGI settings from the NGINX config template

### DIFF
--- a/roles/galaxy/templates/nginx-galaxy.conf.j2
+++ b/roles/galaxy/templates/nginx-galaxy.conf.j2
@@ -31,11 +31,6 @@ server {
 {% endif %}
     client_body_temp_path {{ nginx_client_body_temp_path }};
     client_max_body_size {{ nginx_client_max_body_size }};
-    # UWSGI settings
-    uwsgi_temp_path /tmp/uwsgi;
-    uwsgi_max_temp_file_size 1024k;
-    uwsgi_read_timeout 600s;
-    uwsgi_send_timeout 600s;
     # Additional locations (may be none)
 {% if galaxy_nginx_extra_locations is not none %}
     {% for loc in galaxy_nginx_extra_locations %}


### PR DESCRIPTION
Removes the redundant uWSGI settings from the nginx configuration template in the `galaxy` role (no longer needed as gunicorn is now used to serve Galaxy).