### PR TITLE
Fix Galaxy URL in job completion emails

### DIFF
--- a/roles/galaxy/templates/galaxy-config-release_22.05.yml.j2
+++ b/roles/galaxy/templates/galaxy-config-release_22.05.yml.j2
@@ -1152,7 +1152,13 @@ galaxy:
   # If you plan to run Interactive Tools make sure the docker container
   # can reach this URL. For more details see
   # `job_conf.xml.interactivetools`.
-  #galaxy_infrastructure_url: http://localhost:8080
+  # NB This is also used as the URL for the Galaxy instance in completed
+  # job emails
+{% if enable_https %}
+  galaxy_infrastructure_url: https://{{ galaxy_server_name }}
+{% else %}
+  galaxy_infrastructure_url: http://{{ galaxy_server_name }}
+{% endif %}
 
   # If the above URL cannot be determined ahead of time in dynamic
   # environments but the port which should be used to access Galaxy can


### PR DESCRIPTION
Fixes the Galaxy URL that is used in job completion notification emails, which had previously been broken (it was always set to `http://localhost:8080`) by explicitly setting `galaxy_infrastructure_url` in the Galaxy configuration.

(NB it's unclear from the comments in the config file that this setting is used in the emails, however examining the source code indicates that this was the case.)