### PR TITLE
Update JSE-Drop runner to work with Slurm cluster

### DIFF
--- a/instances/centaurus/job_conf.yml
+++ b/instances/centaurus/job_conf.yml
@@ -6,32 +6,33 @@ galaxy_job_destinations:
   # Serial jobs
   - id: "jse_drop_serial"
     runner: "jse_drop"
-    jse_drop_qsub_options: "-V -j n"
+    jse_drop_submit_options: "-p serial -t 7-0"
   # Multicore jobs
   - id: "jse_drop_smp_4"
     runner: "jse_drop"
-    jse_drop_qsub_options: "-V -j n -pe smp.pe 4"
+    jse_drop_submit_options: "-p multicore -n 4 -t 7-0"
     jse_drop_slots: "4"
   - id: "jse_drop_smp_6"
     runner: "jse_drop"
-    jse_drop_qsub_options: "-V -j n -pe smp.pe 6"
+    jse_drop_submit_options: "-p multicore -n 6 -t 7-0"
     jse_drop_slots: "6"
   - id: "jse_drop_smp_8"
     runner: "jse_drop"
-    jse_drop_qsub_options: "-V -j n -pe smp.pe 8"
+    jse_drop_submit_options: "-p multicore -n 8 -t 7-0"
     jse_drop_slots: "8"
   - id: "jse_drop_smp_12"
     runner: "jse_drop"
-    jse_drop_qsub_options: "-V -j n -pe smp.pe 12"
+    jse_drop_submit_options: "-p multicore -n 12 -t 7-0"
     jse_drop_slots: "12"
   - id: "jse_drop_smp_16"
     runner: "jse_drop"
-    jse_drop_qsub_options: "-V -j n -pe smp.pe 16"
+    jse_drop_submit_options: "-p multicore -n 16 -t 7-0"
     jse_drop_slots: "16"
   # High memory runner
   - id: "jse_drop_smp_4_mem512"
     runner: "jse_drop"
-    jse_drop_qsub_options: "-V -j n -pe smp.pe 4 -l mem512"
+    # Minimum 32GB/core = 128GB
+    jse_drop_submit_options: "-p himem -n 4 -t 7-0"
     jse_drop_slots: "4"
     envs:
       - id: "GALAXY_MEMORY_MB"
@@ -39,11 +40,11 @@ galaxy_job_destinations:
   # Short serial queue runner for quick jobs (or testing)
   - id: "jse_drop_short"
     runner: "jse_drop"
-    jse_drop_qsub_options: "-j n -l short"
+    jse_drop_submit_options: "-p serial -t 0-1"
   # Runner for Amplicon analysis pipeline
   - id: "jse_drop_amplicon_analysis"
     runner: "jse_drop"
-    jse_drop_qsub_options: "-V -j n -pe smp.pe 8"
+    jse_drop_submit_options: "-p multicore -n 8 -t 7-0"
     jse_drop_slots: "8"
     envs:
       - id: "AMPLICON_ANALYSIS_REF_DATA_PATH"
@@ -51,19 +52,20 @@ galaxy_job_destinations:
   # Runner for NCBI Blast+
   - id: "jse_drop_ncbi_blast_plus"
     runner: "jse_drop"
-    jse_drop_qsub_options: "-V -j n -pe smp.pe 8 -l mem512"
+    # Minimum 32GB/core = 256GB
+    jse_drop_submit_options: "-p himem -n 8 -t 7-0"
     jse_drop_slots: "8"
   # Runner for Picard MarkDuplicates (needs Java options)
   - id: "jse_drop_picard_markduplicates"
     runner: "jse_drop"
-    jse_drop_qsub_options: "-V -j n -pe smp.pe 2"
+    jse_drop_submit_options: "-p multicore -n 2 -t 7-0"
     envs:
       - id: "_JAVA_OPTIONS"
         value: "-Xmx6G -Xms256m"
   # Runner for snp2hla
   - id: "jse_drop_snp2hla"
     runner: "jse_drop"
-    jse_drop_qsub_options: "-V -j n"
+    jse_drop_submit_options: "-p serial -t 7-0"
     envs:
       - id: "ref_panel"
         value: "/mnt/rvmi/centaurus/galaxy/devel/local_tools/snp2hla/data/REF"
@@ -77,7 +79,7 @@ galaxy_job_destinations:
   # not available)
   - id: "jse_drop_trinity"
     runner: "jse_drop"
-    jse_drop_qsub_options: "-V -j n -l mem512 -pe smp.pe 12"
+    jse_drop_submit_options: "-p himem -n 12 -t 7-0"
     jse_drop_slots: "12"
     envs:
       - id: "GALAXY_MEMORY_MB"

--- a/inventories/palfinder/production.yml
+++ b/inventories/palfinder/production.yml
@@ -15,22 +15,23 @@ palfinder:
     ##galaxy_reinstall_conda: yes
     ##galaxy_new_db_sql: "/mnt/rvmi/palfinder/galaxy/galaxy_palfinder.dump.2023-07-28.sql"
     # Job configuration
-    galaxy_jse_drop_dir: "{{ galaxy_install_dir }}/palfinder/jse-drop-csf3"
+    galaxy_jse_drop_dir: "{{ galaxy_install_dir }}/palfinder/jse-drop-slurm"
     galaxy_jse_drop_galaxy_id: "{{ galaxy_name }}"
     enable_local_jse_drop: no
     galaxy_default_runner: "jse_drop_default"
     galaxy_job_destinations:
       - id: "jse_drop_default"
         runner: "jse_drop"
+        jse_drop_submit_options: "-p serial -t 7-0"
       - id: "jse_drop_8_cores"
         runner: "jse_drop"
-        jse_drop_qsub_options: "-pe smp.pe 8"
+        jse_drop_submit_options: "-p multicore -n 8 -t 7-0"
         jse_drop_slots: "8"
     galaxy_tool_destinations:
       - id: "trimmomatic"
         destination: "jse_drop_8_cores"
     # Cluster needs to use its own virtual env
-    galaxy_jse_drop_virtual_env: "/mnt/rvmi/palfinder/galaxy/shared/csf/galaxy/22.05/venv_py3.8"
+    galaxy_jse_drop_virtual_env: "/mnt/rvmi/palfinder/galaxy/shared/csf-slurm/galaxy/22.05/venv_py3.8"
     # Postfix/email configuration
     enable_smtp: yes
     # SSL configuration

--- a/inventories/palfinder/test.yml
+++ b/inventories/palfinder/test.yml
@@ -17,23 +17,23 @@ palfinder:
     # Secrets
     palfinder_secrets: palfinder_passwds.yml
     # Job configuration
-    galaxy_jse_drop_dir: "/mnt/rvmi/palfinder/galaxy/palfinder/jse-drop-csf3"
+    galaxy_jse_drop_dir: "/mnt/rvmi/palfinder/galaxy/palfinder/jse-drop-slurm"
     galaxy_jse_drop_galaxy_id: "{{ galaxy_name }}"
     enable_local_jse_drop: no
     galaxy_default_runner: "jse_drop_default"
     galaxy_job_destinations:
       - id: "jse_drop_default"
         runner: "jse_drop"
-        jse_drop_qsub_options: "-l short"
+        jse_drop_submit_options: "-p serial -t 0-1"
       - id: "jse_drop_8_cores"
         runner: "jse_drop"
-        jse_drop_qsub_options: "-pe smp.pe 8"
+        jse_drop_submit_options: "-p multicore -n 8 -t 7-0"
         jse_drop_slots: "8"
     galaxy_tool_destinations:
       - id: "trimmomatic"
         destination: "jse_drop_8_cores"
     # Cluster needs to use its own virtual env
-    galaxy_jse_drop_virtual_env: "/mnt/rvmi/palfinder/galaxy/shared/csf/galaxy/22.05/venv_py3.8"
+    galaxy_jse_drop_virtual_env: "/mnt/rvmi/palfinder/galaxy/shared/csf-slurm/galaxy/22.05/venv_py3.8"
     # Postfix/email configuration
     enable_smtp: yes
     # SSL configuration

--- a/inventories/palfinder/vagrant.yml
+++ b/inventories/palfinder/vagrant.yml
@@ -13,7 +13,7 @@ palfinder:
     # Galaxy base installation dir
     galaxy_install_dir: "/mnt/rvmi/palfinder/galaxy"
     # Job configuration
-    galaxy_jse_drop_dir: "{{ galaxy_install_dir }}/palfinder/jse-drop-csf3"
+    galaxy_jse_drop_dir: "{{ galaxy_install_dir }}/palfinder/jse-drop-slurm"
     galaxy_jse_drop_galaxy_id: "{{ galaxy_name }}_vagrant"
     enable_local_jse_drop: yes
     galaxy_default_runner: "jse_drop_default"

--- a/roles/galaxy/defaults/main.yml
+++ b/roles/galaxy/defaults/main.yml
@@ -183,6 +183,7 @@ galaxy_default_runner: "local"
 galaxy_jse_drop_galaxy_id: "{{ galaxy_name }}"
 galaxy_jse_drop_dir: "{{ galaxy_dir }}/jse-drop"
 galaxy_jse_drop_virtual_env: "{{ galaxy_root }}/.venv"
+galaxy_jse_interface: "slurm"
 # Grace period after which files from finished or deleted
 # jobs can be removed (seconds)
 galaxy_jse_drop_cleanup_grace_period: "60"
@@ -191,7 +192,8 @@ galaxy_jse_drop_cleanup_grace_period: "60"
 # Define entries as a dictionary with:
 # - id     (destination ID)
 # - runner (target runner)
