### PR TITLE
Centaurus: allow admins to delete users in 'production' & 'devel' instances

### DIFF
--- a/instances/centaurus/devel_config.yml
+++ b/instances/centaurus/devel_config.yml
@@ -21,7 +21,7 @@ galaxy_new_file_path: "{{ galaxy_install_dir }}/tmp"
 
 # Account management
 allow_user_creation: no
-allow_user_deletion: no
+allow_user_deletion: yes
 enable_require_login: yes
 enable_user_activation: no
 

--- a/instances/centaurus/production_config.yml
+++ b/instances/centaurus/production_config.yml
@@ -21,7 +21,7 @@ galaxy_new_file_path: "{{ galaxy_install_dir }}/tmp"
 
 # Account management
 allow_user_creation: no
-allow_user_deletion: no
+allow_user_deletion: yes
 enable_require_login: yes
 enable_user_activation: no
 


### PR DESCRIPTION
Update the configuration for the Centaurus "production" and "devel" instances to allow admins to delete user accounts, by setting the `allow_user_deletion` parameter to `yes`.

The parameter was previously set to `no`, possibly because there is some ambiguity over the scope of the different `allow_...` parameters in the Galaxy configuration file (where some refer to what is allowed for admins and others to users).