### PR TITLE
'export-galaxy-for-cluster' role: update the 'CentOS-Base.repo' file

### DIFF
--- a/roles/export-galaxy-for-cluster/tasks/main.yml
+++ b/roles/export-galaxy-for-cluster/tasks/main.yml
@@ -1,6 +1,8 @@
 # Install Galaxy
 ---
 
+- include: update_centos_base_repo.yml
+
 - include: dependencies.yml
 
 - include: galaxy_user.yml

--- a/roles/export-galaxy-for-cluster/tasks/update_centos_base_repo.yml
+++ b/roles/export-galaxy-for-cluster/tasks/update_centos_base_repo.yml
@@ -1,0 +1,21 @@
+---
+- name: "Update mirrorlist in /etc/yum.repos.d/CentOS-Base.repo"
+  replace:
+    path: /etc/yum.repos.d/CentOS-Base.repo
+    regexp: '(.*)=http://mirrorlist\.centos\.org(.*)$'
+    replace: '\1=http://vault.centos.org\2'
+    backup: true
+
+- name: "Update mirror in /etc/yum.repos.d/CentOS-Base.repo"
+  replace:
+    path: /etc/yum.repos.d/CentOS-Base.repo
+    regexp: '(.*)=http://mirror\.centos\.org(.*)$'
+    replace: '\1=http://vault.centos.org\2'
+    backup: true
+
+- name: "Uncomment baseurl in /etc/yum.repos.d/CentOS-Base.repo"
+  replace:
+    path: /etc/yum.repos.d/CentOS-Base.repo
+    regexp: '#baseurl=(.*)$'
+    replace: 'baseurl=\1'
+    backup: true


### PR DESCRIPTION
Updates the `export-galaxy-for-cluster` role to fix the `/etc/yum.repos.d/CentOS-Base.repo` file, specifically:

* Replace occurances of `http://mirrorlist.centos.org` and `http://mirror.centos.org` with `http://vault.centos.org`, and
* Uncomment `baseurl=...` lines

The changes are required to fix a bug whereby the role fails with the message:

    Failure talking to yum: Cannot find a valid baseurl for repo: base/7/x86_64

when attempting to update the dependencies. The fix was suggested by the post at https://www.tecmint.com/fix-cannot-find-a-valid-baseurl-for-repo/