-# - jse_drop_qsub_options (optional, JSE-drop 'qsub_options')
+# - jse_drop_submit_options (optional, JSE-drop 'options')
+# - jse_drop_qsub_options (optional, JSE-drop 'qsub_options', deprecated)
 # - jse_drop_slots (optional, JSE-drop 'galaxy_slots')
 # - envs (optional dictionary defining <env...> elements, see below)
 # - user_concurrent_jobs (optional; sets maximum number of concurrent

--- a/roles/galaxy/files/jse_drop.py
+++ b/roles/galaxy/files/jse_drop.py
@@ -113,28 +113,47 @@ class JSEDrop(object):
     (See the FileLock class for details of how the locking is
     implemented.)
     """
-    def __init__(self,drop_dir):
+    def __init__(self,drop_dir,mode="ge"):
         """
         Create new JSEDrop instance
 
         Arguments:
           drop_dir (str): path to JSE 'drop-off' directory
+          mode (str): JSE-Drop mode (aka interface) (either
+            "ge" or "slurm")
         """
         # Drop off directory
         self._drop_dir = os.path.abspath(drop_dir)
         if not os.path.isdir(self._drop_dir):
             raise OSError("Missing drop dir: %s" % self._drop_dir)
+        # Mode
+        self._mode = str(mode).lower()
         # Define names for control files
-        self._names = {
-            "drop": "qsub",
-            "submit": "qsubmit",
-            "status": "qstat",
-            "delete": "qdel",
-            "completed": "qacct",
-            "deleted": "qdeleted",
-            "fail": "qfail",
-            "cleanup": "cleanup"
-        }
+        if self._mode == "ge":
+            # Grid Engine-style
+            self._names = {
+                "drop": "qsub",
+                "submit": "qsubmit",
+                "status": "qstat",
+                "delete": "qdel",
+                "completed": "qacct",
+                "deleted": "qdeleted",
+                "fail": "qfail",
+                "cleanup": "cleanup"
+            }
+        elif self._mode == "slurm":
+            self._names = {
+                "drop": "sbatch",
+                "submit": "ssubmit",
+                "status": "squeue",
+                "delete": "scancel",
+                "completed": "sacct",
+                "deleted": "sdeleted",
+                "fail": "sfail",
+                "cleanup": "cleanup"
+            }
+        else:
+            raise Exception(f"'{mode}': unrecognised mode")
 
     @property
     def drop_dir(self):
@@ -227,7 +246,14 @@ class JSEDrop(object):
             return job_status['job_number']
         # No status, check output files
         job_id = self.get_job_id(name)
-        output_files = glob.glob(os.path.join(self._drop_dir, f"{job_id}.o*"))
+        if self._mode == "slurm":
+            # Slurm-like mode
+            output_files = glob.glob(os.path.join(self._drop_dir,
+                                                  f"{job_id}.out"))
+        elif self._mode == "ge":
+            # Grid Engine-like mode
+            output_files = glob.glob(os.path.join(self._drop_dir,
+                                                  f"{job_id}.o*"))
         if len(output_files) == 1:
             return output_files[0].split('.')[-1][1:]
         # Unable to acquire the job number
@@ -269,7 +295,7 @@ class JSEDrop(object):
                 if job_state == "Eqw":
                     # Error state
                     return JSEDropStatus.ERROR
-                elif job_state == "r":
+                elif job_state in ("r", "RUNNING"):
                     # Running
                     return JSEDropStatus.RUNNING
             except KeyError:
@@ -303,23 +329,34 @@ class JSEDrop(object):
             return {}
         status = {}
         with open(status_file,'rt') as fp:
-            #<JB_job_number>204784</JB_job_number>
-            #<JAT_prio>50.25000</JAT_prio>
-            #<JB_name>drop-test  qNmoihPDDImLgWtetEZKhTSjmLhUikwg--JSE-DROP</JB_name>
-            #<JB_owner>simonh</JB_owner>
-            #<state>r</state>
-            #<JAT_start_time>2016-04-28T17:30:19</JAT_start_time>
-            #<queue_name>C6220-galaxy.q@node009.prv.hydra.cluster</queue_name>
-            #<slots>1</slots>
-            for line in fp:
-                m = re.match(r'<([^>]+)>([^<]+)</([^>]+)>',line.rstrip('\n'))
-                if m:
-                    key = m.group(1)
-                    value = m.group(2)
-                    if key == "JB_job_number":
-                        status["job_number"] = value
-                    elif key == "state":
-                        status["state"] = value
+            if self._mode == "slurm":
+                # Slurm-like mode
+                #JOBID|PRIORITY|NAME|USER|STATE|START_TIME|PARTITION|NODELIST|CPUS
+                for line in fp:
+                    data = line.rstrip("\n").split("|")
+                    status["job_number"] = data[0]
+                    status["state"] = data[4]
+                    break
+            elif self._mode == "ge":
+                # Grid Engine-like mode
+                #<JB_job_number>204784</JB_job_number>
+                #<JAT_prio>50.25000</JAT_prio>
+                #<JB_name>drop-test  qNmoihPDDImLgWtetEZKhTSjmLhUikwg--JSE-DROP</JB_name>
+                #<JB_owner>simonh</JB_owner>
+                #<state>r</state>
+                #<JAT_start_time>2016-04-28T17:30:19</JAT_start_time>
+                #<queue_name>C6220-galaxy.q@node009.prv.hydra.cluster</queue_name>
+                #<slots>1</slots>
+                for line in fp:
+                    m = re.match(r'<([^>]+)>([^<]+)</([^>]+)>',
+                                 line.rstrip('\n'))
+                    if m:
+                        key = m.group(1)
+                        value = m.group(2)
+                        if key == "JB_job_number":
+                            status["job_number"] = value
+                        elif key == "state":
+                            status["state"] = value
         return status
 
     def failure_info(self, name):
@@ -379,6 +416,13 @@ class JSEDrop(object):
         There is no guarantee that the named file exists.
 
         """
+        # Stdout file template
+        if self._mode == "slurm":
+            # Slurm-like mode
+            template = "{job_id}.out"
+        elif self._mode == "ge":
+            # GE-like mode
+            template = "{job_id}.o{job_number}"
         # Get the job name
         job_id = self.get_job_id(name)
         # Get the job number
@@ -386,8 +430,8 @@ class JSEDrop(object):
         if job_number is not None:
             # Construct stdout file name
             return os.path.join(self._drop_dir,
-                                '%s.o%s' % (job_id,
-                                            job_number))
+                                template.format(job_id=job_id,
+                                                job_number=job_number))
         else:
             # No data available
             return None
@@ -399,15 +443,22 @@ class JSEDrop(object):
         There is no guarantee that the named file exists.
 
         """
+        # Stderr file template
+        if self._mode == "slurm":
+            # No stderr file for Slurm-like mode
+            return None
+        elif self._mode == "ge":
+            # GE-like mode
+            template = "{job_id}.e{job_number}"
         # Get the job name
         job_id = self.get_job_id(name)
         # Get the job number
         job_number = self.get_job_number(name)
         if job_number is not None:
-            # Construct stdout file name
+            # Construct stderr file name
             return os.path.join(self._drop_dir,
-                                '%s.e%s' % (job_id,
-                                            job_number))
+                                template.format(job_id=job_id,
+                                                job_number=job_number))
         else:
             # No data available
             return None

--- a/roles/galaxy/files/jse_drop.py
+++ b/roles/galaxy/files/jse_drop.py
@@ -113,14 +113,14 @@ class JSEDrop(object):
     (See the FileLock class for details of how the locking is
     implemented.)
     """
-    def __init__(self,drop_dir,mode="ge"):
+    def __init__(self,drop_dir,mode="slurm"):
         """
         Create new JSEDrop instance
 
         Arguments:
           drop_dir (str): path to JSE 'drop-off' directory
           mode (str): JSE-Drop mode (aka interface) (either
-            "ge" or "slurm")
+            "ge" or "slurm"; default: "slurm")
         """
         # Drop off directory
         self._drop_dir = os.path.abspath(drop_dir)

--- a/roles/galaxy/files/jse_drop.py
+++ b/roles/galaxy/files/jse_drop.py
@@ -455,7 +455,8 @@ class JSEDrop(object):
         Arguments:
           name (str): name of the job
         """
-        extensions = [f".drop.{self._names[x]}" for x in self._names]
+        extensions = [f".drop.{self._names[x]}" for x in self._names
+                      if x != "cleanup"]
         timestamp = None
         for ext in extensions:
             try:

--- a/roles/galaxy/files/jse_drop.py
+++ b/roles/galaxy/files/jse_drop.py
@@ -16,23 +16,24 @@ There is also a utility function:
 
 In normal operation the status codes indicate the following:
 
-- ``WAITING``: job has ``qsub`` file but not yet been
-  submitted by JSE-Drop (i.e. there is no ``qsubmit`` file)
-- ``RUNNING``: job is running (i.e. there is a ``qsubmit``
-  file indicating job started, but no ``qacct`` file to
-  indicate that it has finished)
-- ``FINISHED``: job has completed (i.e. there is a ``qacct``
+- ``WAITING``: job has ``drop`` file but not yet been
+  submitted by JSE-Drop (i.e. there is no ``*submit`` file)
+- ``RUNNING``: job is running (i.e. there is a ``*submit``
+  file indicating job started, but no ``*acct`` file to
+  indicate that it has finished, and job status from the
+  ``*stat`` file indicates it's running)
+- ``FINISHED``: job has completed (i.e. there is a ``*acct``
   file indicating the job has finished)
 - ``DELETING``: job is scheduled for deletion but may still
-  be active (i.e. there is a ``qdel`` file but no ``qdeleted``
+  be active (i.e. there is a ``*del`` file but no ``*deleted``
   file)
 - ``DELETED``: job has been deleted (i.e. there is a
-  ``qdeleted`` file)
+  ``*deleted`` file)
 
 The following status codes indicate a problem:
 
 - ``FAILED``: job failed on submission (i.e. there is a
-  ``qfail`` file)
+  ``*fail`` file)
 - ``ERROR``: job was submitted but is in an error state
   (e.g. ``Eqw`` state for Grid Engine backend)
 - ``MISSING``: job with that name is not found
@@ -74,7 +75,7 @@ class JSEDrop(object):
 
     Submit the contents of a script:
 
-    >>> jse.run('my_job','sleep 5\necho "Finished sleeping")
+    >>> jse.run('my_job','sleep 5\necho "Finished sleeping"')
 
     Get the id of the job as assigned by JSE-drop:
 
@@ -84,13 +85,9 @@ class JSEDrop(object):
 
     >>> jse.status('my_job')
 
-    Get the contents of qstat for the job (returns a dictionary):
+    Get the status information for the job (returns a dictionary):
 
-    >>> jse.qstat('my_job')
-
-    Get the contents of qacct for the job (returns a dictionary):
-
-    >>> jse.qcct('my_job')
+    >>> jse.job_status('my_job')
 
     Get the stdout and stderr files:
 
@@ -122,11 +119,22 @@ class JSEDrop(object):
 
         Arguments:
           drop_dir (str): path to JSE 'drop-off' directory
-
         """
