### PR TITLE
Update JSE Drop Galaxy virtual env paths for Centaurus and Palfinder for 22.05

### DIFF
--- a/inventories/centaurus/devel.yml
+++ b/inventories/centaurus/devel.yml
@@ -9,7 +9,7 @@ centaurus-dev:
     # Local JSE-Drop service
     enable_local_jse_drop: no
     # Cluster needs to use its own virtual env
-    galaxy_jse_drop_virtual_env: "/mnt/rvmi/centaurus/galaxy/shared/csf/galaxy/21.05/venv_py3.8"
+    galaxy_jse_drop_virtual_env: "/mnt/rvmi/centaurus/galaxy/shared/csf/galaxy/22.05/venv_py3.8"
     # Environment setup file
     galaxy_environment_setup_file: "instances/centaurus/files/centaurus_environment_setup-devel.sh"
     # Postfix/email configuration

--- a/inventories/centaurus/production.yml
+++ b/inventories/centaurus/production.yml
@@ -9,7 +9,7 @@ centaurus:
     # Local JSE-Drop service
     enable_local_jse_drop: no
     # Cluster needs to use its own virtual env
-    galaxy_jse_drop_virtual_env: "/mnt/rvmi/centaurus/galaxy/shared/csf/galaxy/21.05/venv_py3.8"
+    galaxy_jse_drop_virtual_env: "/mnt/rvmi/centaurus/galaxy/shared/csf/galaxy/22.05/venv_py3.8"
     # Environment setup file
     galaxy_environment_setup_file: "instances/centaurus/files/centaurus_environment_setup-production.sh"
     # Postfix/email configuration

--- a/inventories/palfinder/production.yml
+++ b/inventories/palfinder/production.yml
@@ -30,7 +30,7 @@ palfinder:
       - id: "trimmomatic"
         destination: "jse_drop_8_cores"
     # Cluster needs to use its own virtual env
-    galaxy_jse_drop_virtual_env: "/mnt/rvmi/palfinder/galaxy/shared/csf/galaxy/20.09/venv_py3.8"
+    galaxy_jse_drop_virtual_env: "/mnt/rvmi/palfinder/galaxy/shared/csf/galaxy/22.05/venv_py3.8"
     # Postfix/email configuration
     enable_smtp: yes
     # SSL configuration

--- a/inventories/palfinder/test.yml
+++ b/inventories/palfinder/test.yml
@@ -33,7 +33,7 @@ palfinder:
       - id: "trimmomatic"
         destination: "jse_drop_8_cores"
     # Cluster needs to use its own virtual env
-    galaxy_jse_drop_virtual_env: "/mnt/rvmi/palfinder/galaxy/shared/csf/galaxy/20.09/venv_py3.8"
+    galaxy_jse_drop_virtual_env: "/mnt/rvmi/palfinder/galaxy/shared/csf/galaxy/22.05/venv_py3.8"
     # Postfix/email configuration
     enable_smtp: yes
     # SSL configuration


### PR DESCRIPTION
Updates the configurations for the Centaurus, Centaurus-dev and Palfinder Galaxy instances to set the appropriate Galaxy virtual environment locations to be used by JSE-Drop for Galaxy 22.05.