### PR TITLE
centaurus: run file upload jobs on the local server rather than the compute cluster

### DIFF
--- a/instances/centaurus/job_conf.yml
+++ b/instances/centaurus/job_conf.yml
@@ -3,9 +3,11 @@
 
 # Job runners and destinations
 galaxy_job_destinations:
+  # Serial jobs
   - id: "jse_drop_serial"
     runner: "jse_drop"
     jse_drop_qsub_options: "-V -j n"
+  # Multicore jobs
   - id: "jse_drop_smp_4"
     runner: "jse_drop"
     jse_drop_qsub_options: "-V -j n -pe smp.pe 4"
@@ -85,6 +87,8 @@ galaxy_job_destinations:
 
 # Tool destinations
 galaxy_tool_destinations:
+  - id: "__DATA_FETCH__"
+    destination: "local"
   - id: "amplicon_analysis_pipeline"
     destination: "jse_drop_amplicon_analysis"
   - id: "bowtie_wrapper"


### PR DESCRIPTION
Updates the job configuration settings for the Centaurus instances, to run upload jobs (aka the `__DATA_FETCH__` tool) via the `local` job runner (meaning that they are executed on the local server rather than being sent to the compute cluster).

This will hopefully have the effect of making these jobs feel a bit more responsive, as they will start running immediately (provided there is sufficient capacity) without waiting either for JSE-Drop to collect each job or for the compute cluster to actually run it.

The potential downside is that the number of `local` jobs is restricted to one at a time, to avoid overloading the server. However it is hoped that overall this configuration will feel like an improvement for end users.