### PR TITLE
Update Centaurus registration form URL

### DIFF
--- a/instances/centaurus/templates/centaurus-welcome.html.j2
+++ b/instances/centaurus/templates/centaurus-welcome.html.j2
@@ -31,8 +31,7 @@ g/TR/xhtml1/DTD/xhtml1-transitional.dtd">
      <p>Please complete the following online form to request a new
        account on Centaurus:</p>
      <ul>
-       <li><a href="https://drive.google.com/open?id=11SBW87DwUvxzY697RF4OB-XJlHHS3NGmVWoIsOWRfO8" target="_blank">Request an account on Centaurus Galaxy</a>
-	 (Google form)</li>
+       <li><a href="https://forms.office.com/e/Q7aeGZY2LV" target="_blank">Request an account on Centaurus Galaxy</a></li>
      </ul>
      <p>Accounts are only available to users with a University of
        Manchester email address</p>


### PR DESCRIPTION
Updates the template welcome page for Centaurus to switch from Google form to MS 365 form for users to request an account with the service if they don't already have one.