### PR TITLE
'galaxy' role: fix URL used for links in job completion emails

### DIFF
--- a/roles/galaxy/templates/galaxy-config-release_22.05.yml.j2
+++ b/roles/galaxy/templates/galaxy-config-release_22.05.yml.j2
@@ -1154,7 +1154,7 @@ galaxy:
   # `job_conf.xml.interactivetools`.
   # NB This is also used as the URL for the Galaxy instance in completed
   # job emails
-  galaxy_infrastructure_url: {{ galaxy_url }}
+  galaxy_infrastructure_url: {{ galaxy_url|trim('/') }}
 
   # If the above URL cannot be determined ahead of time in dynamic
   # environments but the port which should be used to access Galaxy can


### PR DESCRIPTION
Update the `galaxy.yml` config file template in the `galaxy` role, to fix how the `galaxy_infrastructure_url` is set.

Without this fix, the parameter has a trailing '/' which breaks the links in job completioin emails as it results in a double slash e.g.

    https://centaurus.itservices.manchester.ac.uk//histories/view?id=f6bf211384af63df

The fix strips any trailing slash when `galaxy_infrastructure_url` is set.