### PR TITLE
centaurus-dev: fix typo in configuration for name of MOTD file

### DIFF
--- a/instances/centaurus/devel_config.yml
+++ b/instances/centaurus/devel_config.yml
@@ -94,7 +94,7 @@ enable_tool_shed_check: yes
 # -- for ansible <2.6 "errors=..." option is not supported so
 #    an empty placeholder file is required to stop the playbook
 #    failing
-cdntaurus_motd: "{{ lookup('file', 'instances/centaurus/files/devel-motd', errors='warn') }}"
+centaurus_motd: "{{ lookup('file', 'instances/centaurus/files/devel-motd', errors='warn') }}"
 galaxy_message: "{{ lookup('file', 'instances/centaurus/files/devel-message', errors='warn') }}"
 
 # Tools conf base XML


### PR DESCRIPTION
Fixes a typo in the `instances/centaurus/devel_config.yml` which told the playbooks where to find the message-of-the-day (MOTD) file.