+        # Drop off directory
         self._drop_dir = os.path.abspath(drop_dir)
         if not os.path.isdir(self._drop_dir):
             raise OSError("Missing drop dir: %s" % self._drop_dir)
+        # Define names for control files
+        self._names = {
+            "drop": "qsub",
+            "submit": "qsubmit",
+            "status": "qstat",
+            "delete": "qdel",
+            "completed": "qacct",
+            "deleted": "qdeleted",
+            "fail": "qfail",
+            "cleanup": "cleanup"
+        }
 
     @property
     def drop_dir(self):
@@ -148,9 +156,10 @@ class JSEDrop(object):
         Return a list of job names found in the JSE-drop directory
 
         """
+        drop_file_ext = f".drop.{self._names['drop']}"
         jobs = []
-        for f in glob.glob(os.path.join(self._drop_dir,'*.drop.qsub')):
-            jobs.append(os.path.basename(f)[:-len('.drop.qsub')])
+        for f in glob.glob(os.path.join(self._drop_dir, f"*{drop_file_ext}")):
+            jobs.append(os.path.basename(f)[:-len(drop_file_ext)])
         jobs.sort()
         return jobs
 
@@ -165,7 +174,8 @@ class JSEDrop(object):
             to JSE-drop
 
         """
-        drop_file = os.path.join(self._drop_dir,"%s.drop.qsub" % name)
+        drop_file = os.path.join(self._drop_dir,
+                                 f"{name}.drop.{self._names['drop']}")
         if os.path.exists(drop_file):
             raise OSError("Job with name '%s' already exists" % name)
         fd,tmp_drop_file = tempfile.mkstemp()
@@ -182,12 +192,12 @@ class JSEDrop(object):
 
         Arguments:
           name (str): name of the job
-
         """
-        qsubmit_file = os.path.join(self._drop_dir,"%s.drop.qsubmit" % name)
-        if not os.path.exists(qsubmit_file):
+        submit_file = os.path.join(self._drop_dir,
+                                   f"{name}.drop.{self._names['submit']}")
+        if not os.path.exists(submit_file):
             return None
-        with open(qsubmit_file,'rt') as fp:
+        with open(submit_file,'rt') as fp:
             # //my_job--qNmoihPDDImLgWtetEZKhTSjmLhUikwg--JSE-DROP//
             job_id = fp.read()
         try:
@@ -201,36 +211,23 @@ class JSEDrop(object):
         """
         Return the number assigned by the backend compute engine
 
