### PR TITLE
'galaxy' role: force 'pip' version in Galaxy virtualenv to <24.1 for 'celery'

### DIFF
--- a/roles/galaxy/tasks/galaxy.yml
+++ b/roles/galaxy/tasks/galaxy.yml
@@ -120,6 +120,12 @@
     cmd: "{{ galaxy_python_dir }}/bin/virtualenv .venv -p {{ python_exe }}"
     creates: '{{ galaxy_root }}/.venv'
 
+- name: "Downgrade pip in Galaxy virtualenv (release_21.05)"
+  pip:
+    name: "pip<24.1"
+    virtualenv: "{{ galaxy_root }}/.venv"
+  when: galaxy_version == "release_21.05"
+
 - name: "Check if conda is already installed"
   stat:
     path: "{{ galaxy_tool_dependency_dir }}/_conda/bin/conda"


### PR DESCRIPTION
Fixes an issue when running `common_startup.sh` to install Galaxy version 21.05, as installation of `celery` 5.0.5 requires `pip` <24.1. This patch ensures that the version of `pip` in the Galaxy virtualenv is a suitable version.