### PR TITLE
'galaxy' role: fix broken task for stopping Galaxy using supervisorctl

### DIFF
--- a/roles/galaxy/tasks/halt_galaxy.yml
+++ b/roles/galaxy/tasks/halt_galaxy.yml
@@ -21,7 +21,7 @@
 
 - name: "Halt running Galaxy using Supervisord"
   command:
-    "/usr/local/bin/supervisorct stop {{ galaxy_name }}:"
+    "/usr/local/bin/supervisorctl stop {{ galaxy_name }}:"
   when:
     - galaxy_service.stat.exists == False
     - supervisor_ini.stat.exists == True


### PR DESCRIPTION
Fix to the `galaxy` role when attempting to use `supervisorctl` command to stop a legacy version of Galaxy running.