-        Attempts to fetch the job number from the
-        .drop.qacct file; if no information can be read
-        from .drop.qacct (e.g. job hasn't finished yet) then
-        tries to acquire the data from the .drop.qstat file.
-
-        If neither of these files exists then tries to infer
-        the job number from the '.o' file on the file system.
+        Attempts to acquire the job number from the "status"
+        file; if this doesn't exist then tries to infer
+        the job number from the stdout file on the file system.
 
         If none of these methods yields a job number then
         returns None.
 
         Arguments:
           name (str): name of the job
-
         """
-        # Try qacct
-        qacct = self.qacct(name)
-        if qacct:
-            try:
-                return qacct['jobnumber']
-            except KeyError:
-                # Unable to extract job number
-                pass
-        # Fallback to qstat
-        qstat = self.qstat(name)
-        if qstat:
-            return qstat['JB_job_number']
-        # Finally: try checking the file system
-        output_files = glob.glob(os.path.join(self._drop_dir,
-                                              '%s--*--JSE-DROP.o*' % name))
+        # Check job status
+        job_status = self.job_status(name)
+        if job_status:
+            return job_status['job_number']
+        # No status, check output files
+        job_id = self.get_job_id(name)
+        output_files = glob.glob(os.path.join(self._drop_dir, f"{job_id}.o*"))
         if len(output_files) == 1:
             return output_files[0].split('.')[-1][1:]
         # Unable to acquire the job number
@@ -245,31 +242,30 @@ class JSEDrop(object):
 
         Returns:
           Integer: status code.
-
         """
         base_name = os.path.join(self._drop_dir,name)
-        if not os.path.exists("%s.drop.qsub" % base_name):
+        if not os.path.exists(f"{base_name}.drop.{self._names['drop']}"):
             # No submission script found
             return JSEDropStatus.MISSING
-        if os.path.exists("%s.drop.cleanup" % base_name):
+        if os.path.exists(f"{base_name}.drop.{self._names['cleanup']}"):
             # Job marked for clean up
             return JSEDropStatus.CLEANUP
-        if os.path.exists("%s.drop.qfail" % base_name):
+        if os.path.exists(f"{base_name}.drop.{self._names['fail']}"):
             # Submission failed
             return JSEDropStatus.FAILED
-        if os.path.exists("%s.drop.qdeleted" % base_name):
+        if os.path.exists(f"{base_name}.drop.{self._names['deleted']}"):
             # Job has been deleted
             return JSEDropStatus.DELETED
-        if os.path.exists("%s.drop.qdel" % base_name):
+        if os.path.exists(f"{base_name}.drop.{self._names['delete']}"):
             # Job is pending deletion
             return JSEDropStatus.DELETING
-        if not os.path.exists("%s.drop.qsubmit" % base_name):
+        if not os.path.exists(f"{base_name}.drop.{self._names['submit']}"):
             # Waiting for submission
             return JSEDropStatus.WAITING
-        if not os.path.exists("%s.drop.qacct" % base_name):
+        if not os.path.exists(f"{base_name}.drop.{self._names['completed']}"):
             # Check for job state
             try:
-                job_state = self.qstat(base_name)['state']
+                job_state = self.job_status(base_name)['state']
                 if job_state == "Eqw":
                     # Error state
                     return JSEDropStatus.ERROR
@@ -283,25 +279,30 @@ class JSEDrop(object):
         # Finished
         return JSEDropStatus.FINISHED
 
-    def qstat(self,name):
+    def job_status(self,name):
         """
-        Return the qstat information for the job
+        Return the status information for the job
+
+        Job status will include the following keys:
+
+        - job_number
+        - state
 
         Arguments:
           name (str): name of the job
 
         Returns:
           Dictionary: dictionary where keys are items from
-            the .drop.qstat file; dictionary will be empty if no
-            .drop.qstat file was found (e.g. because the job hasn't
+            the status file; dictionary will be empty if no
+            status file was found (e.g. because the job hasn't
             started yet).
-
         """
-        qstat_file = os.path.join(self._drop_dir,"%s.drop.qstat" % name)
-        if not os.path.exists(qstat_file):
+        status_file = os.path.join(self._drop_dir,
+                                   f"{name}.drop.{self._names['status']}")
+        if not os.path.exists(status_file):
             return {}
-        qstat = {}
-        with open(qstat_file,'rt') as fp:
+        status = {}
+        with open(status_file,'rt') as fp:
             #<JB_job_number>204784</JB_job_number>
             #<JAT_prio>50.25000</JAT_prio>
             #<JB_name>drop-test  qNmoihPDDImLgWtetEZKhTSjmLhUikwg--JSE-DROP</JB_name>
@@ -313,75 +314,33 @@ class JSEDrop(object):
             for line in fp:
                 m = re.match(r'<([^>]+)>([^<]+)</([^>]+)>',line.rstrip('\n'))
                 if m:
-                    qstat[m.group(1)] = m.group(2)
-        return qstat
+                    key = m.group(1)
+                    value = m.group(2)
+                    if key == "JB_job_number":
+                        status["job_number"] = value
+                    elif key == "state":
+                        status["state"] = value
+        return status
 
-    def qacct(self,name):
+    def failure_info(self, name):
         """
-        Return the qacct information for the job
+        Return job submission failure information
 
         Arguments:
           name (str): name of the job
 
         Returns:
           Dictionary: dictionary where keys are items from
-            the .drop.qacct file; dictionary will be empty if no
-            .drop.qacct file was found (e.g. because the job hasn't
-            completed yet).
-
+            the "fail" file; dictionary will be empty if no
+            "fail" file was found (e.g. because the job
+            didn't fail on submission).
         """
-        qacct_file = os.path.join(self._drop_dir,"%s.drop.qacct" % name)
-        if not os.path.exists(qacct_file):
+        failure_file = os.path.join(self._drop_dir,
+                                    f"{name}.drop.{self._names['fail']}")
+        if not os.path.exists(failure_file):
             return {}
-        qacct = {}
-        with open(qacct_file,'rt') as fp:
-            #==============================================================
-            #qname        C6220-galaxy.q
-            #hostname     node009.prv.hydra.cluster
-            #group        simonh
-            #owner        simonh
-            #project      NONE
-            #department   defaultdepartment
-            #jobname      drop-test  qNmoihPDDImLgWtetEZKhTSjmLhUikwg--JSE-DROP
-            #jobnumber    204784
-            #taskid       undefined
-            #account      sge
-            #priority     0
-            #qsub_time    Thu Apr 28 17:30:19 2016
-            #start_time   Thu Apr 28 17:30:19 2016
-            #end_time     Thu Apr 28 17:32:19 2016
-            #granted_pe   NONE
-            #slots        1
-            #failed       0
-            #exit_status  0
-            #...
-            for line in fp:
-                try:
-                    key,value = [x.strip() for x in line.split(' ',1)]
-                    qacct[key] = value
-                except ValueError:
-                    pass
-        return qacct
-
-    def qfail(self,name):
-        """
-        Return the qfail information for the job
-
-        Arguments:
-          name (str): name of the job
-
-        Returns:
-          Dictionary: dictionary where keys are items from
-            the .drop.qfail file; dictionary will be empty if no
-            .drop.qfail file was found (e.g. because the job didn't
-            fail on submission).
-
-        """
-        qfail_file = os.path.join(self._drop_dir,"%s.drop.qfail" % name)
-        if not os.path.exists(qfail_file):
-            return {}
-        qfail = {}
-        with open(qfail_file,'rt') as fp:
+        failure_info = {}
+        with open(failure_file,'rt') as fp:
             #======================================
             #
             #Exit status: //2//
@@ -399,19 +358,19 @@ class JSEDrop(object):
                 if line == "======================================\n":
                     continue
                 if line.startswith('Exit status:'):
-                    qfail['exit_code'] = line[:-1].split()[-1].strip('/')
+                    failure_info['exit_code'] = line[:-1].split()[-1].strip('/')
                     continue
                 if line.startswith('STDOUT:'):
                     section = 'stdout'
-                    qfail['stdout'] = ''
+                    failure_info['stdout'] = ''
                     continue
                 elif line.startswith('STDERR:'):
                     section = 'stderr'
-                    qfail['stderr'] = ''
+                    failure_info['stderr'] = ''
                     continue
                 if section is not None:
-                    qfail[section] += line
-        return qfail
+                    failure_info[section] += line
+        return failure_info
 
     def stdout_file(self,name):
         """
@@ -459,9 +418,9 @@ class JSEDrop(object):
 
         Arguments:
           name (str): name of the job
-
         """
-        kill_file = os.path.join(self._drop_dir,"%s.drop.qdel" % name)
+        kill_file = os.path.join(self._drop_dir,
+                                 f"{name}.drop.{self._names['delete']}")
         if os.path.exists(kill_file):
             # Kill file already exists, ignore
             return
@@ -479,7 +438,7 @@ class JSEDrop(object):
           name (str): name of the job
         """
         cleanup_file = os.path.join(self._drop_dir,
-                                    "%s.drop.cleanup" % name)
+                                    f"{name}.drop.{self._names['cleanup']}")
         if os.path.exists(cleanup_file):
             # Clean up file already exists, ignore
             return
@@ -495,15 +454,8 @@ class JSEDrop(object):
 
         Arguments:
           name (str): name of the job
-
         """
-        extensions = ('.drop.qsub',
-                      '.drop.qsubmit',
-                      '.drop.qfail',
-                      '.drop.qstat',
-                      '.drop.qdel',
-                      '.drop.qdeleted',
-                      '.drop.qacct',)
+        extensions = [f".drop.{self._names[x]}" for x in self._names]
         timestamp = None
         for ext in extensions:
             try:
@@ -527,14 +479,6 @@ class JSEDrop(object):
           name (str): name of the job
 
         """
-        extensions = ('.drop.qsub',
-                      '.drop.qsubmit',
-                      '.drop.qfail',
-                      '.drop.qstat',
-                      '.drop.qdel',
-                      '.drop.qdeleted',
-                      '.drop.qacct',
-                      '.drop.cleanup',)
         # Remove stdout/stderr first
         for f in (self.stdout_file(name),self.stderr_file(name)):
             if f is None:
@@ -551,6 +495,7 @@ class JSEDrop(object):
             except (AttributeError,OSError):
                 pass
         # Remove remaining files
+        extensions = [f".drop.{self._names[x]}" for x in self._names]
         for ext in extensions:
             try:
                 os.remove(os.path.join(self._drop_dir,

--- a/roles/galaxy/files/jse_drop_runner.py
+++ b/roles/galaxy/files/jse_drop_runner.py
@@ -23,6 +23,7 @@ To configure Galaxy to use JSE-drop:
          <param id="galaxy_id">devel</param>
          <param id="drop_dir">/mnt/galaxy/database/jse-drop</param>
          <param id="virtual_env">/mnt/galaxy/.venv</param>
+         <param id="interface">slurm</param>
    </plugins>
 
 2. Create destinations that target this runner.
@@ -36,8 +37,8 @@ To configure Galaxy to use JSE-drop:
    A more advanced example:
 
    <destinations>
-      <destination id="jse_drop_8core" runner="jse_drop">
-         <param id="qsub_options">-pe smp.pe 8</param>
+      <destination id="jse_drop_8core_1hr" runner="jse_drop">
+         <param id="options">-p multicore_small -n 8 -t 0-1</param>
          <param id="galaxy_slots">8</param>
       </destination>
    </destinations>
@@ -56,13 +57,14 @@ The parameters available for the runner plugin are:
 
 The parameters available for the destinations are:
 
- * qsub_options: options to be passed to Grid Engine when
-   running jobs (optional)
+ * options: options to be passed to the batch job submission
+   system (e.g. Slurm, Grid Engine) when running jobs (optional)
  * galaxy_slots: the number of slots/processors available
    to Galaxy jobs (optional, but should match the number
    of cores available under Grid Engine when using the
    environment defined by 'qsub_options')
-
+ * qsub_options: options to be passed to Grid Engine when
+   running jobs (optional, deprecated - use "options" instead)
 """
 
 import logging
@@ -93,6 +95,7 @@ class JSEDropJobRunner(AsynchronousJobRunner):
     Job runner dropping job files into shared dir for execution by JSE
     """
     runner_name = "JSEDropJobRunner"
+    default_interface = "slurm"
 
     def __init__(self,app,nworkers,**kwargs):
         """
@@ -104,6 +107,7 @@ class JSEDropJobRunner(AsynchronousJobRunner):
             'galaxy_id': dict(map=str,default=None),
             'virtual_env': dict(map=str,default=None),
             'drop_dir': dict(map=str,default=None),
+            'interface': dict(map=str,default=None)
         }
         if 'runner_param_specs' not in kwargs:
             kwargs[ 'runner_param_specs' ] = dict()
@@ -147,11 +151,26 @@ class JSEDropJobRunner(AsynchronousJobRunner):
         except KeyError:
             return None
 
+    def _get_interface(self):
+        """
+        Extract interface mode ("ge" or "slurm") from runner params
+        """
+        try:
+            return self.runner_params['interface']
+        except KeyError:
+            return self.default_interface
+
     def _get_qsub_options(self,job_destination):
         """
         Extract qsub options from job destination parameters
         """
         return job_destination.params.get('qsub_options',None)
