### PR TITLE
JSE-drop client interface: 'running' status more accurately reflects job status on cluster

### DIFF
--- a/roles/galaxy/files/jse_drop.py
+++ b/roles/galaxy/files/jse_drop.py
@@ -267,14 +267,19 @@ class JSEDrop(object):
             # Waiting for submission
             return JSEDropStatus.WAITING
         if not os.path.exists("%s.drop.qacct" % base_name):
-            # Check for job in error state
+            # Check for job state
             try:
-                if self.qstat(base_name)['state'] == "Eqw":
+                job_state = self.qstat(base_name)['state']
+                if job_state == "Eqw":
+                    # Error state
                     return JSEDropStatus.ERROR
+                elif job_state == "r":
+                    # Running
+                    return JSEDropStatus.RUNNING
             except KeyError:
                 pass
-            # Running
-            return JSEDropStatus.RUNNING
+            # Assume job is waiting to run
+            return JSEDropStatus.WAITING
         # Finished
         return JSEDropStatus.FINISHED
 


### PR DESCRIPTION
Updates the JSE-Drop client interface (file `jse_drop.py`) in the `galaxy` role, so that the job status (returned by `JSEDrop.status(...)`) is only returned as "running" when the compute cluster backup also indicates that the job is actually running.

Previously the "running" state was returned for any job that had been submitted to the compute cluster by the JSE-Drop server process, even if it was only queued waiting to run. This meant that jobs were displayed in the "running" (amber) state in Galaxy as soon as they were queued, arguably giving a false impression of the job state.

One potential side effect of this change is that short lived jobs that run and complete within the JSE-Drop server interval may appear in Galaxy to go directly from "queued" (grey) to "finished" (green) without appearing to go to "running" (amber) in between (probably not a big deal).