### PR TITLE
Implement management of database backup SQL files

### DIFF
--- a/roles/galaxy/files/manage_db_backups.sh
+++ b/roles/galaxy/files/manage_db_backups.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+USAGE="$(basename $0) BACKUP_DIR MAX_BACKUPS"
+
+# Backup directory
+BACKUPS_DIR=$1
+if [ -z "$BACKUPS_DIR" ] || [ ! -d "$BACKUPS_DIR" ] ; then
+    echo "usage: $USAGE"
+    echo "ERROR: no backup directory specified" >&2
+    exit 1
+fi
+
+# Maximum number of backups to keep
+MAX_BACKUPS=$2
+if [ -z "$MAX_BACKUPS" ] ; then
+    echo "usage: $USAGE"
+    echo "ERROR: maximum number of backups not specified" >&2
+    exit 1
+fi
+
+# Compress SQL dumps of database
+find "${BACKUPS_DIR}" -name "*.sql" -exec gzip {} \;
+
+# Keep most recent database dumps
+while [ $(ls -1 ${BACKUPS_DIR} | grep '.sql.gz$' | wc -l) -gt ${MAX_BACKUPS} ] ; do
+    /bin/rm -f "$(ls -t -1 ${BACKUPS_DIR}/*.sql.gz | tail -n 1)"
+done

--- a/roles/galaxy/tasks/cleanup.yml
+++ b/roles/galaxy/tasks/cleanup.yml
@@ -58,3 +58,11 @@
     hour: '00'
     minute: '20'
     state: present
+
+- name: "Manage Galaxy SQL database backups"
+  cron:
+    user: "{{ galaxy_user }}"
+    name: "{{ galaxy_name }} manage SQL database backups"
+    job: "{{ galaxy_dir }}/scripts/manage_db_backups.sh {{ galaxy_dir }}/backups 8"
+    special_time: 'weekly'
+    state: present

--- a/roles/galaxy/tasks/galaxy.yml
+++ b/roles/galaxy/tasks/galaxy.yml
@@ -14,6 +14,7 @@
   - '{{ galaxy_dir }}/logs'
   - '{{ galaxy_dir }}/backups'
   - '{{ galaxy_dir }}/gravity'
+  - '{{ galaxy_dir }}/scripts'
 
 - name: "Stop if proxy prefix is set but is missing leading slash"
   fail:
@@ -25,6 +26,14 @@
 - name: Set Galaxy URL
   set_fact:
     galaxy_url: "{{ 'https' if enable_https else 'http' }}://{{ galaxy_server_name }}{{ galaxy_proxy_prefix }}/"
+
+- name: "Install utility scripts"
+  copy:
+    src={{ item }}
+    dest='{{ galaxy_dir }}/scripts'
+    mode='ugo+rx'
+  with_items:
+  - "manage_db_backups.sh"
 
 - name: "Clone Galaxy source"
   git:


### PR DESCRIPTION
Adds a script and cronjob to the `galaxy` role which manages the backup SQL files that are produced for the Galaxy database each time the role is executed. The backups are dumps of the database SQL and are written to a `backups` subdirectory.

The update runs a weekly job which compresses (gzips) any uncompressed SQL files in the subdirectory and only keeps the most recent 8 backup files.