+
+    def _get_submit_options(self,job_destination):
+        """
+        Extract batch submission options from job destination parameters
+        """
+        return job_destination.params.get('options',None)
 
     def _get_galaxy_slots(self,job_destination):
         """
@@ -203,15 +222,19 @@ class JSEDropJobRunner(AsynchronousJobRunner):
         # Get the parameters defined for this destination
         # i.e. location of the drop-off directory etc
         drop_off_dir = self._get_drop_dir()
+        interface = self._get_interface()
         virtual_env = self._get_virtual_env()
-        qsub_options = self._get_qsub_options(job_destination)
+        submit_options = self._get_submit_options(job_destination)
+        if not submit_options:
+            submit_options = self._get_qsub_options(job_destination)
         galaxy_slots = self._get_galaxy_slots(job_destination)
         galaxy_id = self._get_galaxy_id()
-        log.debug("queue_job: drop-off dir = %s" % drop_off_dir)
-        log.debug("queue_job: virtual_env  = %s" % virtual_env)
-        log.debug("queue_job: qsub options = %s" % qsub_options)
-        log.debug("queue_job: galaxy_slots = %s" % galaxy_slots)
-        log.debug("queue_job: galaxy_id    = %s" % galaxy_id)
+        log.debug("queue_job: drop-off dir  = %s" % drop_off_dir)
+        log.debug("queue_job: interface     = %s" % interface)
+        log.debug("queue_job: virtual_env   = %s" % virtual_env)
+        log.debug("queue_job: submit options= %s" % submit_options)
+        log.debug("queue_job: galaxy_slots  = %s" % galaxy_slots)
+        log.debug("queue_job: galaxy_id     = %s" % galaxy_id)
         if drop_off_dir is None:
             # Can't locate drop-off dir
             job_wrapper.fail("failure preparing job script (no JSE-drop "
@@ -221,7 +244,7 @@ class JSEDropJobRunner(AsynchronousJobRunner):
                           (galaxy_id_tag,job_name))
             return
         # Initialise JSE-drop client interface
-        jse_drop = JSEDrop(drop_off_dir)
+        jse_drop = JSEDrop(drop_off_dir, mode=interface)
         # ID and name for job
         galaxy_id_tag = job_wrapper.get_id_tag()
         log.debug("ID tag: %s" % galaxy_id_tag)
@@ -253,15 +276,30 @@ class JSEDropJobRunner(AsynchronousJobRunner):
                                  script.split('\n')))
         script = '\n'.join(filter(lambda x: not x.startswith('#!'),
                                   script.split('\n')))
-        # Create header with embedded qsub flags
-        qsub_header = ["-V",
-                       "-wd %s" % job_wrapper.working_directory]
-        if qsub_options:
-            qsub_header.append(qsub_options)
-        qsub_header = '\n'.join(["#$ %s" % opt for opt in qsub_header])
-        log.debug("qsub_header: %s" % qsub_header)
+        # Batch system specific options
+        if interface == "slurm":
+            # Create header with embedded Slurm sbatch flags
+            slurm_header = [f"-J {job_name}",
+                            f"-D {job_wrapper.working_directory}"]
+            if submit_options:
+                slurm_header.append(submit_options)
+            slurm_header = "\n".join([f"#SBATCH {opt}"
+                                      for opt in slurm_header])
+            log.debug("slurm_header: %s" % slurm_header)
+            batch_header = slurm_header
+        elif interface == "ge":
+            # Create header with embedded qsub flags
+            qsub_header = ["-V",
+                           "-wd %s" % job_wrapper.working_directory]
+            if submit_options:
+                qsub_header.append(submit_options)
+            qsub_header = '\n'.join(["#$ %s" % opt for opt in qsub_header])
+            log.debug("qsub_header: %s" % qsub_header)
+            batch_header = qsub_header
+        else:
+            batch_header = ""
         # Reassemble the script components
-        script = "\n".join((shell,qsub_header,script))
+        script = "\n".join((shell, batch_header, script))
         # Create the drop file to submit the job
         try:
             with jse_drop.get_lock(timeout=60):

--- a/roles/galaxy/files/jse_drop_runner.py
+++ b/roles/galaxy/files/jse_drop_runner.py
@@ -340,10 +340,10 @@ class JSEDropJobRunner(AsynchronousJobRunner):
                          job_name)
                 self._register_completed_job(job_name)
                 if jse_drop_status == JSEDropStatus.FAILED:
-                    # Get message from qfail file
+                    # Get message from failure file
                     log.warn("%s: failed" % job_name)
                     message = "Submission to JSE-drop failed: %s" % \
-                              jse_drop.qfail(job_name)['stderr']
+                              jse_drop.failure_info(job_name)['stderr']
                 elif jse_drop_status == JSEDropStatus.ERROR:
                     # Job is in error state
                     log.warn("%s: job is in error state" % job_name)

--- a/roles/galaxy/templates/job_conf.xml.j2
+++ b/roles/galaxy/templates/job_conf.xml.j2
@@ -17,6 +17,9 @@
 {%      if galaxy_jse_drop_galaxy_id is defined %}
 	  <param id="galaxy_id">{{ galaxy_jse_drop_galaxy_id }}</param>
 {%      endif %}
+{%      if galaxy_jse_interface is defined %}
+	  <param id="interface">{{ galaxy_jse_interface }}</param>
+{%      endif %}
         </plugin>
 {% endif %}
     </plugins>
@@ -31,7 +34,11 @@
 {% if galaxy_job_destinations %}
 {%   for dest in galaxy_job_destinations %}
         <destination id="{{ dest.id }}" runner="{{ dest.runner }}">
+{%      if dest.jse_drop_submit_options is defined %}
+          <param id="options">{{ dest.jse_drop_submit_options }}</param>
+{%      endif %}
 {%      if dest.jse_drop_qsub_options is defined %}
+          <!-- 'qsub_options' deprecated: use 'options' instead -->
           <param id="qsub_options">{{ dest.jse_drop_qsub_options }}</param>
 {%      endif %}
 {%      if dest.jse_drop_slots is defined %}

--- a/roles/jsedrop/defaults/main.yml
+++ b/roles/jsedrop/defaults/main.yml
@@ -2,4 +2,5 @@
 # jsedrop.py installation defaults
 jsedrop_install_dir: "/usr/local/bin"
 jsedrop_drop_dir: "/usr/share/drop-off"
+jsedrop_interface: "ge"
 jsedrop_python3: "/usr/local/bin/python3"

--- a/roles/jsedrop/defaults/main.yml
+++ b/roles/jsedrop/defaults/main.yml
@@ -2,5 +2,5 @@
 # jsedrop.py installation defaults
 jsedrop_install_dir: "/usr/local/bin"
 jsedrop_drop_dir: "/usr/share/drop-off"
-jsedrop_interface: "ge"
+jsedrop_interface: "slurm"
 jsedrop_python3: "/usr/local/bin/python3"

--- a/roles/jsedrop/files/jsedrop.py
+++ b/roles/jsedrop/files/jsedrop.py
@@ -419,12 +419,14 @@ class JSEDrop(object):
     """
     Class implementing JSE-Drop protocol
     """
-    def __init__(self,drop_dir,interface=JSEDropInterfaces.GE,
+    def __init__(self,drop_dir,interface=JSEDropInterfaces.SLURM,
                  submission_engine=None,run_as_user=False,
                  log_file=None,pid_file=None):
         """
         Arguments:
           drop_dir: drop-off directory to monitor
+          interface: interface mode for JSEDrop (defaults
+            to JSEDropInterfaces.SLURM)
           submission_engine: backend instance (defaults
             to 'PopenBackend'
           run_as_user: if True then submission engine should
@@ -680,9 +682,10 @@ if __name__ == "__main__":
 
     # Available interfaces
     interfaces = {
-        "ge": JSEDropInterfaces.GE,
         "slurm": JSEDropInterfaces.SLURM,
+        "ge": JSEDropInterfaces.GE,
     }
+    default_interface = "slurm"
     
     # Process command line
     p = ArgumentParser(description="Python implementation of JSE-Drop")
@@ -695,10 +698,11 @@ if __name__ == "__main__":
                    "(default: %ss)" % DEFAULT_INTERVAL)
     p.add_argument("--interface",
                    dest="interface",metavar="JSEDROP_INTERFACE",
-                   choices=[x for x in interfaces],default="ge",
+                   choices=[x for x in interfaces],
+                   default=default_interface,
                    help="JSE-Drop interface to use (one of %s; default: "
                    "'%s')" % (",".join([f"'{x}'" for x in interfaces]),
-                            "ge"))
+                              default_interface))
     p.add_argument("--run-as-user",
                    dest="run_as_user",action="store_true",
                    help="run jobs as the user who owns the drop files")

--- a/roles/jsedrop/files/jsedrop.py
+++ b/roles/jsedrop/files/jsedrop.py
@@ -20,13 +20,251 @@ import subprocess
 
 DEFAULT_INTERVAL = 30
 
