### PR TITLE
Update centaurus-dev 'welcome.html' template to include message-of-the-day

### DIFF
--- a/instances/centaurus/templates/centaurus-devel-welcome.html.j2
+++ b/instances/centaurus/templates/centaurus-devel-welcome.html.j2
@@ -13,6 +13,11 @@
 	      University of Manchester at the Faculty of Biology, Medicine
 	      and Health (FBMH)</strong></p>
 	</div>
+{% if centaurus_motd is defined and centaurus_motd %}
+      <div class="infomessagelarge">
+        {{ centaurus_motd }}
+      </div>
+{% endif %}
     </div>
     <div class="container">
       <h2>About</h2>


### PR DESCRIPTION
Fixes the `welcome.html` template for the `centaurus-dev` instance so that the MOTD (message-of-the-day) text is included, if present.