### PR TITLE
'galaxy' role: simplify setting of 'galaxy_infrastructure_url' in config file

### DIFF
--- a/roles/galaxy/templates/galaxy-config-release_22.05.yml.j2
+++ b/roles/galaxy/templates/galaxy-config-release_22.05.yml.j2
@@ -1154,11 +1154,7 @@ galaxy:
   # `job_conf.xml.interactivetools`.
   # NB This is also used as the URL for the Galaxy instance in completed
   # job emails
-{% if enable_https %}
-  galaxy_infrastructure_url: https://{{ galaxy_server_name }}
-{% else %}
-  galaxy_infrastructure_url: http://{{ galaxy_server_name }}
-{% endif %}
+  galaxy_infrastructure_url: {{ galaxy_url }}
 
   # If the above URL cannot be determined ahead of time in dynamic
   # environments but the port which should be used to access Galaxy can


### PR DESCRIPTION
Reimplements the setting of the `galaxy_infrastructure_url` parameter in the template Galaxy config YAML file (originally introduced in PR #290), and uses a simpler method to obtain the correct URL.