+class JSEDropInterface:
+    """
+    Base class for implementing JSE-Drop interface to cluster
+
+    Subclass needs to define the drop-off directory and the
+    names used to identify the following types of file:
+
+    - drop_name (extension for submitted job script)
+    - submit_name (extension when JSE-Drop has submitted the job)
+    - status_name (extension for status file for running job)
+    - completion_name (extension for file indicating job has finished)
+    - delete_name (extension for removing a submitted job)
+    - fail_name (extention for file indicating job submission failed)
+
+    e.g. drop_name will be "qsub" for SGE and "sbatch" for Slurm.
+
+    Additionally the subclass also needs to supply the template
+    strings for naming the stdout and stderr files. The templates
+    should be of the form e.g. "{job_id}.o{job_number}" (for SGE)
+    or "{job_id}.log" (for Slurm).
+
+    The subclass also needs to implement the "write_status_file"
+    and "write_completion_file" methods, to write the appropriate
+    content for each.
+    """
+    def __init__(self, drop_dir, drop_name, submit_name, status_name,
+                 completion_name, delete_name, deleted_name, fail_name,
+                 stdout_tmpl, stderr_tmpl):
+        self._drop_dir = drop_dir
+        self._names = {
+            "drop": drop_name,
+            "submit": submit_name,
+            "status": status_name,
+            "completion": completion_name,
+            "delete": delete_name,
+            "deleted": deleted_name,
+            "fail": fail_name
+        }
+        self.stdout_tmpl = stdout_tmpl
+        self.stderr_tmpl = stderr_tmpl
+
+    def list_active_jobs(self):
+        """
+        Return list of active jobs for monitoring
+        """
+        # Get list of all *.drop.* files
+        drop_dir = self._drop_dir
+        drop_files = [os.path.basename(f)
+                      for f in glob.glob(os.path.join(drop_dir, "*.drop.*"))]
+        # Get initial list of names from drop files
+        drop_ext = f".drop.{self._names['drop']}"
+        job_names = [f[:-len(drop_ext)]
+                     for f in drop_files if f.endswith(drop_ext)]
+        # Ignore completed, deleted and failed jobs
+        job_names = [j for j in job_names
+                     if not
+                     (f"{j}.drop.{self._names['completion']}" in drop_files or
+                      f"{j}.drop.{self._names['deleted']}" in drop_files or
+                      f"{j}.drop.{self._names['fail']}" in drop_files)]
+        return job_names
+
+    def make_job_id(self, job_name):
+        """
+        Return random ID for job
+        """
+        return "%s%s--%s--JSE-DROP" % (job_name,
+                                       "_"*max(0,10-len(job_name)),
+                                       "".join(random.choice(
+                                           string.ascii_uppercase +
+                                           string.ascii_lowercase)
+                                               for _ in range(32)))
+
+    def get_job_id(self, job_name):
+        """
+        Extract job ID from 'submit' file
+        """
+        submit_file = os.path.join(self._drop_dir,
+                                   f"{job_name}.drop.{self._names['submit']}")
+        if os.path.exists(submit_file):
+            # //my_job--qNmoihPDDImLgWtetEZKhTSjmLhUikwg--JSE-DROP//
+            try:
+                with open(submit_file, "rt") as fp:
+                    job_id = fp.read()
+                # Remove leading and trailing spaces and '//'
+                return job_id.strip().strip('/')
+            except Exception as ex:
+                raise Exception(f"Failed to extract job id for '{job_name}' "
+                                f"from '{job_id}': {ex}")
+        else:
+            return None
+
+    def write_file(self, job_name, name, content, user=None):
+        """
+        Write file to the drop-off directory
+        """
+        if name not in [self._names[x] for x in self._names]:
+            raise Exception(f"'{name}': unknown JSE-Drop file type")
+        file_path = os.path.join(self._drop_dir,
+                                 f"{job_name}.drop.{name}")
+        if user is None:
+            # Write file directly
+            with open(file_path,'wt') as fp:
+                fp.write("%s" % content)
+        else:
+            # Write intermediate file and copy as user
+            file_no, tmp_file = tempfile.mkstemp(
+                suffix=f".jsedrop.{name}",
+                text=True)
+            os.fdopen(file_no).close()
+            with open(tmp_file, "wt") as fp:
+                fp.write("%s" % content)
+            os.chmod(tmp_file, 0o644)
+            cmd = f'su -m {user} -c "cp -f {tmp_file} {file_path}"'
+            retcode = subprocess.check_call(cmd, shell=True)
+            os.remove(tmp_file)
+        return file_path
+
+    def drop_file(self, job_name):
+        """
+        Return path to the "drop" file
+        """
+        return os.path.join(self._drop_dir,
+                            f"{job_name}.drop.{self._names['drop']}")
+
+    def submit_file(self, job_name):
+        """
+        Return the path to the "submit" file
+        """
+        return os.path.join(self._drop_dir,
+                            f"{job_name}.drop.{self._names['submit']}")
+
+    def delete_file(self, job_name):
+        """
+        Return the path to the "delete" file
+        """
+        return os.path.join(self._drop_dir,
+                            f"{job_name}.drop.{self._names['delete']}")
+
+    def write_submit_file(self, job_name, job_id, user=None):
+        """
+        Write the "submit" file
+        """
+        self.write_file(job_name,
+                        self._names["submit"],
+                        " //%s//\n" % job_id,
+                        user=user)
+
+    def write_fail_file(self, job_name, status, ex, user=None):
+        # Write the "fail" file
+        self.write_file(job_name,
+                        self._names["fail"],
+                        """======================================
+
+Exit status: //{status}//
+
+STDOUT: 
+ job submission had exception
+
+STDERR: 
+ {ex}
+
+======================================
+""".format(status=status, ex=ex),
+                        user=user)
+
+    def write_deleted_file(self, job_name, status, stdout, stderr,
+                           user=None):
+        """
+        Write the "deleted" file
+        """
+        self.write_file(job_name,
+                        self._names["deleted"],
+                        """Exit status: //{status}//
+
+STDOUT: 
+ {stdout}
+
+STDERR: 
+ {stderr}
+""".format(status=status, stdout=stdout, stderr=stderr),
+                          user=user)
+
+    def write_status_file(self, job_name, status_info, user=None):
+        raise NotImplementedError("Must be implemented by subclass")
+
+    def write_completion_file(self, job_name, job_id, user=None):
+        raise NotImplementedError("Must be implemented by subclass")
+
+
+class JSEDropGEInterface(JSEDropInterface):
+    """
+    Implements Grid Engine-like JSE-Drop interface
+    """
+    def __init__(self, drop_dir):
+        JSEDropInterface.__init__(self,
+                                  drop_dir=drop_dir,
+                                  drop_name="qsub",
+                                  submit_name="qsubmit",
+                                  status_name="qstat",
+                                  completion_name="qacct",
+                                  delete_name="qdel",
+                                  deleted_name="qdeleted",
+                                  fail_name="qfail",
+                                  stdout_tmpl="{job_id}.o{job_number}",
+                                  stderr_tmpl="{job_id}.e{job_number}")
+
+    def write_status_file(self, job_name, status_info, user=None):
+        self.write_file(job_name,
+                        "qstat",
+                        """<JB_job_number>{job_number}</JB_job_number>
+<JB_name>{job_id}</JB_name>
+<JB_owner>{user}</JB_owner>
+<state>{state}</state>
+<JAT_start_time>{start_time}<start_time>
+<slots>{slots}</slots>
+""".format(user=status_info["user"],
+           start_time=status_info["start_time"],
+           job_number=status_info["job_number"],
+           job_id=status_info["job_name"],
+           state=status_info["state"],
+           slots=status_info["slots"]),
+                        user=user)
+
+    def write_completion_file(self, job_name, job_id, user=None):
+        self.write_file(job_name,
+                        "qacct",
+                        """Job accounting (hostname, jobname, end_time, etc) info can be obtained by running: qacct -j \"{job_id}\"
+""".format(job_id=job_id),
+                        user=user)
+
+
 class PopenBackend(object):
     """
     Example backend for JSEDrop which runs jobs via subprocess
     """
-    def __init__(self):
+    def __init__(self, stdout="{job_id}_{job_number}.log",
+                 stderr=None):
         """
         Create a PopenBackend instance
+
+        'stdout' and 'stderr' are templates for the output
+        log file names.
+
+        If 'stderr' is None then redirect all output to a
+        single output file.
         """
         # Internal tracking of job data
         self._job_count = 0
@@ -37,6 +275,9 @@ class PopenBackend(object):
         self._job_owner = dict()
         self._job_start_time = dict()
         self._job_end_time = dict()
+        # Templates for stdout and stderr files
+        self._stdout_tmpl = stdout
+        self._stderr_tmpl = stderr
 
     def submit(self,name,job_id,script,out_dir,user=None):
         """
@@ -51,32 +292,36 @@ class PopenBackend(object):
         self._job_owner[job_id] = user
         self._job_start_time[job_id] = time.localtime()
         try:
+            # Job number
+            job_number = self._job_number[job_id]
             # Paths to output files
             stdout_path = os.path.join(out_dir,
-                                       "%s.o%s" %
-                                       (job_id,
-                                        self._job_number[job_id]))
-            stderr_path = os.path.join(out_dir,
-                                       "%s.e%s" %
-                                       (job_id,
-                                        self._job_number[job_id]))
-            # Run the script
-            if user is None:
-                cmd = '%s 1>%s 2>%s' % (script,
-                                        stdout_path,
-                                        stderr_path)
+                                       self._stdout_tmpl.format(
+                                           job_id=job_id,
+                                           job_number=job_number))
+            if self._stderr_tmpl:
+                stderr_path = os.path.join(out_dir,
+                                           self._stderr_tmpl.format(
+                                               job_id=job_id,
+                                               job_number=job_number))
             else:
-                cmd = 'su -m %s -c "%s 1>%s 2>%s"' % (user,
-                                                      script,
-                                                      stdout_path,
-                                                      stderr_path)
-            p = Popen(cmd,shell=True)
+                stderr_path = None
+            # Build command to run the script
+            cmd = "%s 1>%s" % (script, stdout_path)
+            if stderr_path:
+                cmd = "%s 2>%s" % (cmd, stderr_path)
+            else:
+                cmd = "%s 2>&1" % cmd
+            if user is not None:
+                cmd = 'su -m %s -c "%s"' % (user, cmd)
+            # Execute the command
+            p = Popen(cmd, shell=True)
             # Store Popen object
             self._job_popen[job_id] = p
         except Exception as ex:
             raise ex
 
-    def get_status(self,job_id):
+    def get_status(self, job_id):
         """
         Fetch status information for job
         """
@@ -94,48 +339,21 @@ class PopenBackend(object):
             user = pwd.getpwuid(os.getuid()).pw_name
         # Return output based on status
         if self._job_status[job_id] is None:
-            # Job is still running, return qstat-style output
-            return (None,
-                    """<JB_job_number>{job_number}</JB_job_number>
-<JB_name>{job_id}</JB_name>
-<JB_owner>{user}</JB_owner>
-<state>r</state>
-<JAT_start_time>{start_time}<start_time>
-<slots>1</slots>
-""".format(user=user,
-           start_time=time.strftime("%Y-%m-%dT%T",
-                                    self._job_start_time[job_id]),
-           job_number=self._job_number[job_id],
-           job_id=job_id))
+            # Job is still running, return information
+            job_number=self._job_number[job_id]
+            start_time=time.strftime("%Y-%m-%dT%T",
+                                     self._job_start_time[job_id])
+            return (None, {
+                "job_number": job_number,
+                "job_name": job_id,
+                "user": user,
+                "state": "r",
+                "start_time": start_time,
+                "slots": 1
+            })
         else:
-            # Job has finished, return qacct-style output
-            self._job_end_time[job_id] = time.localtime()
-            group = grp.getgrgid(pwd.getpwnam(user).pw_gid).gr_name
-            return (self._job_status[job_id],
-                    """==============================================================
-qname        test
-hostname     {hostname}
-group        {group}
-owner        {user}
-jobname      {job_id}
-jobnumber    {job_number}
-qsub_time    {start_time}
-start_time   {start_time}
-end_time     {end_time}
-granted_pe   NONE
-slots        1
-failed       0
-exit_status  {status}
-""".format(hostname=platform.node(),
-           group=group,
-           user=user,
-           start_time=time.strftime("%a %b %d %T %Y",
-                                    self._job_start_time[job_id]),
-           end_time=time.strftime("%a %b %d %T %Y",
-                                  self._job_end_time[job_id]),
-           job_id=job_id,
-           job_number=self._job_number[job_id],
-           status=self._job_status[job_id]))
+            # Job has finished, return status
+            return (self._job_status[job_id], {})
         
     def terminate(self,job_id):
         """
@@ -186,9 +404,12 @@ class JSEDrop(object):
         # Set flag for drop directory existence
         self._drop_dir_status = None
         self._check_drop_dir()
+        # JSEDrop interface
+        self._jsedrop = JSEDropGEInterface(self._drop_dir)
         # Submission engine backend
         if submission_engine is None:
-            submission_engine = PopenBackend()
+            submission_engine = PopenBackend(stdout=self._jsedrop.stdout_tmpl,
+                                             stderr=self._jsedrop.stderr_tmpl)
         self._backend = submission_engine
         # Write PID file
         if pid_file:
@@ -241,18 +462,7 @@ class JSEDrop(object):
         """
         Acquire list of job names needing action
         """
-        # Get list of all *.drop.* files
-        drop_dir = self._drop_dir
-        drop_files = [os.path.basename(f)
-                      for f in glob.glob(os.path.join(drop_dir,"*.drop.*"))]
-        # Get initial list of names from .drop.qsub files
-        jobs = [f[:-len(".drop.qsub")]
-                for f in drop_files if f.endswith(".drop.qsub")]
-        # Ignore completed or deleted jobs
-        jobs = [j for j in jobs
-                if not ("%s.drop.qacct" % j in drop_files or
-                        "%s.drop.qdeleted" % j in drop_files or
-                        "%s.drop.qfail" % j in drop_files)]
+        jobs = self._jsedrop.list_active_jobs()
         if jobs:
             self.log("Monitoring jobs: %s" %
                      (', '.join(["'%s'" % j for j in jobs]),))
@@ -262,55 +472,8 @@ class JSEDrop(object):
         """
         Get the user name for the owner of the drop file
         """
-        qsub_file = os.path.join(self._drop_dir,"%s.drop.qsub" % job)
-        return pwd.getpwuid(os.stat(qsub_file).st_uid).pw_name
-
-    def _get_job_id(self,job):
-        """
-        Extract job ID from qsubmit file
-        """
-        qsubmit_file = os.path.join(self._drop_dir,
-                                    "%s.drop.qsubmit" % job)
-        if os.path.exists(qsubmit_file):
-            # //my_job--qNmoihPDDImLgWtetEZKhTSjmLhUikwg--JSE-DROP//
-            try:
-                with open(qsubmit_file,'rt') as fp:
-                    job_id = fp.read()
-                # Remove leading and trailing spaces and '//'
-                return job_id.strip().strip('/')
-            except Exception as ex:
-                raise Exception("Failed to extract job id for '%s' "
-                                "from '%s': %s" % (job,job_id,ex))
-        else:
-            return None
-
-    def _write_qfile(self,job,qfile,content):
-        """
-        Write content to a 'qfile' (e.g. 'qsubmit','qstat' etc)
-        """
-        qfile_path = os.path.join(self._drop_dir,"%s.drop.%s" %
-                                  (job,qfile))
-        if self._run_as_user:
-            user = self._get_job_owner(job)
-        else:
-            user = None
-        if user is None:
-            # Write file directly
-            with open(qfile_path,'wt') as fp:
-                fp.write("%s" % content)
-        else:
-            # Write intermediate file and copy as user
-            file_no,tmp_qfile = tempfile.mkstemp(
-                suffix=".jsedrop.%s" % qfile,
-                text=True)
-            os.fdopen(file_no).close()
-            with open(tmp_qfile,'wt') as fp:
-                fp.write("%s" % content)
-            os.chmod(tmp_qfile,0o644)
-            cmd = 'su -m %s -c "cp -f %s %s"' % (user,tmp_qfile,qfile_path)
-            retcode = subprocess.check_call(cmd,shell=True)
-            os.remove(tmp_qfile)
-        return qfile_path
+        drop_file = self._jsedrop.drop_file(job)
+        return pwd.getpwuid(os.stat(drop_file).st_uid).pw_name
 
     def log(self,s):
         """
@@ -334,52 +497,34 @@ class JSEDrop(object):
             self.log("-- Submitting as user '%s'" % user)
         else:
             user = None
-        # Get random ID for job
-        job_id = "%s%s--%s--JSE-DROP" % (job,
-                                         '_'*max(0,10-len(job)),
-                                         ''.join(random.choice(
-                                             string.ascii_uppercase +
-                                             string.ascii_lowercase)
-                                                 for _ in range(32)))
+        # Get ID for job from interface
+        job_id = self._jsedrop.make_job_id(job)
         self.log("-- Assigned job ID: %s" % job_id)
         # Submit job
         try:
             self._backend.submit(name=job,
                                  job_id=job_id,
-                                 script=os.path.join(self._drop_dir,
-                                                     "%s.drop.qsub" % job),
+                                 script=self._jsedrop.drop_file(job),
                                  out_dir=self._drop_dir,
                                  user=user)
-            # Write the qsubmit file to indicate job has started
-            self._write_qfile(job,"qsubmit"," //%s//\n" % job_id)
+            # Write the "*submit" file to indicate job has started
+            self._jsedrop.write_submit_file(job, job_id)
         except Exception as ex:
-            # Submission failed, write qfail file
+            # Submission failed, write "*fail" file
             status = 1
             self.log("-- Submission failed for job '%s': %s" % (job,ex))
             try:
-                self._write_qfile(job,"qfail",
-                            """======================================
-
-Exit status: //{status}//
-
-STDOUT: 
- job submission had exception
-
-STDERR: 
- {ex}
-
-======================================
-""".format(status=status,ex=ex))
+                self._jsedrop.write_fail_file(job, status, ex)
             except Exception as ex:
-                self.log("-- Error attempting to write qfail file "
-                         "for job '%s': %s" % (job,ex))
+                self.log("-- Error attempting to write 'fail' file "
+                         "for job '%s': %s" % (job, ex))
             return
 
     def delete(self,job):
         """
         Delete a job from the backend
         """
-        job_id = self._get_job_id(job)
+        job_id = self._jsedrop.get_job_id(job)
         if job_id is not None:
             try:
                 status,stdout,stderr = self._backend.terminate(job_id)
@@ -392,38 +537,28 @@ STDERR:
             status = 1
             stdout = ""
             stderr = "No submitted job matching '%s'" % job
-        # Write qdeleted file
-        self._write_qfile(job,"qdeleted",
-                    """Exit status: //{status}//
+        # Write *deleted file
+        self._jsedrop.write_deleted_file(job, status, stdout, stderr)
 
-STDOUT: 
- {stdout}
-
-STDERR: 
- {stderr}
-""".format(status=status,stdout=stdout,stderr=stderr))
-
-    def update(self,job):
+    def update(self, job):
         """
         Get update on the job status from the backend
         """
-        job_id = self._get_job_id(job)
+        job_id = self._jsedrop.get_job_id(job)
         if job_id is not None:
             # Get status and output
             try:
-                status,output = self._backend.get_status(job_id)
+                status, info = self._backend.get_status(job_id)
             except Exception as ex:
                 self.log("-- WARNING error getting status for "
-                         "job '%s': %s" % (job,ex))
+                         "job '%s': %s" % (job, ex))
                 return
             if status is None:
-                # Job still running, write qstat file
-                self._write_qfile(job,"qstat",output)
+                # Job still running, write "status" file
+                self._jsedrop.write_status_file(job, info)
             else:
-                # Job has completed, write qacct file
-                self._write_qfile(job,"qacct",
-                                  """Job accounting (hostname, jobname, end_time, etc) info can be obtained by running: qacct -j \"{job_id}\"
-""".format(job_id=job_id))
+                # Job has completed, write "completion" file
+                self._jsedrop.write_completion_file(job, job_id)
                 self.log("-- Job '%s' has completed" % job)
         
     def process(self):
@@ -435,12 +570,11 @@ STDERR:
             return
         # Perform actions on jobs
         for job in self._get_jobs():
-            drop_file = os.path.join(self._drop_dir,job)
-            if os.path.exists("%s.drop.qdel" % drop_file):
+            if os.path.exists(self._jsedrop.delete_file(job)):
                 # Handle job deletion first
                 self.log("-- Deleting job '%s'" % job)
                 self.delete(job)
-            elif os.path.exists("%s.drop.qsubmit" % drop_file):
+            elif os.path.exists(self._jsedrop.submit_file(job)):
                 # Handle job updates
                 self.update(job)
             else:
@@ -457,7 +591,7 @@ STDERR:
         # Terminate all jobs still running
         for job in self._get_jobs():
             self.log("-- Terminating job '%s'" % job)
-            job_id = self._get_job_id(job)
+            job_id = self._jsedrop.get_job_id(job)
             if job_id is not None:
                 try:
                     self._backend.terminate(job_id)

--- a/roles/jsedrop/files/jsedrop.py
+++ b/roles/jsedrop/files/jsedrop.py
@@ -529,6 +529,20 @@ class JSEDrop(object):
         drop_file = self._jsedrop.drop_file(job)
         return pwd.getpwuid(os.stat(drop_file).st_uid).pw_name
 
+    def run_as_user(self, job):
+        """
+        Return user name associated with job
+
+        If 'run_as_user' then return the user name
+        associated with the specific job, otherwise
+        return None.
+        """
+        # Get user associated with run job as
+        if self._run_as_user:
+            return self._get_job_owner(job)
+        else:
+            return None
+
     def log(self,s):
         """
         Write to log file
@@ -546,11 +560,9 @@ class JSEDrop(object):
         Submit a job to the backend
         """
         # Get user to run job as
-        if self._run_as_user:
-            user = self._get_job_owner(job)
+        user = self.run_as_user(job)
+        if user:
             self.log("-- Submitting as user '%s'" % user)
-        else:
-            user = None
         # Get ID for job from interface
         job_id = self._jsedrop.make_job_id(job)
         self.log("-- Assigned job ID: %s" % job_id)
@@ -562,13 +574,13 @@ class JSEDrop(object):
                                  out_dir=self._drop_dir,
                                  user=user)
             # Write the "*submit" file to indicate job has started
-            self._jsedrop.write_submit_file(job, job_id)
+            self._jsedrop.write_submit_file(job, job_id, user=user)
         except Exception as ex:
             # Submission failed, write "*fail" file
             status = 1
             self.log("-- Submission failed for job '%s': %s" % (job,ex))
             try:
-                self._jsedrop.write_fail_file(job, status, ex)
+                self._jsedrop.write_fail_file(job, status, ex, user=user)
             except Exception as ex:
                 self.log("-- Error attempting to write 'fail' file "
                          "for job '%s': %s" % (job, ex))
@@ -592,7 +604,8 @@ class JSEDrop(object):
             stdout = ""
             stderr = "No submitted job matching '%s'" % job
         # Write *deleted file
-        self._jsedrop.write_deleted_file(job, status, stdout, stderr)
+        self._jsedrop.write_deleted_file(job, status, stdout, stderr,
+                                         user=self.run_as_user(job))
 
     def update(self, job):
         """
@@ -609,10 +622,12 @@ class JSEDrop(object):
                 return
             if status is None:
                 # Job still running, write "status" file
-                self._jsedrop.write_status_file(job, info)
+                self._jsedrop.write_status_file(job, info,
+                                                user=self.run_as_user(job))
             else:
                 # Job has completed, write "completion" file
-                self._jsedrop.write_completion_file(job, job_id)
+                self._jsedrop.write_completion_file(job, job_id,
+                                                    user=self.run_as_user(job))
                 self.log("-- Job '%s' has completed" % job)
         
     def process(self):

--- a/roles/jsedrop/files/jsedrop.py
+++ b/roles/jsedrop/files/jsedrop.py
@@ -20,6 +20,11 @@ import subprocess
 
 DEFAULT_INTERVAL = 30
 
+# JSE-drop interfaces
+class JSEDropInterfaces:
+    GE = 1
+    SLURM = 2
+
 class JSEDropInterface:
     """
     Base class for implementing JSE-Drop interface to cluster
@@ -243,10 +248,51 @@ class JSEDropGEInterface(JSEDropInterface):
            slots=status_info["slots"]),
                         user=user)
 
+
     def write_completion_file(self, job_name, job_id, user=None):
         self.write_file(job_name,
                         "qacct",
                         """Job accounting (hostname, jobname, end_time, etc) info can be obtained by running: qacct -j \"{job_id}\"
+""".format(job_id=job_id),
+                        user=user)
+
+
+class JSEDropSlurmInterface(JSEDropInterface):
+    """
+    Implements Slurm-like JSE-Drop interface
+    """
+    def __init__(self, drop_dir):
+        JSEDropInterface.__init__(self,
+                                  drop_dir=drop_dir,
+                                  drop_name="sbatch",
+                                  submit_name="ssubmit",
+                                  status_name="squeue",
+                                  completion_name="sacct",
+                                  delete_name="scancel",
+                                  deleted_name="sdeleted",
+                                  fail_name="sfail",
+                                  stdout_tmpl="{job_id}.out",
+                                  stderr_tmpl=None)
+
+    def write_status_file(self, job_name, status_info, user=None):
+        # Format is a single line:
+        # JOBID|PRIORITY|NAME|USER|STATE|START_TIME|PARTITION|NODELIST|CPUS
+        self.write_file(job_name,
+                        "squeue",
+                        """{job_number}|0.00000222772360|{job_name}|{user}|RUNNING|{start_time}|galaxyq|node001|{slots}
+
+""".format(user=status_info["user"],
+           start_time=status_info["start_time"],
+           job_number=status_info["job_number"],
+           job_name=status_info["job_name"],
+           state=status_info["state"],
+           slots=status_info["slots"]),
+                        user=user)
+
+    def write_completion_file(self, job_name, job_id, user=None):
+        self.write_file(job_name,
+                        "sacct",
+                        """Job accounting (hostname, jobname, end_time, etc) info can be obtained by running: /usr/bin/sacct -S 2025-05-16 --name \"{job_id}\"
 """.format(job_id=job_id),
                         user=user)
 
@@ -373,7 +419,8 @@ class JSEDrop(object):
     """
     Class implementing JSE-Drop protocol
     """
-    def __init__(self,drop_dir,submission_engine=None,run_as_user=False,
+    def __init__(self,drop_dir,interface=JSEDropInterfaces.GE,
+                 submission_engine=None,run_as_user=False,
                  log_file=None,pid_file=None):
         """
         Arguments:
@@ -405,7 +452,14 @@ class JSEDrop(object):
         self._drop_dir_status = None
         self._check_drop_dir()
         # JSEDrop interface
-        self._jsedrop = JSEDropGEInterface(self._drop_dir)
+        if interface == JSEDropInterfaces.GE:
+            self._jsedrop = JSEDropGEInterface(self._drop_dir)
+            self.log("Using Grid Engine interface")
+        elif interface == JSEDropInterfaces.SLURM:
+            self._jsedrop = JSEDropSlurmInterface(self._drop_dir)
+            self.log("Using Slurm interface")
+        else:
+            raise Exception("Unrecognised JSEDrop interface")
         # Submission engine backend
         if submission_engine is None:
             submission_engine = PopenBackend(stdout=self._jsedrop.stdout_tmpl,
@@ -608,6 +662,12 @@ class JSEDrop(object):
             os.remove(self._pid_file)
 
 if __name__ == "__main__":
+
+    # Available interfaces
+    interfaces = {
+        "ge": JSEDropInterfaces.GE,
+        "slurm": JSEDropInterfaces.SLURM,
+    }
     
     # Process command line
     p = ArgumentParser(description="Python implementation of JSE-Drop")
@@ -618,6 +678,12 @@ if __name__ == "__main__":
                    default=DEFAULT_INTERVAL,type=float,
                    help="interval between checks on DROP_DIR, in seconds "
                    "(default: %ss)" % DEFAULT_INTERVAL)
+    p.add_argument("--interface",
+                   dest="interface",metavar="JSEDROP_INTERFACE",
+                   choices=[x for x in interfaces],default="ge",
+                   help="JSE-Drop interface to use (one of %s; default: "
+                   "'%s')" % (",".join([f"'{x}'" for x in interfaces]),
+                            "ge"))
     p.add_argument("--run-as-user",
                    dest="run_as_user",action="store_true",
                    help="run jobs as the user who owns the drop files")
@@ -633,6 +699,7 @@ if __name__ == "__main__":
     # Set up JSE-Drop
     try:
         jse_drop = JSEDrop(args.drop_dir,
+                           interface=interfaces[args.interface],
                            run_as_user=args.run_as_user,
                            log_file=args.log_file,
                            pid_file=args.pid_file)

--- a/roles/jsedrop/templates/jsedrop.service.j2
+++ b/roles/jsedrop/templates/jsedrop.service.j2
@@ -5,7 +5,7 @@ Conflicts=getty@tty1.service
 
 [Service]
 Type=simple
-ExecStart={{ jsedrop_python3 }} {{ jsedrop_install_dir }}/jsedrop.py {{ jsedrop_drop_dir }} --log /var/log/jsedrop.log --run-as-user
+ExecStart={{ jsedrop_python3 }} {{ jsedrop_install_dir }}/jsedrop.py {{ jsedrop_drop_dir }} --interface {{ jsedrop_interface }} --log /var/log/jsedrop.log --run-as-user
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
The CSF compute cluster has been upgraded and now uses Slurm as the job submission system (instead of Grid Engine). The JSE-Drop mechanism on the cluster has likewise been updated to reflect this, with the main changes being the naming of the control files, the format of the "status" output, and the requirement to supply Slurm `sbatch`-compatible options when running jobs (instead of the old `qsub` options).

The following changes have therefore been implemented:

* `jsedrop` role: the "reference" JSEDrop server (used for testing on Vagrant) has been updated to implement a Slurm-based interface (mimicking the changes on the cluster system). The old Grid Engine-based interface is also still available via the `--interface` CLI option
* `galaxy` role:
  - The JSEDrop client API has been updated to add support for the Slurm-based interface (the old Grid Engine interface is also still supported)
  - The JSEDrop runner has been updated to accept a new `interface` parameter when defining the plugin (sets whether Slurm or GE are being used), and a new `options` parameter when defining the destinations (replaces the GE-specific `qsub_options` parameter as way to supply the submission system-specific options when running jobs)
  - The `job_conf.xml` template has been updated to handle the interface and option specifications

In addition the job configuration for the `centaurus` and `palfinder` instances have been updated to specify the new Slurm-compatible job runner options.